### PR TITLE
review: ignore .cpa-workflow-artifacts/ files in reviews

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -43,7 +43,7 @@ Before posting a 🔴 Important finding, read the code path and cite `file:line`
 - Suggestions to refactor working code into a different pattern
 - Naming preferences for variables, functions, classes, files
 - Docstring or comment wording
-- Generated files (`*.lock`, `__pycache__/`, anything under a path containing `generated`)
+- Generated files (`*.lock`, `__pycache__/`, anything under a path containing `generated`, anything under `.cpa-workflow-artifacts/`)
 - Test-only code that intentionally violates production rules
 
 ## Always check


### PR DESCRIPTION
Add `.cpa-workflow-artifacts/` to the "Generated files" exclusion in `REVIEW.md` so Claude Code Review skips the cost/user_inputs/review-report artifacts that `/wrap-up` and other CPA workflow steps generate.

See https://github.com/canvas-medical/gtm-extensions/pull/220 for an example PR where these files would otherwise flood the review.