### PR TITLE
Fix ChartEventPublisher target ID extraction

### DIFF
--- a/extensions/provider_clinical_summary_companion/provider_clinical_summary_companion/handlers/chart_event_publisher.py
+++ b/extensions/provider_clinical_summary_companion/provider_clinical_summary_companion/handlers/chart_event_publisher.py
@@ -59,10 +59,11 @@ class ChartEventPublisher(BaseHandler):
             return []
         model, sections = mapping
 
-        target_id = getattr(self.event, "target", None)
-        if target_id is None:
+        target = getattr(self.event, "target", None)
+        target_id = getattr(target, "id", None) if not isinstance(target, str) else target
+        if not target_id:
             target_id = self.event.context.get("target") if hasattr(self.event, "context") else None
-        patient_id = _patient_id_from_target(model, str(target_id) if target_id else "")
+        patient_id = _patient_id_from_target(model, target_id or "")
         if not patient_id:
             return []
 

--- a/extensions/provider_clinical_summary_companion/tests/handlers/test_chart_event_publisher.py
+++ b/extensions/provider_clinical_summary_companion/tests/handlers/test_chart_event_publisher.py
@@ -104,3 +104,15 @@ class TestCompute:
 
         assert len(effects) == 1
         assert mock_lookup.call_args[0][1] == "ctx-target"
+
+    def test_target_dataclass_id_is_extracted(self) -> None:
+        # In production self.event.target is a TargetType dataclass with .id/.type,
+        # not a string. Verify we extract .id rather than stringifying the whole object.
+        target_obj = SimpleNamespace(id=TARGET_UUID, type=object)
+        handler = _make("INTERVIEW_CREATED", target=target_obj)
+        with patch.object(publisher.EventType, "Name", return_value="INTERVIEW_CREATED"), \
+             patch.object(publisher, "_patient_id_from_target", return_value=PATIENT_UUID) as mock_lookup:
+            effects = handler.compute()
+
+        assert len(effects) == 1
+        assert mock_lookup.call_args[0][1] == TARGET_UUID


### PR DESCRIPTION
## Summary
- `self.event.target` is a `TargetType` dataclass with `.id`/`.type` attributes, not a UUID string. The handler did `str(target_id)` which produced the dataclass repr (e.g. `\"TargetType(id='ccc0a14e-...', type=<class '...Interview'>)\"`) and then passed it to `model.objects.filter(id=...)`, raising `badly formed hexadecimal UUID string` for every event in `EVENT_MAP`. The chart-event broadcaster has been silently failing for every chart change since this code shipped — no patient channel ever got a section-refresh ping.
- Extract `target.id` from the dataclass; preserve the string-target path the existing tests use and the `context["target"]` fallback.
- Added a regression test covering the dataclass-shaped target.

## Test plan
- [x] `pytest extensions/provider_clinical_summary_companion/tests/handlers/test_chart_event_publisher.py` — 11 passed
- [x] After deploy, edit a condition/medication/allergy/immunization/interview/vital and confirm the patient channel receives a section-refresh broadcast (no more UUID validation traceback in plugin-runner logs)