### PR TITLE
Fix timezone display bug in provider availability manager

### DIFF
--- a/extensions/provider-calendaring/provider_scheduling/handlers/availability_web_app.py
+++ b/extensions/provider-calendaring/provider_scheduling/handlers/availability_web_app.py
@@ -96,8 +96,8 @@ class AvailabilityWebApp(StaffSessionAuthMixin, SimpleAPI):
                         if event.calendar.title and ":" in event.calendar.title
                         else ""
                     ),
-                    "startTime": event.starts_at.strftime("%Y-%m-%dT%H:%M"),
-                    "endTime": event.ends_at.strftime("%Y-%m-%dT%H:%M"),
+                    "startTime": event.starts_at.strftime("%Y-%m-%dT%H:%MZ"),
+                    "endTime": event.ends_at.strftime("%Y-%m-%dT%H:%MZ"),
                     "daysOfWeek": (
                         event.recurrence
                         and "BYDAY=" in event.recurrence
@@ -128,7 +128,7 @@ class AvailabilityWebApp(StaffSessionAuthMixin, SimpleAPI):
                             ).get("INTERVAL", "")
                         )
                         or 0,
-                        "endDate": event.recurrence_ends_at.strftime("%Y-%m-%dT%H:%M")
+                        "endDate": event.recurrence_ends_at.strftime("%Y-%m-%dT%H:%MZ")
                         if event.recurrence_ends_at
                         else "",
                     },


### PR DESCRIPTION
## Summary
- Event times in the availability manager were serialized as naive datetime strings (e.g., `2026-04-07T19:00`) with no timezone indicator
- The browser interpreted these UTC values as local time, causing times to shift on save/reload (e.g., 2:00 PM CDT displayed as 7:00 PM CDT)
- Added `Z` suffix to `startTime`, `endTime`, and recurrence `endDate` so the browser correctly treats them as UTC and converts to the user's local timezone

## Test plan
- [ ] Open the Availability Manager plugin
- [ ] Create or edit an availability event with specific start/end times
- [ ] Save the event, then reload the page
- [ ] Verify the times display correctly (no shift) in the availability manager
- [ ] Verify the availability block renders correctly on the native Canvas calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)