### PR TITLE
Ignore .claude/settings.local.json to prevent accidental commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ cython_debug/
 
 # Canvas plugin workflow artifacts
 .cpa-workflow-artifacts/
+
+# Claude Code local settings (may be created in any plugin subdirectory)
+.claude/settings.local.json
+**/.claude/settings.local.json


### PR DESCRIPTION
## Summary

A recent PR accidentally checked in a `.claude/settings.local.json` (Claude Code per-developer local settings) inside a plugin subdirectory. This adds gitignore patterns so those files are ignored wherever they appear in the tree.

## Changes

- Added `.claude/settings.local.json` and `**/.claude/settings.local.json` to `.gitignore`, covering both the repo root and any plugin subdirectory.

Note: only the local settings file is ignored — a shared, intentionally-committed `.claude/settings.json` is unaffected.