### PR TITLE
Store Canvas Patient Metadata on Create

### DIFF
--- a/extensions/bridge/CANVAS_MANIFEST.json
+++ b/extensions/bridge/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.10.1",
-    "plugin_version": "0.1.13",
+    "plugin_version": "0.1.14",
     "name": "bridge",
     "description": "Bridge integration for Canvas",
     "components": {
@@ -20,7 +20,12 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["BRIDGE_UI_BASE_URL", "BRIDGE_API_BASE_URL", "BRIDGE_SECRET_API_KEY"],
+    "secrets": [
+        "BRIDGE_UI_BASE_URL",
+        "BRIDGE_API_BASE_URL",
+        "BRIDGE_SECRET_API_KEY",
+        "CANVAS_BASE_URL"
+    ],
     "tags": {},
     "references": [],
     "license": "",

--- a/extensions/bridge/protocols/bridge_patient_sync.py
+++ b/extensions/bridge/protocols/bridge_patient_sync.py
@@ -5,6 +5,7 @@ from canvas_sdk.utils import Http
 from canvas_sdk.effects.banner_alert import AddBannerAlert
 from canvas_sdk.v1.data.patient import Patient
 
+BRIDGE_SANDBOX = 'https://app.usebridge.xyz'
 
 class BridgePatientSync(BaseProtocol):
     RESPONDS_TO = [
@@ -22,16 +23,23 @@ class BridgePatientSync(BaseProtocol):
 
     @property
     def bridge_api_base_url(self):
-        return self.sanitize_url(self.secrets['BRIDGE_API_BASE_URL'])
+        return self.sanitize_url(self.secrets['BRIDGE_API_BASE_URL'] or f'{BRIDGE_SANDBOX}/api')
 
     @property
     def bridge_ui_base_url(self):
-        return self.sanitize_url(self.secrets['BRIDGE_UI_BASE_URL'])
+        return self.sanitize_url(self.secrets['BRIDGE_UI_BASE_URL'] or BRIDGE_SANDBOX)
 
     @property
     def bridge_request_headers(self):
         bridge_secret_api_key = self.secrets['BRIDGE_SECRET_API_KEY']
         return {'X-API-Key': bridge_secret_api_key}
+    
+    @property
+    def bridge_patient_metadata(self):
+        return {
+            'canvasPatientId': self.target,
+            'canvasUrl': self.secrets['CANVAS_BASE_URL'],
+        }
 
     def compute(self):
         canvas_patient_id = self.target
@@ -67,6 +75,7 @@ class BridgePatientSync(BaseProtocol):
         if event_type == EventType.PATIENT_CREATED:
             # Add placeholder email when creating the Bridge patient since it's required
             bridge_payload['email'] = 'patient_' + canvas_patient.id + '@canvasmedical.com'
+            bridge_payload['metadata'] = self.bridge_patient_metadata
         
         base_request_url = f'{self.bridge_api_base_url}/patients/v2'
         # If we have a Bridge patient id, we know this is an update, so we'll append it to the request URL

--- a/extensions/bridge/protocols/bridge_patient_sync.py
+++ b/extensions/bridge/protocols/bridge_patient_sync.py
@@ -36,10 +36,15 @@ class BridgePatientSync(BaseProtocol):
     
     @property
     def bridge_patient_metadata(self):
-        return {
-            'canvasPatientId': self.target,
-            'canvasUrl': self.secrets['CANVAS_BASE_URL'],
+        metadata = {
+            'canvasPatientId': self.target
         }
+
+        canvas_url = self.secrets['CANVAS_BASE_URL']
+        if canvas_url:
+            metadata['canvasUrl'] = canvas_url
+
+        return metadata
 
     def compute(self):
         canvas_patient_id = self.target


### PR DESCRIPTION
Store the Canvas patient ID and canvas URL (should correspond with the instance, e.g. `xpc-dev.canvasmedical.com`) so we can render Canvas patient backlinks on the Bridge platform