### PR TITLE
Update last reviewed section

### DIFF
--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.17",
+    "plugin_version": "0.1.18",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.10",
+    "plugin_version": "0.1.11",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.8",
+    "plugin_version": "0.1.9",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.15",
+    "plugin_version": "0.1.16",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.14",
+    "plugin_version": "0.1.15",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.9",
+    "plugin_version": "0.1.10",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.16",
+    "plugin_version": "0.1.17",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.13",
+    "plugin_version": "0.1.14",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.12",
+    "plugin_version": "0.1.13",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
+++ b/extensions/last_reviewed/last_reviewed/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.11",
+    "plugin_version": "0.1.12",
     "name": "last_reviewed",
     "description": "Adds a 'Last Reviewed' patient summary section showing when each chart section was last marked as reviewed and by whom.",
     "components": {

--- a/extensions/last_reviewed/last_reviewed/README.md
+++ b/extensions/last_reviewed/last_reviewed/README.md
@@ -39,15 +39,30 @@ Two handlers, both responding to chart-summary events:
   `PatientChartSummaryCustomSection` effect with HTML rendered from
   `static/section.html` and styles loaded from `static/section.css`.
 
-Markup and styling live as separate files under `static/`:
+Markup, styling, and a small client-side script live as separate files
+under `static/`:
 
 - `static/section.html` — Django template for the section body
 - `static/section.css` — visual styles (font, weight, color hierarchy,
   icon size) tuned to match native chart sections
+- `static/section.js` — toggles a `.lr-section--at-bottom` modifier
+  class once the user has scrolled to the end of the section so the
+  bottom-fade overflow affordance can drop out
 
-The custom section ships as a single inline content blob, so the CSS is
-loaded via `render_to_string` and inlined into the HTML at render time
-rather than referenced by URL.
+The custom section ships as a single inline content blob, so the CSS
+and JS are loaded via `render_to_string` and inlined into the HTML at
+render time rather than referenced by URL.
+
+## Bottom-fade overflow affordance
+
+When the section's contents extend below the host's chart-summary slot,
+a sticky `::after` overlay on `.lr-section` paints a soft fade at the
+bottom edge as a "more below" hint. Because the host owns the scroll
+container (not us), the fade is implemented in two pieces: a CSS-only
+sticky pseudo that always sits at the visible viewport bottom, and the
+small `static/section.js` listener that finds the nearest scrolling
+ancestor and toggles a modifier class so the fade goes away once the
+section's bottom edge is fully in view.
 
 ## Filtering deleted reviews
 

--- a/extensions/last_reviewed/last_reviewed/README.md
+++ b/extensions/last_reviewed/last_reviewed/README.md
@@ -25,6 +25,47 @@ review, the section automatically rolls back to whatever the previous
 valid review was (or "Never reviewed" if none) — see *Filtering deleted
 reviews* below.
 
+## The problem this solves
+
+Clinicians rely on the patient chart summary to make care decisions, but
+the rows inside each section do not reflect whether the information is
+considered current. Canvas exposes a *Mark as reviewed* button on each
+section, but the history of those reviews is buried inside individual
+notes — there's no single place to see when each section was last
+reviewed and by whom. This plugin surfaces that history as a
+top-of-summary section so the review status of every chart section is
+visible at a glance.
+
+## Who it's for
+
+- Clinicians who own a panel of patients and need to know which
+  sections have been reviewed recently before relying on them in a
+  visit.
+- Visiting or covering providers who are seeing a chart for the first
+  time and want a quick read on how stale each section's contents
+  might be.
+- Ops or quality teams auditing review compliance across patients.
+
+## How to install
+
+Standard Canvas plugin install, run from the repository's `extensions/`
+directory:
+
+```bash
+canvas install --host <your-instance> last_reviewed
+```
+
+No secrets, environment variables, or external API keys are required —
+the plugin only reads internal Canvas chart-section-review commands.
+
+The only configurable surface is **section ordering**. The plugin pins
+its custom section to the top of the chart summary and lists the
+default chart sections underneath in their default order; if another
+plugin also emits a `PatientChartSummaryConfiguration` for the same
+patient, the last-applied configuration wins (see *Caveat: section
+ordering* below). To change the order, edit the `sections` list in
+`handlers/section_config.py`.
+
 ## How it works
 
 Two handlers, both responding to chart-summary events:

--- a/extensions/last_reviewed/last_reviewed/handlers/section_content.py
+++ b/extensions/last_reviewed/last_reviewed/handlers/section_content.py
@@ -110,8 +110,10 @@ class LastReviewedSectionContent(PatientChartSummaryCustomSectionHandler):
 
         rows = [_format_row(label, latest.get(value)) for label, value in _SECTIONS]
         styles = render_to_string("static/section.css")
+        script = render_to_string("static/section.js")
         html = render_to_string(
-            "static/section.html", {"rows": rows, "styles": styles}
+            "static/section.html",
+            {"rows": rows, "styles": styles, "script": script},
         )
 
         return [

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -6,15 +6,23 @@
   box-sizing: border-box;
   max-height: 280px;
   overflow-y: auto;
-  /* Static "there's more below" hint: an inset shadow at the bottom edge
-     of the visible area. Doesn't depend on the host's background color
-     and never has to fight macOS's hide-when-idle scrollbar behavior --
-     the native scrollbar still works during scroll, this just gives an
-     idle-time affordance that the section is scrollable. */
-  box-shadow: inset 0 -16px 16px -16px rgba(0, 0, 0, 0.18);
   /* Firefox: still ask for the thin native scrollbar where supported. */
   scrollbar-width: thin;
   scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+}
+/* Always-visible "more below" overlay. Lives on top of the content (an
+   inset box-shadow is painted behind content and was only visible at
+   the very bottom of scroll). Sticky to bottom: 0 keeps it at the
+   bottom edge of the visible scroll viewport at every scroll position. */
+.lr-section::after {
+  content: "";
+  display: block;
+  position: sticky;
+  bottom: 0;
+  height: 36px;
+  margin-top: -36px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.28));
 }
 .lr-section::-webkit-scrollbar {
   width: 8px;

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -10,10 +10,11 @@
   display: block;
   position: sticky;
   bottom: 0;
-  height: 36px;
-  margin-top: -36px;
+  height: 14px;
+  margin-top: -14px;
+  border-radius: 14px;
   pointer-events: none;
-  background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.22));
+  background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.1));
   /* The script in static/section.js toggles the modifier class below
      once the user has scrolled to the end of the section. Default to
      visible so charts that load without JS (or before it runs) still

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -5,34 +5,29 @@
   color: rgba(0, 0, 0, 0.87);
   box-sizing: border-box;
   max-height: 280px;
-  overflow-y: scroll; /* always reserve the gutter, not just when overflowing */
-  /* Firefox: persistent thin scrollbar with explicit colors. */
+  overflow-y: auto;
+  /* Static "there's more below" hint: an inset shadow at the bottom edge
+     of the visible area. Doesn't depend on the host's background color
+     and never has to fight macOS's hide-when-idle scrollbar behavior --
+     the native scrollbar still works during scroll, this just gives an
+     idle-time affordance that the section is scrollable. */
+  box-shadow: inset 0 -16px 16px -16px rgba(0, 0, 0, 0.18);
+  /* Firefox: still ask for the thin native scrollbar where supported. */
   scrollbar-width: thin;
