### PR TITLE
Scope availability Rooms dropdown to chosen location

### DIFF
--- a/extensions/scheduling-with-rooms/scheduling_with_rooms/api/events.py
+++ b/extensions/scheduling-with-rooms/scheduling_with_rooms/api/events.py
@@ -191,6 +191,7 @@ class CalendarEventsAPI(StaffSessionAuthMixin, SimpleAPIRoute):
         providers = list(
             Staff.objects
             .filter(active=True, roles__internal_code__in=role_codes)
+            .select_related("primary_practice_location")
             .distinct()
         )
         locations = list(PracticeLocation.objects.filter(active=True))

--- a/extensions/scheduling-with-rooms/scheduling_with_rooms/handlers/availability_web_app.py
+++ b/extensions/scheduling-with-rooms/scheduling_with_rooms/handlers/availability_web_app.py
@@ -62,6 +62,7 @@ class AvailabilityWebApp(StaffSessionAuthMixin, SimpleAPI):
         providers = (
             Staff.objects
             .filter(active=True, roles__internal_code__in=role_codes)
+            .select_related("primary_practice_location")
             .distinct()
         )
         room_ids = set(
@@ -101,6 +102,16 @@ class AvailabilityWebApp(StaffSessionAuthMixin, SimpleAPI):
                     "name": provider.credentialed_name,
                     "full_name": provider.full_name,
                     "is_room": provider.id in room_ids,
+                    # For rooms, this drives the location-aware Rooms dropdown:
+                    # the UI only offers a room when its staff profile's
+                    # primary_practice_location matches the chosen location.
+                    # Use the location's UUID `id` (not the integer FK dbid) so
+                    # it matches the location ids the dropdown is built from.
+                    "primary_practice_location": (
+                        str(provider.primary_practice_location.id)
+                        if provider.primary_practice_location
+                        else None
+                    ),
                 }
                 for provider in providers
             ]),

--- a/extensions/scheduling-with-rooms/scheduling_with_rooms/static/availability/main.js
+++ b/extensions/scheduling-with-rooms/scheduling_with_rooms/static/availability/main.js
@@ -147,6 +147,13 @@
         const l = state.locations.find(l => String(l.id) === String(id));
         return l ? l.name : '';
     }
+    // A room is offered only when its staff profile's primary_practice_location
+    // matches the chosen location. With no specific location chosen ("All
+    // locations"), every room is offered.
+    function roomMatchesLocation(room) {
+        if (!state.locationId) return true;
+        return String(room.primary_practice_location) === String(state.locationId);
+    }
     function noteTypeName(id) {
         const key = String(id);
         // window.noteTypeNames is the full id→name map (includes inactive /
@@ -366,7 +373,10 @@
         // dropdown so the user can filter independently.
         const allStaff = state.providers;
         const onlyProviders = allStaff.filter(p => !p.is_room);
-        const onlyRooms = allStaff.filter(p => p.is_room);
+        // Rooms are scoped to the chosen location: only offer a room when its
+        // staff profile's primary_practice_location matches state.locationId.
+        // With no specific location chosen ("All locations"), show every room.
+        const onlyRooms = allStaff.filter(p => p.is_room && roomMatchesLocation(p));
 
         const popoverFor = (group, label) => {
             if (state.openFilter !== label) return null;
@@ -1053,7 +1063,12 @@
             }, p.full_name || p.name);
         });
         const providerChips = makeChips(state.providers.filter(p => !p.is_room));
