### PR TITLE
nutrition_charting: move NoteApplication to protocols to remove drawer icon

### DIFF
--- a/extensions/nutrition_charting/nutrition_charting/CANVAS_MANIFEST.json
+++ b/extensions/nutrition_charting/nutrition_charting/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.14",
+    "plugin_version": "0.1.15",
     "name": "nutrition_charting",
     "description": "Structured ADIME charting tab for Nutrition note types, plus a printable nutrition note matching the dietician template.",
     "components": {
@@ -52,7 +52,8 @@
         "practice-name",
         "practice-address",
         "practice-phone",
-        "practice-fax"
+        "practice-fax",
+        "namespace_read_write_access_key"
     ],
     "tags": {},
     "references": [],

--- a/extensions/nutrition_charting/nutrition_charting/CANVAS_MANIFEST.json
+++ b/extensions/nutrition_charting/nutrition_charting/CANVAS_MANIFEST.json
@@ -1,19 +1,16 @@
 {
     "sdk_version": "0.142.0",
-    "plugin_version": "0.1.13",
+    "plugin_version": "0.1.14",
     "name": "nutrition_charting",
     "description": "Structured ADIME charting tab for Nutrition note types, plus a printable nutrition note matching the dietician template.",
     "components": {
-        "applications": [
+        "applications": [],
+        "protocols": [
             {
                 "class": "nutrition_charting.applications.nutrition_charting_app:NutritionChartingApp",
-                "name": "Nutrition",
-                "description": "Structured ADIME charting tab — visible only on Nutrition note types",
-                "scope": "patient_specific",
-                "icon": "assets/icon.png"
-            }
-        ],
-        "protocols": [
+                "description": "NoteApplication rendering the structured ADIME charting tab on Nutrition note types.",
+                "data_access": { "event": "", "read": [], "write": [] }
+            },
             {
                 "class": "nutrition_charting.protocols.print_button:PrintNutritionNoteButton",
                 "description": "Note-header button that opens the printable Nutrition Note modal",

--- a/extensions/nutrition_charting/nutrition_charting/README.md
+++ b/extensions/nutrition_charting/nutrition_charting/README.md
@@ -89,6 +89,7 @@ Admin-UI access to plugin secrets is governed per-plugin by a **Managing users**
 | `practice-phone` | "P:" entry in the print header / footer. |
 | `practice-fax` | "F:" entry in the print header / footer. |
 | `simple-api-key` | Auth fallback for `PrintNutritionNoteAPI` outside a staff session. Optional. |
+| `namespace_read_write_access_key` | Auto-declared because the plugin has a `custom_data` block; auto-managed by Canvas on install. No manual configuration required. |
 
 If any practice secret is unset, that line renders empty in the print header rather than failing.
 


### PR DESCRIPTION
## Summary
- Moves `NutritionChartingApp` (a `NoteApplication` subclass) from `components.applications` to `components.protocols` in `CANVAS_MANIFEST.json` so it no longer registers a `plugin_io_application` row and no longer surfaces an unwanted icon in the chart's 9-dot drawer.
- Bumps `plugin_version` 0.1.13 → 0.1.14.

## Why this works
The plugin runner concatenates `protocols + applications + handlers` into one handler list, so the class is still loaded and the SDK's `APPLICATION__ON_GET` event still wires the in-note tab. The class's `NAME` and `IDENTIFIER` attributes drive the note tab strip — no `icon`, `name`, or `scope` field is needed (or allowed) on a `protocols` entry. This matches the pattern used by `hyperscribe`'s `ScribeApp`.

What does NOT work as alternatives (already validated):
- `applications` + `scope: patient_specific` → icon appears in drawer
- `applications` + `show_in_panel: false` → no-op (false is the default)
- `applications` + `show_in_panel: true` → moves icon to the patient-header panel strip, doesn't hide it
- Overriding `visible()` in Python → only affects the in-note tab; the drawer icon is registered statically from the manifest

## Deployment caveat (important)
`canvas install` on update does **not** garbage-collect the existing `plugin_io_application` row when an entry leaves the `applications` array. Instances already running 0.1.13 will still show the drawer icon after a plain reinstall.

To clean up on each target instance:

```
canvas disable nutrition_charting --host <instance>
canvas uninstall nutrition_charting --host <instance>
canvas install nutrition_charting --host <instance>
```

Then browser hard-refresh (Cmd+Shift+R) to bust Apollo Client's drawer query cache.

**Warning:** `uninstall` drops the plugin's `AttributeHub` rows on that instance, so any in-progress nutrition note draft state is lost. Coordinate with users before rolling out.

## Test plan
- [ ] Install the new version on a clean Canvas instance and confirm no Nutrition icon appears in the chart 9-dot drawer
- [ ] Create a Nutrition note type and confirm the ADIME charting tab still renders on the note body
- [ ] Save a section, reopen the note, and confirm form state restores correctly (existing `AttributeHub` behavior unchanged)
- [ ] Open the printable Nutrition Note via the header button and confirm it renders
- [ ] On an instance already running 0.1.13, run the disable → uninstall → install procedure above and confirm the drawer icon is gone after a hard-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