-  scrollbar-color: #d35400 #fde9d8;
+  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
 }
-/* DIAGNOSTIC: bright, unmistakable colors to verify the rules are being
-   applied at all. If the scrollbar shows orange-on-cream during scroll,
-   our CSS is loading and the only remaining fight is the macOS overlay
-   "fade when idle" behavior. If it shows the macOS default translucent
-   pill instead, our pseudo-element rules are being filtered somewhere
-   and we need a different approach. Revert to neutral colors after we
-   have an answer. */
 .lr-section::-webkit-scrollbar {
-  width: 12px;
-  -webkit-appearance: none;
-  appearance: none;
-  background-color: #fde9d8;
+  width: 8px;
 }
 .lr-section::-webkit-scrollbar-track {
-  background-color: #fde9d8;
+  background: transparent;
 }
 .lr-section::-webkit-scrollbar-thumb {
-  background-color: #d35400;
-  border-radius: 6px;
-  border: 2px solid #fde9d8;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
 }
 .lr-section::-webkit-scrollbar-thumb:hover {
-  background-color: #a04000;
+  background: rgba(0, 0, 0, 0.5);
 }
 .lr-section *,
 .lr-section *::before,

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -13,7 +13,16 @@
   height: 36px;
   margin-top: -36px;
   pointer-events: none;
