### PR TITLE
nutrition_charting: register NoteApplication under protocols, not applications

### DIFF
--- a/extensions/nutrition_charting/nutrition_charting/CANVAS_MANIFEST.json
+++ b/extensions/nutrition_charting/nutrition_charting/CANVAS_MANIFEST.json
@@ -1,19 +1,16 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.13",
+    "plugin_version": "0.1.14",
     "name": "nutrition_charting",
     "description": "Structured ADIME charting tab for Nutrition note types, plus a printable nutrition note matching the dietician template.",
     "components": {
-        "applications": [
+        "applications": [],
+        "protocols": [
             {
                 "class": "nutrition_charting.applications.nutrition_charting_app:NutritionChartingApp",
-                "name": "Nutrition",
-                "description": "Structured ADIME charting tab — visible only on Nutrition note types",
-                "scope": "patient_specific",
-                "icon": "assets/icon.png"
-            }
-        ],
-        "protocols": [
+                "description": "NoteApplication rendering the Nutrition tab on the note body. Declared under protocols (not applications) to keep the entry out of the chart's 9-dot drawer — the drawer is populated from plugin_io_application rows that only the applications array creates. The plugin runner still loads the class so the SDK's APPLICATION__ON_GET event wires the note tab.",
+                "data_access": { "event": "", "read": [], "write": [] }
+            },
             {
                 "class": "nutrition_charting.protocols.print_button:PrintNutritionNoteButton",
                 "description": "Note-header button that opens the printable Nutrition Note modal",


### PR DESCRIPTION
## Summary

- `NutritionChartingApp` is a `NoteApplication` subclass and was incorrectly declared under `components.applications` in the manifest. The `applications` array creates a `plugin_io_application` row that puts an icon in the chart's 9-dot drawer — that drawer entry was never intended.
- Moves the entry to `components.protocols`, drops `name`/`scope`/`icon` (not valid on a `protocols` entry; the class carries `NAME` and `IDENTIFIER`), and bumps `plugin_version` 0.1.13 → 0.1.14.
- The note tab continues to render: the SDK's `APPLICATION__ON_GET` event fires on any class the plugin runner loads, regardless of which manifest array it sits in.

## Migration impact

`canvas install` on update does **not** GC the existing `plugin_io_application` row. Any instance that already has 0.1.13 installed will keep the drawer icon after upgrading to 0.1.14. To clear it:

    canvas disable nutrition_charting --host <instance>
    canvas uninstall nutrition_charting --host <instance>
    canvas install nutrition_charting --host <instance>

Hard-refresh the browser afterwards to bust the drawer query cache.

⚠️  `uninstall` drops the plugin's `AttributeHub` rows, which is where the plugin stores draft nutrition-chart form state. Any in-progress charts on those instances will be lost. Coordinate with users before running it on production instances.

## Test plan

- [ ] `canvas install` on a clean instance: Nutrition tab appears on nutrition-typed notes; no nutrition_charting icon in the 9-dot drawer.
- [ ] `canvas install` on an instance previously running 0.1.13: Nutrition tab still works; drawer icon persists until the disable→uninstall→install sequence above is run.
- [ ] Existing unit/integration tests still pass (manifest-only change; no Python touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
