### PR TITLE
Invert ADMIN_STAFF_IDS default: unset = open, listed = restricted

### DIFF
--- a/extensions/dea-prescriber-filter/README.md
+++ b/extensions/dea-prescriber-filter/README.md
@@ -32,7 +32,7 @@ cd dea_prescriber_filter
 canvas install . --host <your-instance>
 ```
 
-After install, the Prescriber Assist app appears in the app drawer for authenticated staff. Before anyone can open the admin UI, configure the `ADMIN_STAFF_IDS` secret (see [Configuration options](#configuration-options)) — without it, all admin-UI requests return 403 Forbidden.
+After install, the Prescriber Assist app appears in the app drawer for authenticated staff. Any logged-in Canvas staff member can open the admin UI by default; to restrict access to a named subset of admins, configure the `ADMIN_STAFF_IDS` secret (see [Configuration options](#configuration-options)).
 
 ## Important: disable `RESTRICT_MEDICATION_ORDERS_TO_PRESCRIBER`
 
@@ -46,16 +46,16 @@ With the built-in setting disabled and the plugin installed:
 
 ## Configuration options
 
-### `ADMIN_STAFF_IDS` (required plugin secret)
+### `ADMIN_STAFF_IDS` (optional plugin secret)
 
-The Prescriber Assist admin UI controls prescribing-delegation, which decides who can sign controlled-substance prescriptions on behalf of a provider. Access is denied unless `ADMIN_STAFF_IDS` is set to a comma-separated list of staff UUIDs.
+The Prescriber Assist admin UI controls prescribing-delegation, which decides who can sign controlled-substance prescriptions on behalf of a provider. By default, any authenticated Canvas staff member can access the admin UI. Set `ADMIN_STAFF_IDS` to a comma-separated list of staff UUIDs to restrict access to a named subset.
 
 **Example:**
 ```
 ADMIN_STAFF_IDS=57f3668ea9f84f3980e772ea8451af38,a1b2c3d4e5f6...
 ```
 
-- Empty or unset → all callers get 403 Forbidden (a warning is logged pointing at this secret)
+- Empty or unset → any authenticated Canvas staff member can access the admin UI
 - Set to UUIDs → only listed staff can access the admin UI; all others get 403 Forbidden
 
 Configure this in the Canvas admin panel: **Plugins → dea_prescriber_filter → Secrets**.

--- a/extensions/dea-prescriber-filter/dea_prescriber_filter/CANVAS_MANIFEST.json
+++ b/extensions/dea-prescriber-filter/dea_prescriber_filter/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.94.0",
-    "plugin_version": "0.1.30",
+    "plugin_version": "0.2.0",
     "name": "dea_prescriber_filter",
     "description": "Filters prescribe actions based on NPI matching between user and selected prescriber",
     "license": "MIT",

--- a/extensions/dea-prescriber-filter/dea_prescriber_filter/api/delegation_api.py
+++ b/extensions/dea-prescriber-filter/dea_prescriber_filter/api/delegation_api.py
@@ -443,20 +443,17 @@ class DelegationUIApi(StaffSessionAuthMixin, SimpleAPI):
     def _is_admin_user(self) -> bool:
         """Check if the current user is allowed to manage delegations.
 
-        Requires ADMIN_STAFF_IDS to be configured (comma-separated staff UUIDs).
-        Empty / unset secret denies all callers — controlled-substance delegation
-        must be granted by an explicitly-listed admin, never by "any authenticated
-        staff." See CLAUDE.md fail-closed anti-pattern guidance.
+        ADMIN_STAFF_IDS is an *optional* restriction list. When unset or empty,
+        any authenticated Canvas staff member can manage delegations
+        (StaffSessionAuthMixin already enforces that the caller is a logged-in
+        staff user). When set to a comma-separated list of staff UUIDs, access
+        is restricted to those staff members only.
         """
         admin_ids_raw = self.secrets.get("ADMIN_STAFF_IDS", "") or ""
         admin_ids = {s.strip() for s in admin_ids_raw.split(",") if s.strip()}
 
         if not admin_ids:
-            log.warning(
-                "ADMIN_STAFF_IDS is not configured; denying admin access. "
-                "Set this secret to a comma-separated list of staff UUIDs to allow admins."
-            )
-            return False
+            return True
 
         headers = getattr(self.request, "headers", {}) or {}
         user_id = headers.get("canvas-logged-in-user-id") or headers.get("Canvas-Logged-In-User-Id")

--- a/extensions/dea-prescriber-filter/tests/api/test_delegation_api.py
+++ b/extensions/dea-prescriber-filter/tests/api/test_delegation_api.py
@@ -28,22 +28,22 @@ def _make_handler(
 # _is_admin_user — auth check
 # ─────────────────────────────────────────────────────────────
 
-def test_is_admin_user_denies_when_secret_empty() -> None:
-    """Empty ADMIN_STAFF_IDS secret denies admin access (fail-closed)."""
+def test_is_admin_user_allows_when_secret_empty() -> None:
+    """Empty ADMIN_STAFF_IDS secret means any authenticated staff is admin."""
     tested = _make_handler(secrets={"ADMIN_STAFF_IDS": ""})
 
     result = tested._is_admin_user()
 
-    assert result is False
+    assert result is True
 
 
-def test_is_admin_user_denies_when_secret_missing() -> None:
-    """Missing ADMIN_STAFF_IDS secret denies admin access (fail-closed)."""
+def test_is_admin_user_allows_when_secret_missing() -> None:
+    """Missing ADMIN_STAFF_IDS secret means any authenticated staff is admin."""
     tested = _make_handler(secrets={})
 
     result = tested._is_admin_user()
 
-    assert result is False
+    assert result is True
 
 
 def test_is_admin_user_restricts_when_secret_set_and_user_not_listed() -> None:


### PR DESCRIPTION
## Summary

Inverts the default behavior of the Prescriber Assist admin UI access check.

**Before:** \`ADMIN_STAFF_IDS\` was required (fail-closed). Empty/unset → all callers got 403 Forbidden. Plugin was unusable out of the box until an admin manually configured the secret with their own staff UUID.

**After:** \`ADMIN_STAFF_IDS\` is an optional restriction list. Empty/unset → any authenticated Canvas staff member can manage delegations. Set → access is restricted to listed UUIDs only. \`StaffSessionAuthMixin\` still enforces that the caller is a logged-in Canvas staff user.

## Trade-off

The previous fail-closed default was more secure — a fresh install couldn't grant admin to anyone until the secret was explicitly set. The new default is more usable — works out of the box, restrict later if needed. Product call.

## Changes
- \`api/delegation_api.py\` — \`_is_admin_user()\` returns \`True\` when \`ADMIN_STAFF_IDS\` is unset/empty instead of \`False\`
- README \`ADMIN_STAFF_IDS\` section reworded to describe the optional-restriction model
- README "How to install" callout reworded — no longer says you must configure the secret before anyone can use the admin UI
- Tests \`test_is_admin_user_denies_when_secret_empty\` and \`..._missing\` flipped to \`..._allows_when_...\`
- \`plugin_version\` bumped \`0.1.30\` → \`0.2.0\`

## Test plan
- [x] All 136 existing tests pass
- [ ] Install on support-team and verify Prescriber Assist no longer returns 403 when \`ADMIN_STAFF_IDS\` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)