-        const roomChips = makeChips(state.providers.filter(p => p.is_room));
+        // Offer rooms whose primary_practice_location matches the chosen
+        // location, plus any room already selected on this event so an existing
+        // (possibly off-location) assignment stays visible and deselectable.
+        const roomChips = makeChips(state.providers.filter(p =>
+            p.is_room && (roomMatchesLocation(p) || f.providers.includes(String(p.id)))
+        ));
 
         const noteTypeChips = state.noteTypes.map(nt => {
             const id = String(nt.id);

--- a/extensions/scheduling-with-rooms/tests/api/test_events.py
+++ b/extensions/scheduling-with-rooms/tests/api/test_events.py
@@ -270,7 +270,7 @@ def test_get_no_tz_param():
         "scheduling_with_rooms.api.events._serialize_event",
         return_value={"id": "ev-1"},
     ):
-        mock_staff.objects.filter.return_value.distinct.return_value = []
+        mock_staff.objects.filter.return_value.select_related.return_value.distinct.return_value = []
         mock_loc.objects.filter.return_value = []
         mock_em.objects.all.return_value.select_related.return_value.prefetch_related.return_value = [MagicMock()]
         result = h.get()
@@ -289,7 +289,7 @@ def test_get_invalid_tz_falls_back():
         "scheduling_with_rooms.api.events._serialize_event",
         return_value={"id": "ev-1"},
     ):
-        mock_staff.objects.filter.return_value.distinct.return_value = []
+        mock_staff.objects.filter.return_value.select_related.return_value.distinct.return_value = []
         mock_loc.objects.filter.return_value = []
         mock_em.objects.all.return_value.select_related.return_value.prefetch_related.return_value = []
         result = h.get()
@@ -308,7 +308,7 @@ def test_get_with_valid_tz():
         "scheduling_with_rooms.api.events._serialize_event",
         return_value={"id": "ev-1"},
     ):
-        mock_staff.objects.filter.return_value.distinct.return_value = []
+        mock_staff.objects.filter.return_value.select_related.return_value.distinct.return_value = []
         mock_loc.objects.filter.return_value = []
         mock_em.objects.all.return_value.select_related.return_value.prefetch_related.return_value = []
         result = h.get()

--- a/extensions/scheduling-with-rooms/tests/handlers/test_availability_web_app.py
+++ b/extensions/scheduling-with-rooms/tests/handlers/test_availability_web_app.py
@@ -78,7 +78,7 @@ def test_index_returns_html_response():
         # Two filter chains with .distinct()
         providers_qs = MagicMock()
         providers_qs.__iter__ = lambda self: iter([provider])
-        mock_staff.objects.filter.return_value.distinct.return_value = providers_qs
+        mock_staff.objects.filter.return_value.select_related.return_value.distinct.return_value = providers_qs
         mock_staff.objects.filter.return_value.values_list.return_value = ["prov-1"]
         mock_loc.objects.filter.return_value = [location]
         # Two NoteType.objects calls: filter() and all().
@@ -88,6 +88,116 @@ def test_index_returns_html_response():
 
         result = h.index()
         assert len(result) == 1
