### PR TITLE
Fix workflow: use uv run directly without sync

### DIFF
--- a/.github/workflows/update-coding-context.yml
+++ b/.github/workflows/update-coding-context.yml
@@ -21,11 +21,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Install dependencies
-        run: uv sync
-
       - name: Run update script
-        run: uv run python assemble_coding_agent_context.py
+        run: uv run assemble_coding_agent_context.py
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
## Summary
Fixes the workflow error where `uv sync` was failing because there's no `pyproject.toml` in the root directory.

## Changes
- Removed the `uv sync` step
- Changed to use `uv run assemble_coding_agent_context.py` directly
- The script has inline dependency metadata (`# /// script` block) that uv will use automatically

This allows uv to install dependencies (bs4, html2text, requests) directly from the script's metadata without needing a separate project file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)