### PR TITLE
Add document_parser extension template

### DIFF
--- a/extensions/document_parser/README.md
+++ b/extensions/document_parser/README.md
@@ -1,0 +1,12 @@
+# Document Parser
+
+Automated document intake plugin using Extend AI for document classification and extraction.
+
+## Overview
+
+This plugin receives document PDFs via HTTP POST, classifies and extracts structured data using Extend AI,
+matches patients using LLM-based demographics matching, and creates FHIR resources in Canvas.
+
+## Demo
+
+Request a demo: https://portal.usepylon.com/canvas-medical/forms/agent-enablement


### PR DESCRIPTION
Initial README with overview and demo link for the automated document intake plugin using Extend AI.