### PR TITLE
Adjust the authentication parameters of these plugins

### DIFF
--- a/extensions/visualizations/scoring_visualizer/protocols/visualizer.py
+++ b/extensions/visualizations/scoring_visualizer/protocols/visualizer.py
@@ -3,7 +3,7 @@ import arrow, json
 from http import HTTPStatus
 
 from canvas_sdk.handlers.action_button import ActionButton
-from canvas_sdk.handlers.simple_api import SimpleAPI, api, Credentials
+from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.launch_modal import LaunchModalEffect
 from canvas_sdk.effects.simple_api import HTMLResponse, Response
@@ -31,10 +31,7 @@ class ScoringVisualizerButton(ActionButton):
             ).apply()
         ]
 
-class VisualApp(SimpleAPI):
-    def authenticate(self, credentials: Credentials) -> bool:
-        return True
-
+class VisualApp(StaffSessionAuthMixin, SimpleAPI):
     def get_survey_date(self, survey: dict) -> str:
         """
 

--- a/extensions/visualizations/vitals_visualizer/protocols/visualizer.py
+++ b/extensions/visualizations/vitals_visualizer/protocols/visualizer.py
@@ -3,7 +3,7 @@ import arrow, json
 from http import HTTPStatus
 
 from canvas_sdk.handlers.action_button import ActionButton
-from canvas_sdk.handlers.simple_api import SimpleAPI, api, Credentials
+from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.launch_modal import LaunchModalEffect
 from canvas_sdk.effects.simple_api import HTMLResponse, Response
@@ -30,10 +30,7 @@ class VitalsVisualizerButton(ActionButton):
             ).apply()
         ]
 
-class VisualApp(SimpleAPI):
-    def authenticate(self, credentials: Credentials) -> bool:
-        return True
-
+class VisualApp(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/")
     def index(self) -> list[Response | Effect]:
         patient = self.request.query_params.get("patient")


### PR DESCRIPTION
Aligns the authentication scheme on these two plugins' `SimpleAPI` handlers with the rest of the reference plugins.

Follow-up work (READMEs, tests, companion-scope Application, responsive layout) continues on `ad/reference-companion-apps` and should merge separately.