-  background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.28));
+  background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.22));
+  /* The script in static/section.js toggles the modifier class below
+     once the user has scrolled to the end of the section. Default to
+     visible so charts that load without JS (or before it runs) still
+     get the affordance. */
+  opacity: 1;
+  transition: opacity 150ms ease-out;
+}
+.lr-section--at-bottom::after {
+  opacity: 0;
 }
 .lr-section *,
 .lr-section *::before,

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -4,9 +4,12 @@
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
   box-sizing: border-box;
-  /* If the host's container is shorter than our six rows, scroll inside
-     our content rather than letting the host clip rows silently. */
-  max-height: 100%;
+  /* Force our element to be the scroll container (rather than letting
+     the host's outer wrapper own the scroll), so our scrollbar styling
+     below actually applies. The pixel cap is arbitrary -- just tall
+     enough to show a few rows comfortably while ensuring overflow when
+     all six are populated. */
+  max-height: 280px;
   overflow-y: auto;
   /* Firefox: persistent thin scrollbar instead of the OS overlay default. */
   scrollbar-width: thin;

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -19,7 +19,6 @@
      visible so charts that load without JS (or before it runs) still
      get the affordance. */
   opacity: 1;
-  transition: opacity 150ms ease-out;
 }
 .lr-section--at-bottom::after {
   opacity: 0;

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -4,32 +4,35 @@
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
   box-sizing: border-box;
-  /* Force our element to be the scroll container (rather than letting
-     the host's outer wrapper own the scroll), so our scrollbar styling
-     below actually applies. The pixel cap is arbitrary -- just tall
-     enough to show a few rows comfortably while ensuring overflow when
-     all six are populated. */
   max-height: 280px;
-  overflow-y: auto;
-  /* Firefox: persistent thin scrollbar instead of the OS overlay default. */
+  overflow-y: scroll; /* always reserve the gutter, not just when overflowing */
+  /* Firefox: persistent thin scrollbar with explicit colors. */
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+  scrollbar-color: #d35400 #fde9d8;
 }
-/* WebKit/Blink: defining ::-webkit-scrollbar opts out of the OS overlay
-   scrollbar (macOS Safari/Chrome) so the bar stays visible whenever
-   there is overflow, instead of only during active scroll. */
+/* DIAGNOSTIC: bright, unmistakable colors to verify the rules are being
+   applied at all. If the scrollbar shows orange-on-cream during scroll,
+   our CSS is loading and the only remaining fight is the macOS overlay
+   "fade when idle" behavior. If it shows the macOS default translucent
+   pill instead, our pseudo-element rules are being filtered somewhere
+   and we need a different approach. Revert to neutral colors after we
+   have an answer. */
 .lr-section::-webkit-scrollbar {
-  width: 8px;
+  width: 12px;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: #fde9d8;
 }
 .lr-section::-webkit-scrollbar-track {
-  background: transparent;
+  background-color: #fde9d8;
 }
 .lr-section::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
+  background-color: #d35400;
+  border-radius: 6px;
+  border: 2px solid #fde9d8;
 }
 .lr-section::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.5);
+  background-color: #a04000;
 }
 .lr-section *,
 .lr-section *::before,

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -4,9 +4,8 @@
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
   box-sizing: border-box;
-  /* Safety net: if the host's container is shorter than our six rows
-     after the compact layout, scroll inside our content rather than
-     letting the host clip rows silently. */
+  /* If the host's container is shorter than our six rows, scroll inside
+     our content rather than letting the host clip rows silently. */
   max-height: 100%;
   overflow-y: auto;
 }
