### PR TITLE
dea_prescriber_filter: make pharmacy/prescriber state validation configurable

### DIFF
--- a/extensions/dea_prescriber_filter/CANVAS_MANIFEST.json
+++ b/extensions/dea_prescriber_filter/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.94.0",
-    "plugin_version": "0.3.0",
+    "plugin_version": "0.4.0",
     "name": "dea_prescriber_filter",
     "description": "Filters prescribe actions based on NPI matching between user and selected prescriber",
     "license": "MIT",
@@ -57,7 +57,7 @@
             }
         ]
     },
-    "secrets": ["ADMIN_STAFF_IDS"],
+    "secrets": ["ADMIN_STAFF_IDS", "STATE_VALIDATION_ENFORCE"],
     "tags": {},
     "references": [],
     "diagram": false,

--- a/extensions/dea_prescriber_filter/README.md
+++ b/extensions/dea_prescriber_filter/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-The DEA Prescriber Filter plugin controls who can sign prescriptions for which providers in Canvas. It prevents staff from signing prescriptions on behalf of providers they are not authorized for, and blocks prescriptions being sent to pharmacies in states the prescriber is not licensed in.
+The DEA Prescriber Filter plugin controls who can sign prescriptions for which providers in Canvas. It prevents staff from signing prescriptions on behalf of providers they are not authorized for. By default, it also blocks prescriptions being sent to pharmacies in states the prescriber is not licensed in — this state-block can be disabled via the `STATE_VALIDATION_ENFORCE` secret (see [Configuration options](#configuration-options)).
 
 An admin UI called **Prescriber Assist** lets administrators explicitly authorize delegation relationships — for example, granting a clinical assistant the right to sign on behalf of a specific prescriber.
 
@@ -66,6 +66,20 @@ ADMIN_STAFF_IDS=57f3668ea9f84f3980e772ea8451af38,a1b2c3d4e5f6...
 
 Configure this in the Canvas admin panel: **Plugins → dea_prescriber_filter → Secrets**.
 
+### `STATE_VALIDATION_ENFORCE` (optional plugin secret)
+
+Controls whether the plugin blocks prescriptions when the prescriber's license state doesn't match the pharmacy's state. Dropdown state annotations are independent of this setting and always show.
+
+**Accepted values:**
+- `true` / `1` / `yes` — block on state mismatch with a validation error on review
+- `false` / `0` / `no` — skip the blocking check; the dropdown still shows each prescriber's license state so reviewers can catch mismatches visually
+
+**Default behavior** — when the secret is unset, empty, or set to an unrecognized value, the plugin enforces state validation. This preserves 0.3.0 behavior for any installation upgrading to 0.4.0 without configuration changes.
+
+Parsing is case- and whitespace-insensitive (`" True "` is accepted).
+
+Configure this in the Canvas admin panel: **Plugins → dea_prescriber_filter → Secrets**.
+
 ## Screenshots
 
 ![Prescriber Assist admin UI](assets/admin-ui-screenshot.png)
@@ -80,8 +94,10 @@ The Prescriber Assist admin UI: administrators select a provider and a set of st
 - **Sign button hiding** — when the current user is not authorized for the selected prescriber, sign/send/print actions are removed from the command, preventing the commit
 - **Validation error** — when review is clicked without authorization, the user sees "Not authorized to prescribe for this provider."
 
-### State license validation
-- On review, checks that the selected prescriber profile's license state matches the pharmacy's state
+### State license validation (configurable)
+- Controlled by the `STATE_VALIDATION_ENFORCE` plugin secret (see [Configuration options](#configuration-options)). Default: enforce.
+- **When enforced** — on review, checks that the selected prescriber profile's license state matches the pharmacy's state; blocks signing on mismatch
+- **When not enforced** — no blocking check; dropdown annotations still show each provider's license state so reviewers can spot mismatches visually
 - The check scopes to the specific selected profile (e.g. "Dr Brown (AK)"), not all NPI-linked profiles — so picking the wrong profile for a cross-state prescription is caught
 - Pharmacy state is looked up live via the Canvas pharmacy service (NCPDP)
 
@@ -151,8 +167,9 @@ POST_VALIDATION fires
       │
       ├─ Reads the cached user key
       ├─ If present and user is unauthorized → shows "Not authorized" error
-      ├─ Checks the selected prescriber profile's license states
-      └─ If pharmacy state not in license states → shows state-mismatch error
+      └─ If STATE_VALIDATION_ENFORCE is true (the default):
+           ├─ Checks the selected prescriber profile's license states
+           └─ If pharmacy state not in license states → shows state-mismatch error
 ```
 
 The action filter is the primary safety gate: it always runs with the *current* user context (not a cached decision), so user-switching does not leak authorization.

--- a/extensions/dea_prescriber_filter/protocols/prescriber_filter.py
+++ b/extensions/dea_prescriber_filter/protocols/prescriber_filter.py
@@ -402,8 +402,12 @@ class AdjustPrescriptionActionFilter(PrescribeActionFilter):
 
 class PrescribeValidation(BaseProtocol):
     """
-    Validates user authorization (via cached user key) and that the prescriber's
-    license state matches the pharmacy's state.
+    Validates user authorization (via cached user key). Optionally also blocks
+    when the selected prescriber's license state does not match the pharmacy's
+    state — controlled by the STATE_VALIDATION_ENFORCE plugin secret
+    (default: enforce, for backward compatibility with 0.3.0).
+
+    Dropdown state annotations are independent of this setting and always show.
     """
 
     RESPONDS_TO = [
@@ -441,11 +445,27 @@ class PrescribeValidation(BaseProtocol):
                 "skipping auth error message. Action filter still blocks signing."
             )
 
-        state_error = self._check_pharmacy_state(prescriber_key)
-        if state_error:
-            effect.add_error(state_error)
+        if self._state_validation_enforced():
+            state_error = self._check_pharmacy_state(prescriber_key)
+            if state_error:
+                effect.add_error(state_error)
 
         return [effect.apply()]
+
+    def _state_validation_enforced(self) -> bool:
+        """Whether to block on pharmacy/prescriber state mismatch.
+
+        Reads the STATE_VALIDATION_ENFORCE plugin secret. Accepts
+        true/1/yes (enforce) and false/0/no (don't enforce), case- and
+        whitespace-insensitive. Anything else — including unset — defaults
+        to True to preserve 0.3.0 behavior on upgrade.
+        """
+        raw = (self.secrets.get("STATE_VALIDATION_ENFORCE", "") or "").strip().lower()
+        if raw in ("true", "1", "yes"):
+            return True
+        if raw in ("false", "0", "no"):
+            return False
+        return True
 
     def _get_prescriber_key(self) -> str | None:
         """Get prescriber key from the Command object (same approach as action filter)."""
@@ -529,12 +549,12 @@ class PrescribeValidation(BaseProtocol):
 
 
 class RefillValidation(PrescribeValidation):
-    """Authorization + state validation for refill commands."""
+    """Authorization + optional state validation for refill commands."""
     RESPONDS_TO = [EventType.Name(EventType.REFILL_COMMAND__POST_VALIDATION)]
 
 
 class AdjustPrescriptionValidation(PrescribeValidation):
-    """Authorization + state validation for adjust prescription commands."""
+    """Authorization + optional state validation for adjust prescription commands."""
     RESPONDS_TO = [EventType.Name(EventType.ADJUST_PRESCRIPTION_COMMAND__POST_VALIDATION)]
 
 


### PR DESCRIPTION
## Summary
- Adds a `STATE_VALIDATION_ENFORCE` plugin secret that controls whether the plugin blocks prescriptions when the selected prescriber's license state doesn't match the pharmacy's state.
- When set to `false` / `0` / `no` (case-insensitive), the blocking validation is skipped. Dropdown state annotations remain so reviewers can still spot mismatches visually.
- Defaults to enforce, so any 0.3.0 installation that upgrades without changing configuration sees no behavior change. Bumps `plugin_version` to `0.4.0`.

## Test plan
- [x] Installed against a Canvas dev instance via `canvas install`; upgrade-in-place from 0.3.0 succeeds
- [x] Default behavior (secret unset): prescribing with a prescriber licensed in one state and a pharmacy in another still produces the existing `"Prescriber state (X) does not match pharmacy state (Y)."` blocking error
- [x] Don't-enforce behavior (secret set to `false`): same flow no longer produces the state-mismatch error; dropdown still annotates each prescriber with their license state
- [x] Auth regression check: non-prescriber staff still sees `"Not authorized to prescribe for this provider."` and sign actions are hidden, regardless of the new secret's value

🤖 Generated with [Claude Code](https://claude.com/claude-code)