### PR TITLE
Add contents write permission to workflow

### DIFF
--- a/.github/workflows/update-coding-context.yml
+++ b/.github/workflows/update-coding-context.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-context:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
Adds `permissions: contents: write` to the workflow to fix the 403 permission error when the github-actions bot tries to push changes.

## Issue
The workflow was failing with:
```
remote: Permission to Medical-Software-Foundation/canvas.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/Medical-Software-Foundation/canvas/': The requested URL returned error: 403
```

## Solution
GitHub Actions workflows need explicit permissions to write to the repository. This PR adds the `contents: write` permission to allow the bot to commit and push the updated context file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)