### PR TITLE
Add REVIEW.md and CLAUDE.md for Claude Code Review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Consult these for correct patterns:
 
 The single most dangerous pattern. A handler that subscribes to `PLUGIN_CREATED` or `PLUGIN_UPDATED` and iterates every patient turns any plugin reinstall — even an unrelated config tweak — into a potentially instance-killing batch. `PATIENT_UPDATED` is similarly broad: it fires on every attribute change.
 
-Use a global-scope `Application` with a `SimpleAPI` endpoint to let a user intentionally trigger the batch. See `vineyard/vineyard-note-automations/` for the pattern: a global app provides a button, clicking it calls an API that starts the work.
+Use a global-scope `Application` with a `SimpleAPI` endpoint to let a user intentionally trigger the batch — the app provides a button, clicking it calls an API that starts the work.
 
 ### Fail closed, never fail open
 
@@ -178,7 +178,7 @@ When rendering patient data, handle `None`. "None oz" or "None mg" is a poor use
 - Description is not the boilerplate "Edit the description in CANVAS_MANIFEST.json"
 - Handler classes listed in the manifest match actual class paths
 - `data_access.event`, `read`, `write` populated correctly
-- `README.md` includes a demo video link ([video drive](https://drive.google.com/drive/folders/1YaFaXr5x47_t2J_xtSViKeoNwm14vucX))
+- `README.md` describes what the plugin does and how to install it
 - `pyproject.toml` declares `canvas[test-utils]` and test config
 - Tests in `tests/` are meaningful (not just stubs)
 - No leftover `canvas init` boilerplate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@ Consult these for correct patterns:
   - `canvas_sdk/utils/http.py` — the SDK's HTTP client with metrics and timeout enforcement
   - `canvas_sdk/caching/` — `Cache` wrapper with `get_or_set()`, TTLs
 - **canvas-plugins/example-plugins/** — 40+ reference implementations
-- **Medical-Software-Foundation/canvas** (`protocols/`, `extensions/`) — production-quality open-source plugins
 
 ## Critical anti-patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,215 @@
+# Canvas plugin context
+
+This repo contains Canvas plugins. Reviews and code-edit sessions should follow the patterns below, drawn from real issues found in past PRs. Behavior-tuning rules for Claude Code Review live in `REVIEW.md`; this file is the longer-form context that both human and AI reviewers benefit from.
+
+## Reference codebases
+
+Consult these for correct patterns:
+
+- **canvas-plugins** (`canvas_sdk/`) — the plugin SDK. Authoritative source for how plugins should be built.
+  - `canvas_sdk/handlers/` — `BaseHandler`, `ActionButton`, `Application`, `CronTask`, `SimpleAPIRoute`
+  - `canvas_sdk/effects/` — all available effects (banner alerts, tasks, notes, billing, etc.)
+  - `canvas_sdk/v1/data/` — ORM-style data access (`Patient`, `Note`, `Condition`, etc.)
+  - `canvas_sdk/commands/` — command effects (`GoalCommand`, `DiagnoseCommand`, etc.)
+  - `canvas_sdk/utils/http.py` — the SDK's HTTP client with metrics and timeout enforcement
+  - `canvas_sdk/caching/` — `Cache` wrapper with `get_or_set()`, TTLs
+- **canvas-plugins/example-plugins/** — 40+ reference implementations
+- **Medical-Software-Foundation/canvas** (`protocols/`, `extensions/`) — production-quality open-source plugins
+
+## Critical anti-patterns
+
+### All-patient batch ops on plugin or patient lifecycle events
+
+The single most dangerous pattern. A handler that subscribes to `PLUGIN_CREATED` or `PLUGIN_UPDATED` and iterates every patient turns any plugin reinstall — even an unrelated config tweak — into a potentially instance-killing batch. `PATIENT_UPDATED` is similarly broad: it fires on every attribute change.
+
+Use a global-scope `Application` with a `SimpleAPI` endpoint to let a user intentionally trigger the batch. See `vineyard/vineyard-note-automations/` for the pattern: a global app provides a button, clicking it calls an API that starts the work.
+
+### Fail closed, never fail open
+
+When a secret or config value is missing, deny access. Common fail-open patterns to reject:
+
+- Origin validation returning `True` when `CANVAS_INSTANCE_ORIGIN` is unset
+- Admin checks returning `True` when `ADMIN_STAFF_IDS` is empty
+- Authentication bypass when a required secret is absent
+
+```python
+# BAD: fails open
+def is_admin(self, staff_id: str) -> bool:
+    admin_ids = self.secrets.get("ADMIN_STAFF_IDS", "")
+    if not admin_ids.strip():
+        return True
+
+# GOOD: fails closed
+def is_admin(self, staff_id: str) -> bool:
+    admin_ids = self.secrets.get("ADMIN_STAFF_IDS", "")
+    if not admin_ids.strip():
+        log.warning("ADMIN_STAFF_IDS not configured, denying access")
+        return False
+```
+
+### Don't swallow exceptions
+
+Bare `try/except Exception` around handler logic hides bugs from Sentry and monitoring. Catch only the specific exception you expect from an external call.
+
+```python
+# BAD: hides bugs
+try:
+    result = process_patient(patient)
+except Exception:
+    log.error("Something went wrong")
+    return []
+
+# GOOD: let unexpected errors raise, catch only expected ones
+try:
+    pdf_bytes = docusign.get_signed_document(envelope_id)
+except RuntimeError as exc:
+    log.error("DocuSign error: %s", exc)
+    return [JSONResponse({"error": "Unable to retrieve document"}, status_code=503)]
+```
+
+### Filter `entered_in_error` on clinical data
+
+Any query against `Condition`, `Medication`, `LabReport`, etc. must filter retracted records:
+
+```python
+conditions = Condition.objects.filter(
+    patient_id=patient_id,
+    entered_in_error__isnull=True,
+)
+```
+
+### Fail explicitly on missing required data
+
+Never write `"unknown"` / `"N/A"` / `""` into the database for an authenticated user, patient, or note ID. Return an error instead.
+
+```python
+# BAD: silently corrupts data
+sender_id = request.headers.get("X-Staff-Id", "unknown")
+
+# GOOD: explicit failure
+sender_id = request.headers.get("X-Staff-Id")
+if not sender_id:
+    return [JSONResponse({"error": "Missing X-Staff-Id header"}, status_code=400)]
+```
+
+## Important patterns
+
+### N+1 queries
+
+The most common performance issue. Watch for:
+
+- Iterating patients and querying per-patient inside the loop — use a bulk `.filter()` instead
+- `.exists()` + `.last()` (two queries) when `.last()` + None check suffices
+- Fetching related objects in a loop — use `select_related()` / `prefetch_related()`
+- `.filter()` on a prefetched relationship inside a loop (negates the prefetch) — use `Prefetch` or filter in Python
+
+```python
+# BAD: N+1
+for patient in Patient.objects.all():
+    conditions = Condition.objects.filter(patient=patient)
+
+# GOOD: bulk query
+patients = Patient.objects.prefetch_related("conditions").all()
+for patient in patients:
+    conditions = patient.conditions.all()
+```
+
+### Use SDK data models, not FHIR API calls
+
+When data is available through `canvas_sdk.v1.data` (`Patient`, `Condition`, `LabReport`, `StaffRole`, etc.), use it directly. SDK access is faster, type-safe, and doesn't consume API rate limits.
+
+### Use the SDK's HTTP client, not raw `requests`
+
+`canvas_sdk.utils.http.Http` enforces a 30s timeout, validates URLs, and tracks metrics. Don't import `requests` or `httpx`.
+
+```python
+from canvas_sdk.utils.http import Http
+
+http = Http(base_url="https://api.example.com")
+response = http.post("/endpoint", json=payload)
+```
+
+### Use questionnaire codes, not names or IDs
+
+Codes are stable across installations. Names break when versioned (`(v2)` suffix). Database IDs vary per environment. Look up by coding system + code.
+
+### Separate admin/config into global-scope apps
+
+Admin operations (configuration, batch jobs, settings) belong in a global-scope `Application`, not patient-specific apps or handlers. Patient-scoped apps are for patient-level workflows only.
+
+### Subscribe to specific events
+
+Don't use `PATIENT_UPDATED` when you only care about address changes — that fires on every attribute update. Pick the most specific event in `canvas_sdk/events/`.
+
+## Style and quality
+
+### Tests must verify behavior
+
+Asserting that `compute()` returns a list proves nothing. Tests should verify the right effects are returned for given inputs and edge cases.
+
+```python
+# BAD: proves nothing
+def test_handler():
+    handler = MyHandler(event=mock_event)
+    result = handler.compute()
+    assert isinstance(result, list)
+
+# GOOD: verifies behavior
+def test_handler_creates_task_for_overdue_patient():
+    event = make_event(patient_id=overdue_patient.id)
+    handler = MyHandler(event=event)
+    result = handler.compute()
+    assert len(result) == 1
+    assert result[0].type == EffectType.ADD_TASK
+```
+
+### Clean up `canvas init` boilerplate
+
+Remove unused auto-generated files, placeholder descriptions ("A protocol that does xyz..."), empty unused component arrays, and generic test stubs.
+
+### Guard against `None` in templates
+
+When rendering patient data, handle `None`. "None oz" or "None mg" is a poor user experience.
+
+## Plugin architecture checklist
+
+### Structure
+- Plugin has a `CANVAS_MANIFEST.json` with accurate `components`, `secrets`, and `description`
+- Description is not the boilerplate "Edit the description in CANVAS_MANIFEST.json"
+- Handler classes listed in the manifest match actual class paths
+- `data_access.event`, `read`, `write` populated correctly
+- `README.md` includes a demo video link ([video drive](https://drive.google.com/drive/folders/1YaFaXr5x47_t2J_xtSViKeoNwm14vucX))
+- `pyproject.toml` declares `canvas[test-utils]` and test config
+- Tests in `tests/` are meaningful (not just stubs)
+- No leftover `canvas init` boilerplate
+
+### Handler patterns
+- Inherits from the correct base class:
+  - `BaseHandler` — responding to specific events
+  - `CronTask` — scheduled work (set `SCHEDULE` as a cron expression)
+  - `ActionButton` — chart/note buttons (set `BUTTON_TITLE`, `BUTTON_KEY`, `BUTTON_LOCATION`)
+  - `Application` — embeddable apps (implement `on_open()`, global scope for admin)
+  - `SimpleAPIRoute` — custom API endpoints (set `PATH`, implement HTTP methods)
+- `RESPONDS_TO` is the most specific event that does the job
+- `compute()` returns `list[Effect]` (not a single Effect, not None)
+- Early returns with `[]` for events the handler should ignore
+- No side effects outside of the returned `Effect` list (don't write to the DB directly from `compute()`)
+- No batch operations triggered by `PLUGIN_CREATED` / `PLUGIN_UPDATED`
+
+### Data access
+- Uses `canvas_sdk.v1.data` models, not FHIR API calls or raw SQL
+- QuerySets use `select_related()` / `prefetch_related()`, no N+1
+- `.get()` calls are wrapped in try/except for `DoesNotExist`
+- Clinical queries filter `entered_in_error`
+- Questionnaire lookups use codes
+
+### Secrets and configuration
+- All secrets declared in `CANVAS_MANIFEST.json` `secrets` array
+- Accessed via `self.secrets["KEY"]`, never hardcoded
+- Missing secrets cause a clear error, not silent misbehavior
+
+### Effects
+- Created via SDK classes; `.apply()` is called
+- Command effects use `.originate()` or `.edit()` as appropriate
+- API endpoints return `JSONResponse` (from `canvas_sdk.effects.simple_api`)
+- External HTTP uses `canvas_sdk.utils.http.Http`, not raw `requests`/`httpx`

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,6 +4,8 @@ Authors in this repo are Certified Plugin Builders (CPBs). Many are not full-tim
 
 Before this review runs, the author has already run `/wrap-up`, which has verified: project structure, mypy, ≥90% branch coverage, no leftover `print()` / `[DEBUG]` / `# TODO`, no dead code or unused imports, manifest entries match files on disk, cache-bust tokens on HTML asset URLs, 48×48 application icon when an Application is declared, README handler/event lists match code, and license correctness for the repo. Do not re-flag any of those — assume they pass.
 
+Repo-specific patterns and longer-form guidance (reference codebases, anti-pattern explanations, plugin architecture checklist) live in `CLAUDE.md`. Code Review reads `CLAUDE.md` and flags new violations as 🟡 Nit by default; the rules called out under "Always check" below are promoted to 🔴 Important.
+
 ## Audience and tone
 
 Each finding will be acted on by the plugin author directly. Write findings the way you would tell a non-engineer what to change: name the file and line, name the symbol, say what to change. Skip the "why this matters in general" explanation unless it changes the fix.
@@ -17,6 +19,7 @@ Reserve 🔴 Important for findings that, if merged, would:
 - Corrupt or destroy data — non-idempotent writes on event handlers that can replay, effects targeting the wrong object ID, deletes without an explicit user confirmation path
 - Leak secrets — hardcoded credentials, API keys, or tokens in code; secrets read at runtime but not declared in the manifest
 - Block install or deploy — invalid `CANVAS_MANIFEST.json`, missing files declared in the manifest, syntax errors
+- Violate any "Always check" rule below
 
 Everything else is 🟡 Nit at most. Style preferences, naming, refactor opportunities, additional test ideas, docstring wording, comment polish, and "this could be cleaner" suggestions are always Nit.
 
@@ -43,14 +46,21 @@ Before posting a 🔴 Important finding, read the code path and cite `file:line`
 - Generated files (`*.lock`, `__pycache__/`, anything under a path containing `generated`)
 - Test-only code that intentionally violates production rules
 
-## Always check (plugin-specific)
+## Always check
 
-- Handler `compute()` and `effect()` methods handle missing or malformed event payload fields without raising — partial data is the norm in production
-- Every SimpleAPI / WebSocket route has `authenticate` set correctly and the manifest's API scopes match what the route accepts
-- FHIR client calls request only resources/actions covered by the manifest's FHIR scopes
-- Loops over data-model querysets use `select_related()` / `prefetch_related()` for related fields they touch — flag obvious N+1 patterns, not theoretical ones
-- Effects target the correct object IDs (`Patient.id`, `Note.id`, command IDs from the originating event). Wrong target IDs silently no-op in production and are very hard to debug after the fact
-- In `medical-software-foundation/canvas` (reference plugins): no customer-specific identifiers — customer names, brand names, internal IDs, hardcoded note templates, customer-only URLs. Reference plugins must be generic. (In `canvas/gtm-extensions`, customer-specific content is fine — do not flag.)
+These are repo-specific 🔴 Important rules. Each has been a real bug in past reviews — see `CLAUDE.md` for the longer explanation and code examples.
+
+- **No all-patient batch operations on plugin or patient lifecycle events.** Do not subscribe `PLUGIN_CREATED`, `PLUGIN_UPDATED`, or broad `PATIENT_UPDATED` to a handler that iterates every patient. Reinstalls then trigger instance-killing batches. Use a global-scope `Application` + SimpleAPI button instead.
+- **Fail closed when secrets or config are missing.** Origin checks, admin checks, and auth gates must deny when the required secret is empty or unset. A missing secret that grants access is an immediate Important.
+- **No blanket `try/except Exception` around handler logic.** Errors must reach Sentry. Catch only the specific expected exception from an external call.
+- **Clinical-data queries filter `entered_in_error`.** Any query against `Condition`, `Medication`, `LabReport`, etc. must include `entered_in_error__isnull=True` (or equivalent). Without it, retracted records appear in results.
+- **No placeholder values for missing required data.** Don't write `"unknown"`, `"N/A"`, or empty strings into the database when an authenticated user, patient, or note ID is required. Return an error instead.
+- **Effects target the correct object ID.** `Patient.id`, `Note.id`, command IDs from the originating event. Wrong target IDs silently no-op in production and are very hard to debug.
+- **SimpleAPI and WebSocket routes have `authenticate` set, and manifest scopes match the code.** Missing or misaligned auth is an Important.
+- **FHIR client calls stay within manifest scopes.** Calls outside the scopes declared in `CANVAS_MANIFEST.json` are an Important.
+- **Loops over data-model querysets use `select_related()` / `prefetch_related()` for related fields they touch.** Flag obvious N+1 patterns the author can fix in one place; do not flag theoretical N+1.
+- **Handler `compute()` / `effect()` handle missing or malformed event payload fields without raising.** Partial data is the norm in production.
+- **In `Medical-Software-Foundation/canvas` (reference plugins): no customer-specific identifiers.** Customer names, brand names, internal IDs, hardcoded note templates, customer-only URLs. Reference plugins must be generic. (In `canvas/gtm-extensions`, customer-specific content is fine — do not flag.)
 
 ## Summary shape
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,59 @@
+# Review instructions
+
+Authors in this repo are Certified Plugin Builders (CPBs). Many are not full-time software engineers. Reviews must surface a small number of clearly actionable problems, not a long list of every concern.
+
+Before this review runs, the author has already run `/wrap-up`, which has verified: project structure, mypy, ≥90% branch coverage, no leftover `print()` / `[DEBUG]` / `# TODO`, no dead code or unused imports, manifest entries match files on disk, cache-bust tokens on HTML asset URLs, 48×48 application icon when an Application is declared, README handler/event lists match code, and license correctness for the repo. Do not re-flag any of those — assume they pass.
+
+## Audience and tone
+
+Each finding will be acted on by the plugin author directly. Write findings the way you would tell a non-engineer what to change: name the file and line, name the symbol, say what to change. Skip the "why this matters in general" explanation unless it changes the fix.
+
+## What 🔴 Important means here
+
+Reserve 🔴 Important for findings that, if merged, would:
+
+- Break the plugin at runtime — uncaught exceptions on the happy path, missing imports, wrong handler signatures, manifest entries that don't resolve to real code
+- Mishandle patient data — PHI in logs, error messages, or outbound HTTP calls; missing `authenticate` on a SimpleAPI or WebSocket route; FHIR client requests outside the scopes declared in the manifest
+- Corrupt or destroy data — non-idempotent writes on event handlers that can replay, effects targeting the wrong object ID, deletes without an explicit user confirmation path
+- Leak secrets — hardcoded credentials, API keys, or tokens in code; secrets read at runtime but not declared in the manifest
+- Block install or deploy — invalid `CANVAS_MANIFEST.json`, missing files declared in the manifest, syntax errors
+
+Everything else is 🟡 Nit at most. Style preferences, naming, refactor opportunities, additional test ideas, docstring wording, comment polish, and "this could be cleaner" suggestions are always Nit.
+
+## Cap the nits
+
+Post at most three 🟡 Nit findings per review. If more were found, summarize the rest as "plus N similar items" in the review body — do not post them inline.
+
+## Re-review convergence
+
+After the first review on a PR, post 🔴 Important findings only. Suppress all 🟡 Nit findings on subsequent runs — the author saw round one and chose not to act. Do not re-surface them.
+
+## Verification bar
+
+Before posting a 🔴 Important finding, read the code path and cite `file:line` for the problem. When the finding claims a behavior elsewhere ("this caller passes None", "this field is unset"), cite `file:line` for that claim too. Do not infer behavior from names. If you cannot verify, drop the finding rather than posting it speculatively — a wrong Important costs the author a deploy cycle.
+
+## Do not report
+
+- Anything `/wrap-up` already enforces (see top of this file)
+- Anything ruff would catch (formatting, import order, unused vars)
+- Suggestions to add tests when coverage is already ≥90%
+- Suggestions to refactor working code into a different pattern
+- Naming preferences for variables, functions, classes, files
+- Docstring or comment wording
+- Generated files (`*.lock`, `__pycache__/`, anything under a path containing `generated`)
+- Test-only code that intentionally violates production rules
+
+## Always check (plugin-specific)
+
+- Handler `compute()` and `effect()` methods handle missing or malformed event payload fields without raising — partial data is the norm in production
+- Every SimpleAPI / WebSocket route has `authenticate` set correctly and the manifest's API scopes match what the route accepts
+- FHIR client calls request only resources/actions covered by the manifest's FHIR scopes
+- Loops over data-model querysets use `select_related()` / `prefetch_related()` for related fields they touch — flag obvious N+1 patterns, not theoretical ones
+- Effects target the correct object IDs (`Patient.id`, `Note.id`, command IDs from the originating event). Wrong target IDs silently no-op in production and are very hard to debug after the fact
+- In `medical-software-foundation/canvas` (reference plugins): no customer-specific identifiers — customer names, brand names, internal IDs, hardcoded note templates, customer-only URLs. Reference plugins must be generic. (In `canvas/gtm-extensions`, customer-specific content is fine — do not flag.)
+
+## Summary shape
+
+Open the review summary with one line of the form: `N important, M nits` (e.g. `0 important, 2 nits`). When N is 0, the next sentence should be: "No blocking issues — safe to merge once nits are addressed (optional)." so the author knows the PR is not gated on the review.
+
+If any of the posted nits fall into a category `/wrap-up` checks — leftover `print()` / `[DEBUG]` / `# TODO`, dead code, unused imports, manifest entries that don't match files on disk, missing cache-bust tokens, missing application icon, README drift, mypy-flagged type problems, or coverage shortfalls — append this sentence to the summary: "Heads up: some of these nits are things `/wrap-up` checks for. Run `/wrap-up` locally and push the fixes before the next review round." Do not append the sentence when the nits are unrelated to `/wrap-up`'s scope (naming, refactor suggestions, comment wording, etc.) — in that case the author has nothing new to gain from re-running it.


### PR DESCRIPTION
Adds review setup for Claude Code Review, split per [Anthropic's docs](https://code.claude.com/docs/en/code-review#customize-reviews) (length dilutes high-priority rules; general project context belongs in `CLAUDE.md`):

- **`REVIEW.md`** — review-only behavior tuning. Severity definition, 3-nit cap, re-review convergence (Importants only after the first round), verification bar (`file:line` citations required), summary shape, and a terse "Always check" list of repo-specific Important rules.
- **`CLAUDE.md`** — longer-form context: reference codebases, critical anti-pattern walkthroughs with code examples (all-patient batch ops on lifecycle events, fail-open security, exception swallowing, `entered_in_error` filtering, placeholder values), important patterns (N+1, SDK data models, SDK HTTP client, questionnaire codes), and the plugin architecture checklist. Code Review reads `CLAUDE.md` and flags new violations as 🟡 Nit; rules promoted to 🔴 Important live in `REVIEW.md`'s "Always check".

Goal: surface a small number of clearly actionable findings for CPB authors (most are not full-time engineers), avoid re-flagging anything `/wrap-up` already enforces, and stop 10+ round runs.

The same two files are being proposed for `canvas/gtm-extensions` in a separate PR so reviews behave identically across both plugin homes.

Context: [CPB Plugin Development and Release Process](https://www.notion.so/CPB-Plugin-Development-and-Release-Process-DRAFT-3580bd9e40338154ba05c8f69d1700ed) (Step 2.3).

## Test plan

- [ ] Open a follow-up test PR and confirm Claude Code Review honors the severity definitions and nit cap
- [ ] Confirm summary line format matches (`N important, M nits`)
- [ ] After a second push to the test PR, confirm only Important findings reappear
- [ ] Introduce a deliberate `CLAUDE.md` violation (e.g. `entered_in_error` not filtered) and confirm it surfaces as Important via the "Always check" rule