### PR TITLE
Use hosted icon URL so admin-UI uploads work regardless of tarball layout

### DIFF
--- a/extensions/dea-prescriber-filter/dea_prescriber_filter/CANVAS_MANIFEST.json
+++ b/extensions/dea-prescriber-filter/dea_prescriber_filter/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.94.0",
-    "plugin_version": "0.2.0",
+    "plugin_version": "0.2.1",
     "name": "dea_prescriber_filter",
     "description": "Filters prescribe actions based on NPI matching between user and selected prescriber",
     "license": "MIT",
@@ -52,7 +52,7 @@
                 "class": "dea_prescriber_filter.applications.delegation_app:PrescriberDelegationApp",
                 "name": "Prescriber Assist",
                 "description": "Configure which staff can sign prescriptions for each provider",
-                "icon": "assets/prescriber-delegation-icon.png",
+                "icon": "https://raw.githubusercontent.com/Medical-Software-Foundation/canvas/main/extensions/dea-prescriber-filter/dea_prescriber_filter/assets/prescriber-delegation-icon.png",
                 "scope": "global"
             }
         ]


### PR DESCRIPTION
## Summary

Replaces the package-relative icon path with a hosted https URL pointing at the same file in this repo. Plugin version bumped 0.2.0 → 0.2.1.

## Problem

When users install this plugin by uploading a manually built tarball via the Canvas admin UI, Canvas's plugin validator rejects the install with:

> \`{'icon': ['The icon must be an image located within the dea_prescriber_filter package']}\`

The validator does a literal lookup of the manifest's icon path inside the uploaded tarball (\`extract_file_from_archive\` in \`home-app/plugin_io/utils/utils.py\`). \`canvas install\` packages files relative to the inner plugin directory, so \`assets/prescriber-delegation-icon.png\` resolves correctly. Manual tarballs that wrap the package in an extra directory level fail because the entries get prefixed with \`dea_prescriber_filter/\` and the validator's exact-name lookup misses.

This wasn't a problem while the plugin lived in gtm-extensions (only installed via the CLI). Once transitioned to this public repo, anyone can grab the source and install it themselves — and admin-UI uploads with non-standard tarball layouts are now realistic.

## Fix

The validator accepts \`http://\` or \`https://\` URLs as well as archive-relative paths. URL icons are downloaded once during install and stored locally on the Canvas instance, so there's no runtime dependency on GitHub after the install completes.

Switched to:
\`\`\`
https://raw.githubusercontent.com/Medical-Software-Foundation/canvas/main/extensions/dea-prescriber-filter/dea_prescriber_filter/assets/prescriber-delegation-icon.png
\`\`\`

The bundled PNG stays in the repo as the canonical source the URL points at — no asset deletion.

## Test plan

- [x] 136 unit tests pass
- [ ] Install v0.2.1 on a sandbox via the admin UI — confirm Prescriber Assist appears in the app drawer with the correct icon
- [ ] Install v0.2.1 on a sandbox via \`canvas install\` — same verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)