@@ -45,11 +44,7 @@
 }
 
 .lr-item {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75em;
-  padding: 0.25em 1rem;
+  padding: 0.5em 1rem;
   margin: 0;
   border-radius: 0.5em;
   line-height: 1.14285714em;
@@ -59,20 +54,11 @@
   font-weight: 700;
   color: rgba(0, 0, 0, 0.87);
   line-height: 1.14285714em;
-  flex: 0 0 auto;
 }
 
 .lr-detail {
   color: rgba(0, 0, 0, 0.7);
   line-height: 1.14285714em;
-  text-align: right;
-  /* Truncate long reviewer names instead of wrapping them onto a second
-     line, which would defeat the compact-row goal. */
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .lr-detail-by {

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -4,6 +4,11 @@
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
   box-sizing: border-box;
+  /* Safety net: if the host's container is shorter than our six rows
+     after the compact layout, scroll inside our content rather than
+     letting the host clip rows silently. */
+  max-height: 100%;
+  overflow-y: auto;
 }
 .lr-section *,
 .lr-section *::before,
@@ -40,7 +45,11 @@
 }
 
 .lr-item {
-  padding: 0.5em 1rem;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75em;
+  padding: 0.25em 1rem;
   margin: 0;
   border-radius: 0.5em;
   line-height: 1.14285714em;
@@ -50,11 +59,20 @@
   font-weight: 700;
   color: rgba(0, 0, 0, 0.87);
   line-height: 1.14285714em;
+  flex: 0 0 auto;
 }
 
 .lr-detail {
   color: rgba(0, 0, 0, 0.7);
   line-height: 1.14285714em;
+  text-align: right;
+  /* Truncate long reviewer names instead of wrapping them onto a second
+     line, which would defeat the compact-row goal. */
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .lr-detail-by {

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -8,6 +8,25 @@
      our content rather than letting the host clip rows silently. */
   max-height: 100%;
   overflow-y: auto;
+  /* Firefox: persistent thin scrollbar instead of the OS overlay default. */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+}
+/* WebKit/Blink: defining ::-webkit-scrollbar opts out of the OS overlay
+   scrollbar (macOS Safari/Chrome) so the bar stays visible whenever
+   there is overflow, instead of only during active scroll. */
+.lr-section::-webkit-scrollbar {
+  width: 8px;
+}
+.lr-section::-webkit-scrollbar-track {
+  background: transparent;
+}
+.lr-section::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+}
+.lr-section::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.5);
 }
 .lr-section *,
 .lr-section *::before,

--- a/extensions/last_reviewed/last_reviewed/static/section.css
+++ b/extensions/last_reviewed/last_reviewed/static/section.css
@@ -4,16 +4,7 @@
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
   box-sizing: border-box;
-  max-height: 280px;
-  overflow-y: auto;
-  /* Firefox: still ask for the thin native scrollbar where supported. */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
 }
-/* Always-visible "more below" overlay. Lives on top of the content (an
-   inset box-shadow is painted behind content and was only visible at
-   the very bottom of scroll). Sticky to bottom: 0 keeps it at the
-   bottom edge of the visible scroll viewport at every scroll position. */
 .lr-section::after {
   content: "";
   display: block;
@@ -23,19 +14,6 @@
   margin-top: -36px;
   pointer-events: none;
   background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.28));
-}
-.lr-section::-webkit-scrollbar {
-  width: 8px;
-}
-.lr-section::-webkit-scrollbar-track {
-  background: transparent;
-}
-.lr-section::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
-}
-.lr-section::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.5);
 }
 .lr-section *,
 .lr-section *::before,

--- a/extensions/last_reviewed/last_reviewed/static/section.html
+++ b/extensions/last_reviewed/last_reviewed/static/section.html
@@ -27,3 +27,4 @@
     {% endfor %}
   </div>
 </div>
+<script>{{ script|safe }}</script>

--- a/extensions/last_reviewed/last_reviewed/static/section.js
+++ b/extensions/last_reviewed/last_reviewed/static/section.js
@@ -1,0 +1,42 @@
+// Toggle the "at-bottom" class on .lr-section once the user has scrolled
+// to (or past) the section's bottom edge, so the bottom-fade overlay can
+// transition out. Walks up from .lr-section to find the nearest
+// scrolling ancestor, listens for scroll and resize, and updates state.
+(function () {
+  function findScrollContainer(el) {
+    var parent = el.parentElement;
+    while (parent && parent !== document.documentElement) {
+      var cs = getComputedStyle(parent);
+      var oy = cs.overflowY;
+      if ((oy === "auto" || oy === "scroll") && parent.scrollHeight > parent.clientHeight) {
+        return parent;
+      }
+      parent = parent.parentElement;
+    }
+    return window;
+  }
+
+  function init(sectionEl) {
+    var scroller = findScrollContainer(sectionEl);
+    var scrollTarget = scroller === window ? window : scroller;
+
+    function update() {
+      var rect = sectionEl.getBoundingClientRect();
+      var viewportBottom =
+        scroller === window ? window.innerHeight : scroller.getBoundingClientRect().bottom;
+      // Section "still has more below" when its bottom edge sits below
+      // the viewport's bottom edge. Tolerance of 1px to absorb fractional
+      // pixel rounding from getBoundingClientRect.
+      var hasMoreBelow = rect.bottom - viewportBottom > 1;
+      sectionEl.classList.toggle("lr-section--at-bottom", !hasMoreBelow);
+    }
+
+    scrollTarget.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    update();
+    // Re-check after layout settles (e.g., font loading shifts heights).
+    requestAnimationFrame(update);
+  }
+
+  document.querySelectorAll(".lr-section").forEach(init);
+})();

