### PR TITLE
Update workflow to run daily at 1am UTC

### DIFF
--- a/.github/workflows/update-coding-context.yml
+++ b/.github/workflows/update-coding-context.yml
@@ -2,7 +2,7 @@ name: Update Coding Agent Context
 
 on:
   schedule:
-    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+    - cron: '0 1 * * *'  # Every day at 1am UTC
   workflow_dispatch:  # Allows manual trigger from Actions tab
 
 jobs:


### PR DESCRIPTION
## Summary
Changes the workflow schedule from weekly (Monday at 9am UTC) to daily (1am UTC).

## Changes
- Updated cron schedule from `0 9 * * 1` to `0 1 * * *`

This ensures the coding agent context is updated every day at 1am UTC instead of once per week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)