### PR TITLE
order-sets: load modal from API endpoint directly

### DIFF
--- a/extensions/order-sets/order_sets/applications/order_sets_admin_app.py
+++ b/extensions/order-sets/order_sets/applications/order_sets_admin_app.py
@@ -14,30 +14,8 @@ class OrderSetsAdminApp(Application):
     """
 
     def on_open(self) -> Effect:
-        html = (
-            '<html><head><style>'
-            'body { font-family: -apple-system, sans-serif; background: #f9fafb; margin: 0; padding: 0; }'
-            '.loader { display: flex; justify-content: center; align-items: center; min-height: 100vh; flex-direction: column; color: #6b7280; }'
-            '.spinner { width: 40px; height: 40px; border: 4px solid #e5e7eb; border-top-color: #4F46E5; border-radius: 50%; animation: spin 0.8s linear infinite; margin-bottom: 16px; }'
-            '@keyframes spin { to { transform: rotate(360deg); } }'
-            '#error { display: none; color: #ef4444; padding: 20px; }'
-            '</style></head><body>'
-            '<div class="loader" id="loading"><div class="spinner"></div><div>Loading Order Sets Admin...</div></div>'
-            '<div id="error"></div>'
-            '<script>'
-            'fetch("/plugin-io/api/order_sets/admin-ui", {credentials: "same-origin"})'
-            '.then(function(r) { return r.text(); })'
-            '.then(function(html) { document.open(); document.write(html); document.close(); })'
-            '.catch(function(err) {'
-            'document.getElementById("loading").style.display = "none";'
-            'var el = document.getElementById("error");'
-            'el.style.display = "block";'
-            'el.textContent = "Error loading Order Sets Admin: " + err;'
-            '});'
-            '</script></body></html>'
-        )
         return LaunchModalEffect(
-            content=html,
+            url="/plugin-io/api/order_sets/admin-ui",
             target=LaunchModalEffect.TargetType.DEFAULT_MODAL,
             title="Order Sets Admin",
         ).apply()

--- a/extensions/order-sets/order_sets/applications/order_sets_app.py
+++ b/extensions/order-sets/order_sets/applications/order_sets_app.py
@@ -1,50 +1,15 @@
-import json
+from urllib.parse import quote
 
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.launch_modal import LaunchModalEffect
 from canvas_sdk.handlers.application import Application
 
 
-def _js_safe(value: str) -> str:
-    """Encode `value` as a JS string literal that's also safe inside <script>.
-
-    `json.dumps` handles JS string escaping but does not protect against the
-    HTML tokenizer ending the surrounding <script> tag early when the value
-    contains "</script>". Replacing every "</" with "<\\/" (a valid JS string
-    escape that decodes back to "/") prevents the tokenizer from seeing a
-    closing tag while keeping the runtime value unchanged.
-    """
-    return json.dumps(value).replace("</", "<\\/")
-
-
 class OrderSetsApp(Application):
     def on_open(self) -> Effect:
         patient_id = self.event.context.get("patient", {}).get("id", "")
-        patient_id_js = _js_safe(patient_id)
-        html = (
-            '<html><head><style>'
-            'body { font-family: -apple-system, sans-serif; background: #f9fafb; margin: 0; padding: 0; }'
-            '.loader { display: flex; justify-content: center; align-items: center; min-height: 100vh; flex-direction: column; color: #6b7280; }'
-            '.spinner { width: 40px; height: 40px; border: 4px solid #e5e7eb; border-top-color: #4F46E5; border-radius: 50%; animation: spin 0.8s linear infinite; margin-bottom: 16px; }'
-            '@keyframes spin { to { transform: rotate(360deg); } }'
-            '#error { display: none; color: #ef4444; padding: 20px; }'
-            '</style></head><body>'
-            '<div class="loader" id="loading"><div class="spinner"></div><div>Loading Order Sets...</div></div>'
-            '<div id="error"></div>'
-            '<script>'
-            f'var __patientId = {patient_id_js};'
-            'fetch("/plugin-io/api/order_sets/ui?patient_id=" + encodeURIComponent(__patientId), {credentials: "same-origin"})'
-            '.then(function(r) { return r.text(); })'
-            '.then(function(html) { document.open(); document.write(html); document.close(); })'
-            '.catch(function(err) {'
-            'document.getElementById("loading").style.display = "none";'
-            'var el = document.getElementById("error");'
-            'el.style.display = "block";'
-            'el.textContent = "Error loading Order Sets: " + err;'
-            '});'
-            '</script></body></html>'
-        )
+        url = f"/plugin-io/api/order_sets/ui?patient_id={quote(patient_id, safe='')}"
         return LaunchModalEffect(
-            content=html,
+            url=url,
             target=LaunchModalEffect.TargetType.RIGHT_CHART_PANE,
         ).apply()

--- a/extensions/order-sets/tests/conftest.py
+++ b/extensions/order-sets/tests/conftest.py
@@ -55,13 +55,19 @@ class _LaunchModalEffect:
         DEFAULT_MODAL = "DEFAULT_MODAL"
         PAGE = "PAGE"
 
-    def __init__(self, content=None, target=None, title=None):
+    def __init__(self, url=None, content=None, target=None, title=None):
+        self.url = url
         self.content = content
         self.target = target
         self.title = title
 
     def apply(self):
-        return MagicMock(content=self.content, target=self.target, title=self.title)
+        return MagicMock(
+            url=self.url,
+            content=self.content,
+            target=self.target,
+            title=self.title,
+        )
 
 
 _launch_modal_mod = MagicMock()

--- a/extensions/order-sets/tests/test_misc.py
+++ b/extensions/order-sets/tests/test_misc.py
@@ -61,17 +61,13 @@ class TestFindOpenNote:
 
 
 class TestOrderSetsApp:
-    def test_on_open_emits_modal_with_patient_id(self):
+    def test_on_open_emits_modal_url_with_patient_id(self):
         app = OrderSetsApp.__new__(OrderSetsApp)
         app.event = MagicMock()
         app.event.context = {"patient": {"id": "patient-42"}}
 
         effect = app.on_open()
-        # The mocked LaunchModalEffect.apply() returns a MagicMock with the
-        # original content/target, so we can re-derive the HTML.
-        # The test conftest's _LaunchModalEffect stores content/target on the
-        # apply() return.
-        assert "patient-42" in effect.content
+        assert effect.url == "/plugin-io/api/order_sets/ui?patient_id=patient-42"
 
     def test_on_open_handles_missing_patient_id(self):
         app = OrderSetsApp.__new__(OrderSetsApp)
@@ -79,24 +75,18 @@ class TestOrderSetsApp:
         app.event.context = {}
 
         effect = app.on_open()
-        # json.dumps("") → '""'; should appear in the script
-        assert '""' in effect.content
+        assert effect.url == "/plugin-io/api/order_sets/ui?patient_id="
 
-    def test_on_open_blocks_script_tag_breakout(self):
-        """Inline-script breakout via `</script>` must be escaped.
-
-        `json.dumps` alone does NOT escape `</script>`; the HTML tokenizer
-        terminates the script element at the literal closing tag regardless
-        of JS string context. The application's `_js_safe` helper has to
-        replace `</` with `<\\/` so the tokenizer never sees a closing tag.
+    def test_on_open_url_encodes_unsafe_chars_in_patient_id(self):
+        """Patient id is interpolated into a URL query string and must be
+        percent-encoded so reserved characters can't break the request.
         """
         app = OrderSetsApp.__new__(OrderSetsApp)
         app.event = MagicMock()