--- a/extensions/last_reviewed/last_reviewed/static/section.js
+++ b/extensions/last_reviewed/last_reviewed/static/section.js
@@ -18,7 +18,6 @@
 
   function init(sectionEl) {
     var scroller = findScrollContainer(sectionEl);
-    var scrollTarget = scroller === window ? window : scroller;
 
     function update() {
       var rect = sectionEl.getBoundingClientRect();
@@ -31,7 +30,7 @@
       sectionEl.classList.toggle("lr-section--at-bottom", !hasMoreBelow);
     }
 
-    scrollTarget.addEventListener("scroll", update, { passive: true });
+    scroller.addEventListener("scroll", update, { passive: true });
     window.addEventListener("resize", update);
     update();
     // Re-check after layout settles (e.g., font loading shifts heights).


### PR DESCRIPTION
 ## Summary

  Iterative work on top of `last_reviewed` plugin. Two themes:                                                              
  
  - **Overflow affordance.** When the section's six rows extend below the host's chart-summary slot, a soft fade now appears at the bottom edge as a "more below" hint. A sticky `::after` overlay paints the fade so it always sits at the visible viewport bottom (not the bottom of all content), and a small client-side script (`static/section.js`) walks up from `.lr-section` to find the nearest scrolling ancestor, listens for scroll/resize, and toggles a `.lr-section--at-bottom` modifier class so the fade drops out once the user has scrolled to the section's bottom edge. The handler injects the script via `render_to_string` exactly the way it already injects the CSS, since the chart-summary content ships as one inline blob.
  - **README expansion.** Adds *Problem this solves*, *Who it's for*, and *How to install* sections so a reader landing on the plugin can tell at a glance why it exists, who benefits, and that no secrets/env vars are required (only the section-ordering caveat, already documented). 

  - The branch is also where we *learned* a few things about the chart-summary render context — captured in commit messages so future readers know why the code looks the way it does:                                                                                                                                                    
  - The host's wrapper owns the scroll, not us. An earlier attempt to be the scroll container ourselves produced nested scrollbars (commit `653c759` reverts that).
  - Native macOS Chrome/Safari respect the OS "show scrollbars when scrolling" preference even with explicit `::-webkit-scrollbar` styling, so a forced-persistent scrollbar isn't reachable from CSS alone — hence the fade affordance instead.                                                      
  - The host's render context doesn't honor an `opacity` transition on the `::after` pseudo, so the fade snaps in/out rather than animating; the unused `transition` rule was trimmed.                                                                                                                      
                  
  ## Test plan                                                                                                                                         
                  
  - [ ] Open a patient chart with all six chart sections populated; confirm the *Last Reviewed* section still renders correctly above the standard     
  sections.
  - [ ] Resize the browser or navigate to a chart layout where the section overflows the host's slot; confirm a soft fade appears at the bottom edge of
   the visible section.                                                                                                                                
  - [ ] Scroll down within the chart-summary column until the section's last row is fully in view; confirm the fade has disappeared.
  - [ ] Scroll back up; confirm the fade reappears.                                                                                                    
  - [ ] On a layout where the section fits without overflow, confirm there's nothing visually awkward at the bottom edge.
  - [ ] Confirm the rollback-on-deletion behavior from PR #1 still works (mark a section reviewed → refresh → delete the review → refresh → row        
  reverts).                                                                                                                                            
                                                                                                                                                       
  ## Files changed                                                                                                                                     
                  
  - `last_reviewed/static/section.js` (new) — scroll-aware fade visibility                                                                             
  - `last_reviewed/static/section.css` — sticky `::after` overlay + `.lr-section--at-bottom` rule
  - `last_reviewed/static/section.html` — adds the `<script>` tag                                                                                      
  - `last_reviewed/handlers/section_content.py` — loads + injects `section.js`
  - `last_reviewed/README.md` — adds problem/audience/install sections, documents the fade affordance                                                  
  - `last_reviewed/CANVAS_MANIFEST.json` — `0.1.8` → `0.1.18`           -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   - 