### PR TITLE
Fix CCM activity tracker manifest: use package-relative paths

### DIFF
--- a/extensions/chronic-care-management-activity-tracker/chronic_care_management_activity_tracker/CANVAS_MANIFEST.json
+++ b/extensions/chronic-care-management-activity-tracker/chronic_care_management_activity_tracker/CANVAS_MANIFEST.json
@@ -11,7 +11,7 @@
                 "name": "CCM",
                 "description": "Chronic Care Management Activity Tracker Application",
                 "scope": "patient_specific",
-                "icon": "chronic_care_management_activity_tracker/assets/CCM.png"
+                "icon": "assets/CCM.png"
             }
         ],
         "protocols": [
@@ -55,7 +55,7 @@
         ],
         "questionnaires": [
             {
-                "template": "chronic_care_management_activity_tracker/assets/ccmat_questionnaire.yml"
+                "template": "assets/ccmat_questionnaire.yml"
             }
         ],
         "commands": [],


### PR DESCRIPTION
## Summary

- Fixes a Canvas installer error preventing the CCM Activity Tracker plugin from installing: `{"icon":["The icon must be an image located within the chronic_care_management_activity_tracker package"]}`
- Changes `icon` and questionnaire `template` paths in `CANVAS_MANIFEST.json` so they are relative to the plugin package directory instead of being prefixed with the package name.
- Matches the convention documented in the Canvas SDK (e.g. `"icon": "assets/python-logo.png"`) and the format used by other reference plugins (e.g. `patient_csv_loader`).

### Changes

- `icon`: `chronic_care_management_activity_tracker/assets/CCM.png` → `assets/CCM.png`
- `template`: `chronic_care_management_activity_tracker/assets/ccmat_questionnaire.yml` → `assets/ccmat_questionnaire.yml`

## Test plan

- [ ] Run `canvas install` against the plugin locally and confirm the install succeeds without the 400 icon validation error.
- [ ] Verify the CCM application icon renders correctly in the patient chart after install.
- [ ] Verify the CCM questionnaire loads from the manifest template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)