### PR TITLE
order-sets: fix 404 on plugin API by registering under protocols

### DIFF
--- a/extensions/order-sets/order_sets/CANVAS_MANIFEST.json
+++ b/extensions/order-sets/order_sets/CANVAS_MANIFEST.json
@@ -4,7 +4,7 @@
     "name": "order_sets",
     "description": "Predefined order sets for labs, imaging, and POC in-office tests. Select bundles of orders with one click from the patient chart.",
     "components": {
-        "handlers": [
+        "protocols": [
             {
                 "class": "order_sets.api.endpoints:OrderSetsAPI",
                 "description": "API endpoints for order set management and execution",


### PR DESCRIPTION
## Summary

Fix: the `OrderSetsAPI` SimpleAPI handler was declared under `components.handlers` in the manifest. The plugin runner in canvas-plugins only loads handler classes from `components.protocols` and `components.applications` — the `components.handlers` array is silently ignored at routing time.

Result: even though install succeeded and the apps registered correctly, requests from the iframe to `/plugin-io/api/order_sets/ui` and `/plugin-io/api/order_sets/admin-ui` returned 404, and clicking the Order Sets app icons opened blank modals.

### Reference

`canvas-plugins/plugin_runner/plugin_runner.py:590`:

```python
handlers = manifest_json["components"].get("protocols", []) + manifest_json[
    "components"
].get("applications", [])
```

Other SimpleAPI plugins in this repo that register without a `PREFIX` (e.g. `scheduling-with-rooms`) already use `components.protocols` — this PR aligns `order-sets` with that pattern.

### Tests

`uv run pytest tests/` — 146/146 passing. No code changes; tests verify the manifest is internally consistent and don't depend on its top-level section.

## Test plan

- [ ] Reinstall the plugin on a Canvas instance
- [ ] Click the Order Sets app icon in a patient chart → modal opens with the order-set browser UI
- [ ] Click the Order Sets Admin app icon in the global drawer → modal opens with the admin UI
- [ ] Verify in DevTools Network: GET `/plugin-io/api/order_sets/ui?patient_id=…` returns 200 with HTML
- [ ] Verify in DevTools Network: GET `/plugin-io/api/order_sets/admin-ui` returns 200 with HTML