### PR TITLE
Move chart-command-search README into the plugin package

### DIFF
--- a/extensions/chart-command-search/chart_command_search/README.md
+++ b/extensions/chart-command-search/chart_command_search/README.md
@@ -19,10 +19,10 @@ Patient charts grow large quickly. Finding a specific lab result, a past medicat
 
 ## Screenshots
 
-![Keyword search](chart_command_search/screenshots/keyword-search.png)
-![Keyword search filters](chart_command_search/screenshots/keyword-search-filters.png)
-![AI search home screen](chart_command_search/screenshots/ai-search-home-screen.png)
-![AI search with citations](chart_command_search/screenshots/ai-search-with-supporting-entries.png)
+![Keyword search](screenshots/keyword-search.png)
+![Keyword search filters](screenshots/keyword-search-filters.png)
+![AI search home screen](screenshots/ai-search-home-screen.png)
+![AI search with citations](screenshots/ai-search-with-supporting-entries.png)
 
 ## What it does
 


### PR DESCRIPTION
## What

Moves `README.md` from the plugin root into the `chart_command_search/` package, so it sits next to `CANVAS_MANIFEST.json` — matching the layout used by other extensions (e.g. `provider_availability/provider_availability/README.md`).

## Details

- `git mv extensions/chart-command-search/README.md extensions/chart-command-search/chart_command_search/README.md` (rename preserves history).
- Updated the four screenshot image links from `chart_command_search/screenshots/…` to `screenshots/…` so they still resolve from the README's new location (screenshots remain at `chart_command_search/screenshots/`).
- `pyproject.toml` has no `readme` field, so nothing else references the old path.

Follow-up to #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)