### PR TITLE
Improve READMEs for five extensions

### DIFF
--- a/extensions/appointment_rooming_status_banner/README.md
+++ b/extensions/appointment_rooming_status_banner/README.md
@@ -1,8 +1,37 @@
-Appointment Rooming Status Banner
-=================================
+# Appointment Rooming Status Banner
 
-## Description
+## What it does
 
-When an appointment is marked as Arrived or Roomed, add a banner alert to the
-patient's chart indicating as such. Nightly, remove all of these to clean up
-for the next day.
+When an appointment is updated to **Arrived** or **Roomed**, the plugin adds a banner alert to the patient's chart timeline:
+
+- Arrived -> "`{First name}` has arrived."
+- Roomed -> "`{First name}` has been roomed."
+
+If the appointment moves to any other status, the matching banner is removed. A nightly cron task runs at midnight (`0 0 * * *`, instance time) and clears any rooming-status banners still open, so every chart starts the next day clean.
+
+## Problem it solves
+
+Front-desk and clinical staff need an at-a-glance signal of where a patient is in the visit - checked in versus already in a room - without opening the schedule or messaging back and forth. This surfaces that status directly on the chart and removes it automatically, so stale banners do not pile up.
+
+## Who it's for
+
+In-person clinics that want a visible arrival and rooming indicator on the patient chart: front desk, medical assistants, and providers coordinating live visits.
+
+## How to install
+
+1. Download or clone this plugin directory.
+2. From the directory that contains the plugin, install it against your instance:
+   ```
+   canvas install appointment_rooming_status_banner
+   ```
+3. Confirm it is enabled under **Settings > Plugins** in your instance.
+
+See the [Canvas plugin documentation](https://docs.canvasmedical.com/sdk/plugins-overview/) for CLI setup and authentication.
+
+## Configuration options
+
+None. The plugin has no secrets or settings. The banner placement (chart timeline), banner intent (info), and the nightly cleanup schedule (`00:00`) are fixed in code.
+
+## Screenshots or screen recordings
+
+_Screenshots pending. The banner appears at the top of the patient chart timeline when an appointment is marked Arrived or Roomed._

--- a/extensions/default_pharmacy/README.md
+++ b/extensions/default_pharmacy/README.md
@@ -1,18 +1,42 @@
 # Default Pharmacy
-================
 
-## Description
+## What it does
 
-Streamline prescribing by automatically updating a patient's default preferred pharmacy directly from the `Prescribe`, `Refill`, and `Adjust Prescription` commands.
+Keeps a patient's default preferred pharmacy in sync with prescribing. The plugin listens to the `Prescribe`, `Refill`, and `Adjust Prescription` commands. When one of those commands is committed, the pharmacy selected in the command is saved as the patient's default preferred pharmacy on their profile.
 
-**How it works:**
-1. When a patient has a [default preferred pharmacy set](https://canvas-medical.help.usepylon.com/articles/8802451810-patient-demographics#preferred-pharmacies-18), this pharmacy will pre-populated in prescribing workflows.
-2. If a provider changes the pharmacy for one of the prescribing workflows, the new pharmacy will automatically be saved as the default preferred pharmacy to the patient profile.
-3. The next time a provider prescribes for the patient, the new pharmacy will pre-propulate.
+How it works:
 
-By automatically updating the default preferred pharmacy directly in the Prescribe/Refill/Adjust command, users will no longer need to update this value in the patient profile.
+1. When a patient has a [default preferred pharmacy set](https://docs.canvasmedical.com/), it pre-populates in the prescribing workflows.
+2. If a provider changes the pharmacy on a `Prescribe`, `Refill`, or `Adjust Prescription` command, that new pharmacy is automatically saved as the patient's default preferred pharmacy.
+3. The next time anyone prescribes for the patient, the updated pharmacy pre-populates.
 
+## Problem it solves
 
-### Important Note
+Without this plugin, changing a patient's pharmacy at the point of prescribing does not update their profile, so the next prescription defaults back to the old pharmacy. Staff have to remember to edit the profile separately. This removes that extra step by capturing the change directly from the command the provider already used.
 
-The `prescribe`, `refill` and `adjustPrescription` command switches must be on for this protocol.
+## Who it's for
+
+Any practice that prescribes through Canvas and wants the patient's preferred pharmacy to stay current automatically, without a separate profile edit. Useful for high-volume prescribing teams where pharmacy changes are common.
+
+## How to install
+
+1. Download or clone this plugin directory.
+2. From the directory that contains the plugin, install it against your instance:
+   ```
+   canvas install default_pharmacy
+   ```
+3. Confirm it is enabled under **Settings > Plugins** in your instance.
+
+See the [Canvas plugin documentation](https://docs.canvasmedical.com/sdk/plugins-overview/) for CLI setup and authentication.
+
+## Configuration options
+
+No plugin settings. The behavior is automatic once installed.
+
+Requirements:
+
+- The `prescribe`, `refill`, and `adjustPrescription` command switches must be enabled on the instance for the plugin to fire.
+
+## Screenshots or screen recordings
+
+_Screenshots pending. The default preferred pharmacy on the patient profile updates after a Prescribe, Refill, or Adjust Prescription command is committed with a different pharmacy._

--- a/extensions/delete-staged-commands-button/README.md
+++ b/extensions/delete-staged-commands-button/README.md
@@ -1,0 +1,36 @@
+# Delete Staged Commands Button
+
+## What it does
+
+Adds a **Delete All Staged Commands** button to the note header. One click removes every staged (uncommitted) command in the current note. Committed commands are never touched. The button supports 38+ command types - diagnoses, prescriptions, orders, assessments, history, vitals, and more.
+
+## Problem it solves
+
+Clearing a note of staged commands one at a time is tedious, especially when a clinician wants to start fresh or has left several drafts behind. This removes them all at once, while leaving anything already committed safely in place.
+
+## Who it's for
+
+Clinicians and documentation staff who build notes with staged commands and want a fast way to discard the uncommitted ones without deleting them individually.
+
+## How to install
+
+1. Download or clone this plugin directory.
+2. From the directory that contains the plugin, install it against your instance:
+   ```
+   canvas install delete_staged_commands_button
+   ```
+3. Confirm it is enabled under **Settings > Plugins** in your instance.
+
+See the [Canvas plugin documentation](https://docs.canvasmedical.com/sdk/plugins-overview/) for CLI setup and authentication.
+
+## Configuration options
+
+None. The button is always visible in the note header once installed and acts only on commands in the `staged` state for the current note. There are no secrets or settings.
+
+## Screenshots or screen recordings
+
+_Screenshots pending. The "Delete All Staged Commands" button appears in the note header; clicking it removes all staged commands from the open note._
+
+---
+
+For full technical detail (supported command types, architecture, tests, and how to extend the plugin), see the [package README](./delete_staged_commands_button/README.md).

--- a/extensions/delete-staged-commands-button/delete_staged_commands_button/CANVAS_MANIFEST.json
+++ b/extensions/delete-staged-commands-button/delete_staged_commands_button/CANVAS_MANIFEST.json
@@ -2,7 +2,7 @@
     "sdk_version": "0.1.4",
     "plugin_version": "0.0.1",
     "name": "delete_staged_commands_button",
-    "description": "Adds a button to carry forward commands from the previous note to the current note",
+    "description": "Adds a note header button that deletes all staged (uncommitted) commands in the current note.",
     "components": {
         "protocols": [
             {

--- a/extensions/delete-staged-commands-button/delete_staged_commands_button/README.md
+++ b/extensions/delete-staged-commands-button/delete_staged_commands_button/README.md
@@ -1,13 +1,39 @@
 # Delete Staged Commands Button Plugin
 
-## Overview
+## What it does
 
-The Delete Staged Commands Button plugin adds a convenient action button to the Canvas note header that allows users to quickly remove all staged (uncommitted) commands from the current note with a single click.
+Adds a **Delete All Staged Commands** action button to the Canvas note header. One click removes every staged (uncommitted) command in the current note with a single action. Committed commands are never affected. The plugin handles 38+ command types - diagnoses, prescriptions, orders, assessments, history, vitals, and more.
 
-This plugin is useful when:
+## Problem it solves
+
+Removing staged commands one at a time is slow, especially when a clinician wants to start fresh or has left several drafts in a note. This clears them all at once while leaving anything already committed in place. It is useful when:
+
 - A clinician wants to start fresh with their note documentation
-- Staged commands need to be cleared after all needed commands are committed
+- Staged commands need to be cleared after the needed commands are committed
 - Multiple staged commands need to be removed at once instead of individually
+
+## Who it's for
+
+Clinicians and documentation staff who build notes with staged commands and want a fast way to discard the uncommitted ones.
+
+## How to install
+
+1. Download or clone this plugin directory.
+2. From the directory that contains the plugin, install it against your instance:
+   ```
+   canvas install delete_staged_commands_button
+   ```
+3. Confirm it is enabled under **Settings > Plugins** in your instance.
+
+See the [Canvas plugin documentation](https://docs.canvasmedical.com/sdk/plugins-overview/) for CLI setup and authentication.
+
+## Configuration options
+
+None. The button is always visible in the note header once installed and acts only on commands in the `staged` state for the current note. There are no secrets or settings.
+
+## Screenshots or screen recordings
+
+_Screenshots pending. The "Delete All Staged Commands" button appears in the note header; clicking it removes all staged commands from the open note._
 
 ## Features
 

--- a/extensions/delete-staged-commands-button/pyproject.toml
+++ b/extensions/delete-staged-commands-button/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "carry_forward"
+name = "delete_staged_commands_button"
 version = "0.0.1"
-description = "Canvas plugin to carry forward commands from previous notes"
+description = "Canvas plugin that adds a note header button to delete all staged commands in a note"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -10,7 +10,7 @@ python_functions = ["test_*"]
 addopts = "-v"
 
 [tool.coverage.run]
-source = ["carry_forward"]
+source = ["delete_staged_commands_button"]
 omit = ["tests/*", "*/tests/*", "*/__pycache__/*"]
 
 [tool.coverage.report]

--- a/extensions/phq9_followup/README.md
+++ b/extensions/phq9_followup/README.md
@@ -1,6 +1,39 @@
-Automated PHQ-9 Followup
-=============
+# Automated PHQ-9 Follow-up
 
-If a PHQ-2 is recorded with a score greater than 2, originate a PHQ-9 command
-in the same note, pulling forward the responses to the common questions.
+## What it does
 
+Automates the PHQ-2 to PHQ-9 escalation. When a PHQ-2 questionnaire (LOINC `58120-7`) is committed with a score greater than 2, the plugin originates a PHQ-9 questionnaire command (LOINC `44249-1`) in the same note and pulls forward the answers to the questions the two instruments share, so the clinician only fills in what is new.
+
+## Problem it solves
+
+A positive PHQ-2 should trigger a PHQ-9, but adding and partially re-answering the longer instrument by hand is slow and easy to skip. This makes the escalation happen automatically and carries over the overlapping responses, reducing clicks and missed follow-ups for depression screening.
+
+## Who it's for
+
+Primary care and behavioral health teams that screen for depression with the PHQ-2 / PHQ-9 stepped approach and want the follow-up assessment created for them at the point of care.
+
+## How to install
+
+1. Download or clone this plugin directory.
+2. From the directory that contains the plugin, install it against your instance:
+   ```
+   canvas install phq9_followup
+   ```
+3. Confirm it is enabled under **Settings > Plugins** in your instance.
+
+See the [Canvas plugin documentation](https://docs.canvasmedical.com/sdk/plugins-overview/) for CLI setup and authentication.
+
+## Configuration options
+
+No plugin settings. The behavior is automatic once installed.
+
+Requirements:
+
+- The `questionnaire` command switch must be enabled on the instance.
+- Both questionnaires must exist on the instance with their standard LOINC codes: PHQ-2 = `58120-7`, PHQ-9 = `44249-1`.
+- The PHQ-9 questionnaire must be configured to originate in charting (`can_originate_in_charting`).
+- The score threshold for escalation (greater than 2) is fixed in code.
+
+## Screenshots or screen recordings
+
+_Screenshots pending. After a PHQ-2 with a score above 2 is committed, a PHQ-9 command appears in the same note with shared answers pre-filled._

--- a/extensions/portal_disable_cancel_appts/CANVAS_MANIFEST.json
+++ b/extensions/portal_disable_cancel_appts/CANVAS_MANIFEST.json
@@ -7,7 +7,7 @@
         "protocols": [
             {
                 "class": "portal_disable_cancel_appts.protocols.my_protocol:Protocol",
-                "description": "A protocol that does xyz...",
+                "description": "Hides the cancel option on patient portal appointment cards so patients cannot cancel their own appointments.",
                 "data_access": {
                     "event": "",
                     "read": [],

--- a/extensions/portal_disable_cancel_appts/README.md
+++ b/extensions/portal_disable_cancel_appts/README.md
@@ -1,8 +1,32 @@
-portal_disable_cancel_appts
-===========================
+# Portal Disable Cancel Appointments
 
-## Description
+## What it does
 
-This plugin will hide the option for patients to cancel their own appointments within the portal.
+Hides the **Cancel** option on appointment cards in the patient portal. The plugin responds to the portal's "can this appointment be canceled?" check and always answers no, so patients cannot cancel their own appointments from the portal.
 
+## Problem it solves
 
+By default the patient portal lets patients cancel upcoming appointments themselves. Some practices need cancellations to go through staff instead - to manage cancellation policies, late-cancel fees, rescheduling, or schedule density. This removes the self-service cancel path without disabling the rest of the portal.
+
+## Who it's for
+
+Practices that want appointment cancellations handled by staff rather than self-served by patients, while keeping the patient portal otherwise fully available.
+
+## How to install
+
+1. Download or clone this plugin directory.
+2. From the directory that contains the plugin, install it against your instance:
+   ```
+   canvas install portal_disable_cancel_appts
+   ```
+3. Confirm it is enabled under **Settings > Plugins** in your instance.
+
+See the [Canvas plugin documentation](https://docs.canvasmedical.com/sdk/plugins-overview/) for CLI setup and authentication.
+
+## Configuration options
+
+None. The plugin disables patient-initiated cancellation for all portal appointments once installed. There are no secrets or settings.
+
+## Screenshots or screen recordings
+
+_Screenshots pending. With the plugin installed, the Cancel action no longer appears on appointment cards in the patient portal._


### PR DESCRIPTION
Documents five extensions consistently and corrects stale metadata found while writing the docs.

## READMEs

Rewrote the README for each plugin to cover the six standard sections - what it does, problem it solves, who it's for, how to install, configuration options, and screenshots - so each plugin clearly states its purpose, audience, and setup:

| Plugin | Change |
|---|---|
| `appointment_rooming_status_banner` | Expanded from a one-line description to the full six sections |
| `default_pharmacy` | Restructured into the six sections; documents the required command switches |
| `delete-staged-commands-button` | Top-level README was empty - added a complete six-section README; restructured the package README to lead with the same sections while keeping its technical reference |
| `phq9_followup` | Expanded to the six sections; documents the required questionnaires, LOINC codes, and command switch |
| `portal_disable_cancel_appts` | Expanded to the six sections |

Screenshots are noted as pending in each README rather than included.

## Metadata corrections

While documenting, two plugins had stale metadata copied from elsewhere:

- **`delete-staged-commands-button`**: the manifest `description` and `pyproject.toml` `name` (`carry_forward`) were copied from an unrelated plugin. Updated the description, the package name, and the coverage source to match this plugin.
- **`portal_disable_cancel_appts`**: replaced the placeholder protocol description (`"A protocol that does xyz..."`) with an accurate one.

No functional code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)