### PR TITLE
Update apppointments.sql to use SDK views

### DIFF
--- a/sample-sql/apppointments.sql
+++ b/sample-sql/apppointments.sql
@@ -2,24 +2,21 @@
 
 SELECT
     -- Appointment details
-    apt.externally_exposable_id AS apt_UUID,
-    an.id AS appt_note_id,
+    apt.id AS apt_UUID,
+    an.dbid AS appt_note_id,
     an.datetime_of_service AS appt_note_DOS,
     an.originator_id AS originated_by,
-
     -- Provider details
     st.first_name || ' ' || st.last_name AS note_provider,
-
     -- Note details
-    an.externally_exposable_id as note_external_ID,
-
+    an.id as note_external_ID,
     -- Patient details
     ap.first_name || ' ' || ap.last_name as patient_name,
     ap.key AS patient_key
 FROM
-    api_appointment apt
-LEFT JOIN public.api_note an ON apt.note_id = an.id
-LEFT JOIN public.api_staff st ON an.provider_id = st.id
-LEFT JOIN public.api_patient ap ON an.patient_id = ap.id
+    canvas_sdk_data_api_appointment_001 apt
+LEFT JOIN canvas_sdk_data_api_note_001 an ON apt.note_id = an.dbid
+LEFT JOIN canvas_sdk_data_api_staff_001 st ON an.provider_id = st.dbid
+LEFT JOIN canvas_sdk_data_api_patient_001 ap ON an.patient_id = ap.dbid
 WHERE
     apt.entered_in_error_id IS NULL;


### PR DESCRIPTION
By tying as much external access to our database to the Canvas SDK as possible, we can minimize the risk of introducing breaking changes. Canvas engineers will change internal schema and only ensure internal usages do not break. Canvas engineers will ensure backwards compatibility in the SDK views, however. It is required these views remain backwards compatible so deployed plugins do not break.

Building reports on the SDK database views provides more guarantees against breakage, and the documentation for the data present in these views is accessible on the docs site. 

Example: https://docs.canvasmedical.com/sdk/data-appointment/#appointment

The attribute names documented in the data module are not 1:1 to the database views, but are close enough to represent a marked improvement over the out-of-data generated schema docs we've used historically.