### PR TITLE
feat: update Abstractive installation instructions

### DIFF
--- a/extensions/abstractive_health/README.md
+++ b/extensions/abstractive_health/README.md
@@ -6,17 +6,18 @@ An Abstractive account is required to access the platform. The application flow 
 
 ## Installation
 To install the extension and populate the application in your Canvas instance, run the following CLI command:
+
 `canvas install abstractive_health`
 
 ## Authentication
-The application uses SMART on FHIR authentication, as described [here](docs.canvasmedical.com/guides/embedding-a-smart-on-fhir-application). You will need to complete a one time step to authorize the Abstractive Health extension by configuring OAuth credentials for it to use.
+The application uses SMART on FHIR authentication, as described [here](https://docs.canvasmedical.com/guides/embedding-a-smart-on-fhir-application). You will need to complete a one time step to authorize the Abstractive Health extension by configuring OAuth credentials for it to use.
 
 Navigate to <YOUR_CANVAS_URL>/auth/applications/register/ and fill in the following form values:
 
-Name: Abstractive Health Application (* can be any name)
-Client ID: `QthYrxa08pr9wg4QSWtOFJeSuDzsv6XRpeH1lWAL` (* must be an exact match)
-Client secret: <a secret lives here, do not change>
-Client type: Public
-Authorization grant type: Authorization code
-Redirect uris: https://app.abstractive.ai/
-Algorithm: RSA with SHA-2 256
+* Name: Abstractive Health Application (* can be any name)
+* Client ID: `QthYrxa08pr9wg4QSWtOFJeSuDzsv6XRpeH1lWAL` (* must be an exact match)
+* Client secret: <a secret lives here, do not change>
+* Client type: Public
+* Authorization grant type: Authorization code
+* Redirect uris: https://app.abstractive.ai/
+* Algorithm: RSA with SHA-2 256


### PR DESCRIPTION
This PR updates the Abstractive Health Extension instructions to provide detail for setting up the SMART on FHIR authorization. The text of the README is what will populate the [Canvas Extension page](https://www.canvasmedical.com/extensions).