+
+
+def test_index_serializes_room_primary_practice_location():
+    """Each room entry carries its primary_practice_location id so the UI can
+    scope the Rooms dropdown to the chosen location."""
+    import json
+
+    h = _handler(request_headers={"canvas-logged-in-user-id": "user-1"})
+
+    room = MagicMock()
+    room.id = "room-1"
+    room.credentialed_name = "Room A"
+    room.full_name = "Room A"
+    room.primary_practice_location.id = "loc-1"
+
+    location = MagicMock()
+    location.id = "loc-1"
+    location.full_name = "Loc"
+
+    captured = {}
+
+    def fake_render(template, context=None):
+        captured["context"] = context
+        return "<html>"
+
+    with patch(
+        "scheduling_with_rooms.handlers.availability_web_app.Staff"
+    ) as mock_staff, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.PracticeLocation"
+    ) as mock_loc, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.NoteType"
+    ) as mock_nt, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.Event"
+    ) as mock_event_cls, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.render_to_string",
+        side_effect=fake_render,
+    ), patch(
+        "scheduling_with_rooms.handlers.availability_web_app._serialize_event",
+        return_value={"id": "ev-1"},
+    ):
+        providers_qs = MagicMock()
+        providers_qs.__iter__ = lambda self: iter([room])
+        mock_staff.objects.filter.return_value.select_related.return_value.distinct.return_value = providers_qs
+        mock_staff.objects.filter.return_value.values_list.return_value = ["room-1"]
+        mock_loc.objects.filter.return_value = [location]
+        mock_nt.objects.filter.return_value = []
+        mock_nt.objects.all.return_value = []
+        mock_event_cls.objects.all.return_value.select_related.return_value.prefetch_related.return_value = []
+
+        h.index()
+
+    providers = json.loads(captured["context"]["providers"])
+    assert providers == [
+        {
+            "id": "room-1",
+            "name": "Room A",
+            "full_name": "Room A",
+            "is_room": True,
+            "primary_practice_location": "loc-1",
+        }
+    ]
+
+
+def test_index_serializes_null_primary_practice_location():
+    """A staff profile with no primary_practice_location serializes to None."""
+    import json
+
+    h = _handler(request_headers={"canvas-logged-in-user-id": "user-1"})
+
+    provider = MagicMock()
+    provider.id = "prov-1"
+    provider.credentialed_name = "Bob, MD"
+    provider.full_name = "Bob Smith"
+    provider.primary_practice_location = None
+
+    captured = {}
+
+    def fake_render(template, context=None):
+        captured["context"] = context
+        return "<html>"
+
+    with patch(
+        "scheduling_with_rooms.handlers.availability_web_app.Staff"
+    ) as mock_staff, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.PracticeLocation"
+    ) as mock_loc, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.NoteType"
+    ) as mock_nt, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.Event"
+    ) as mock_event_cls, patch(
+        "scheduling_with_rooms.handlers.availability_web_app.render_to_string",
+        side_effect=fake_render,
+    ), patch(
+        "scheduling_with_rooms.handlers.availability_web_app._serialize_event",
+        return_value={"id": "ev-1"},
+    ):
+        providers_qs = MagicMock()
+        providers_qs.__iter__ = lambda self: iter([provider])
+        mock_staff.objects.filter.return_value.select_related.return_value.distinct.return_value = providers_qs
+        mock_staff.objects.filter.return_value.values_list.return_value = []
+        mock_loc.objects.filter.return_value = []
+        mock_nt.objects.filter.return_value = []
+        mock_nt.objects.all.return_value = []
+        mock_event_cls.objects.all.return_value.select_related.return_value.prefetch_related.return_value = []
+
+        h.index()
+
+    providers = json.loads(captured["context"]["providers"])
+    assert providers[0]["primary_practice_location"] is None
+    assert providers[0]["is_room"] is False
 
 
 def test_get_main_js_returns_response():


### PR DESCRIPTION
## What

In the **Availability Manager**, the Rooms dropdown now only offers rooms whose associated staff profile's `primary_practice_location` matches the selected location. This applies to both:

- the toolbar **Rooms** filter, and
- the **Rooms** chips in the create/edit availability form.

With **"All locations"** selected, every room is shown. The create/edit form additionally keeps any already-assigned room visible (even if off-location) so an existing selection can still be seen and deselected.

## The bug it fixes

A first pass serialized the room's location from `provider.primary_practice_location_id`. But the base data `Model` uses an integer `dbid` as its primary key, while `PracticeLocation.id` is a separate UUID — and the location dropdown is keyed on that UUID. Comparing the integer dbid to the UUID matched nothing, so **no rooms appeared** under any specific location.

The handler now uses `select_related("primary_practice_location")` and serializes `primary_practice_location.id` (the UUID), so the comparison lines up.

## Bonus: N+1 fix

Added the same `select_related("primary_practice_location")` to the providers query in `api/events.py`. `_serialize_event` resolves an event's location from the matched provider's `primary_practice_location` on a fallback branch — without the eager load this fired one extra query per event on location-less calendars.

## Testing

- `pytest` — all 315 tests pass, including new coverage for the room serialization (UUID present / `None` when unset).
- Manual: open the Availability Manager, select a location, and confirm only rooms whose practice location matches appear in both the Rooms filter and the create form; "All locations" shows every room; event rendering/location filtering/timezone display unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)