-        app.event.context = {"patient": {"id": '</script><script>alert(1)//'}}
+        app.event.context = {"patient": {"id": "a&b=c#d"}}
 
         effect = app.on_open()
-        assert effect.content.count("</script>") == 1
-        assert "<\\/script>" in effect.content
+        assert effect.url == "/plugin-io/api/order_sets/ui?patient_id=a%26b%3Dc%23d"
 
 
 class TestOrderSetsAdminApp:
@@ -110,6 +100,4 @@ class TestOrderSetsAdminApp:
         # Deliberately do NOT set app.event — on_open must not read patient context.
         effect = app.on_open()
 
-        # Fetches /admin-ui directly with no patient_id query string
-        assert "/admin-ui" in effect.content
-        assert "patient_id" not in effect.content
+        assert effect.url == "/plugin-io/api/order_sets/admin-ui"


### PR DESCRIPTION
## Summary

Simplifies how `OrderSetsApp` and `OrderSetsAdminApp` open their modals. Replaces the inline-HTML-shell pattern with a direct `LaunchModalEffect(url=...)` that points at the plugin's SimpleAPI endpoint.

**Before:** Canvas uploaded the on_open content HTML to S3, the browser loaded a pre-signed URL, that page's inline `<script>` fetched the real UI from `/plugin-io/api/order_sets/ui`, and `document.open/write/close` swapped the loading shell for the real UI.

**After:** Canvas's iframe loads `/plugin-io/api/order_sets/ui` (or `/admin-ui`) directly in a single request. The `/ui` and `/admin-ui` endpoints already return full `HTMLResponse` pages, so no other changes were needed in the API layer.

### Why

- Eliminates the S3 upload + pre-signed URL roundtrip (and the short-lived URL expiry that came with it).
- Drops the inline `<script>` / `document.write()` pattern.
- Removes the `_js_safe` HTML-tokenizer-aware escape helper — URL-encoded query parameters do the equivalent job, and `urllib.parse.quote` is a standard-library primitive rather than a hand-rolled escape.
- Roughly 60 lines of code removed across the two handlers.

### Tests

`uv run pytest tests/` — 146/146 passing.

`TestOrderSetsApp` and `TestOrderSetsAdminApp` were updated to assert the new `url` field on the resulting `LaunchModalEffect` instead of inspecting the inline HTML. The script-tag-breakout test was replaced with a percent-encoding test that verifies reserved URL characters in `patient_id` are escaped via `quote(..., safe='')` before being interpolated into the query string.

## Test plan

- [ ] `uv run pytest tests/` passes locally
- [ ] Install on a Canvas instance and confirm Order Sets opens in the right chart pane from a patient chart
- [ ] Confirm Order Sets Admin opens in the default modal from the global app drawer
- [ ] Confirm no console errors or S3-related network failures on click