### PR TITLE
caretaker: display data in a custom command

### DIFF
--- a/extensions/vitalstream/vitalstream/CANVAS_MANIFEST.json
+++ b/extensions/vitalstream/vitalstream/CANVAS_MANIFEST.json
@@ -22,7 +22,14 @@
                 "description": "Websocket for the integration UI"
             }
         ],
-        "commands": [],
+        "commands": [
+            {
+                "name": "VitalStream",
+                "label": "VitalStream",
+                "schema_key": "vitalStream",
+                "section": "history"
+            }
+        ],
         "content": [],
         "effects": [],
         "views": []

--- a/extensions/vitalstream/vitalstream/templates/vitalstream_summary.html
+++ b/extensions/vitalstream/vitalstream/templates/vitalstream_summary.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .vitalstream-summary {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            padding: 16px;
+        }
+
+        .vitalstream-summary table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        .vitalstream-summary th {
+            padding: 12px 16px;
+            text-align: left;
+            font-weight: 600;
+            background: #f7fafc;
+            color: #2d3748;
+            border-bottom: 2px solid #e2e8f0;
+        }
+
+        .vitalstream-summary td {
+            padding: 12px 16px;
+            color: #1a202c;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .vitalstream-summary tr:last-child td {
+            border-bottom: none;
+        }
+
+        .vitalstream-summary .timestamp {
+            color: #718096;
+            font-size: 13px;
+        }
+
+        .vitalstream-summary .no-data {
+            color: #718096;
+            font-style: italic;
+            padding: 16px;
+        }
+    </style>
+</head>
+<body>
+    <div class="vitalstream-summary">
+        {% if observations %}
+            <table>
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>Measurement</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for obs in observations %}
+                        <tr>
+                            <td class="timestamp">{{ obs.timestamp }}</td>
+                            <td>{{ obs.name }}</td>
+                            <td>{{ obs.value }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="no-data">No data found.</div>
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/extensions/vitalstream/vitalstream/templates/vitalstream_summary_print.html
+++ b/extensions/vitalstream/vitalstream/templates/vitalstream_summary_print.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .vitalstream-summary-print {
+            font-family: Arial, sans-serif;
+            font-size: 11px;
+            line-height: 1.4;
+
+            .section {
+                margin-bottom: 8px;
+            }
+
+            .timestamp {
+                font-weight: bold;
+            }
+        }
+    </style>
+</head>
+<body class="vitalstream-summary-print">
+    {% if observations %}
+        {% for obs in observations %}
+            <div class="section">
+                <span class="timestamp">{{ obs.timestamp }}</span> - {{ obs.name }}: {{ obs.value }}
+            </div>
+        {% endfor %}
+    {% else %}
+        <div class="section">No data found.</div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
This pull request enhances the VitalStream integration by introducing a new custom command for session finalization and improving how vital sign summaries are presented to users. The changes include backend logic updates and the addition of new HTML templates for both standard and print-friendly summaries.

**VitalStream Command Integration:**

- Added a new `VitalStream` custom command to the extension manifest, enabling the integration UI to trigger the command for session summaries.

**Backend Logic Updates:**

- Refactored the session finalization endpoint to use `CustomCommand` instead of `PlanCommand`, and updated the logic to generate structured observation data for rendering in templates. [[1]](diffhunk://#diff-aeb8c0f6ebb6392a471b80d6326d9188eb3294834f22f7fa6b48dcc7e2908483L148-R149) [[2]](diffhunk://#diff-aeb8c0f6ebb6392a471b80d6326d9188eb3294834f22f7fa6b48dcc7e2908483L168-R200)
- Updated imports in `vitalstream_ui_api.py` to use `CustomCommand` and added the `uuid` module to support unique command IDs.

**User Interface Improvements:**

- Added a new `vitalstream_summary.html` template that displays a styled, tabular summary of all vital sign observations for a session.
- Added a new `vitalstream_summary_print.html` template for a print-friendly version of the vital sign summary.