### PR TITLE
docs: add missing README sections across 53 reference plugins

### DIFF
--- a/extensions/abstractive_health/README.md
+++ b/extensions/abstractive_health/README.md
@@ -1,6 +1,10 @@
 # Abstractive Health Plugin
 The Abstractive Health Extension enables your organization to gain deep patient intelligence for your clinicians. You are able to access a patient's complete medical record from the national health information exchanges, see automated AI summaries from those documents, and get quick answers to any clinical questions on the patient chart with streamlined research.
 
+## Problem it solves
+
+A patient's history is often scattered across outside providers and health information exchanges, leaving clinicians to chase records, read long documents, and piece the picture together by hand before a visit. This plugin pulls the patient's records from national exchanges into the chart, generates AI summaries of those documents, and answers clinical questions about them, replacing manual record retrieval and chart review.
+
 ## About Abstractive
 An Abstractive account is required to access the platform. The application flow will prompt you to create one to register for a free trial, after which plans start at $99/month.
 

--- a/extensions/ai-scribe/ai_scribe/README.md
+++ b/extensions/ai-scribe/ai_scribe/README.md
@@ -1,5 +1,26 @@
 # AI Scribe Plugin
 
+## What it does
+
+When an AI medical scribe's transcript is pasted into a note through a Clipboard command, this plugin reads that text, breaks it into structured clinical entries, and turns each one into a Canvas command placed in the note. The clinician gets draft commands to review instead of a wall of text.
+
+## Problem it solves
+
+AI scribes produce a block of narrative text, and someone still has to read it and hand-enter each diagnosis, medication, and plan item as a discrete chart command. That manual transcription is slow and error-prone. This plugin does the parsing and command creation automatically when the transcript lands in the note.
+
+## Who it's for
+
+Prescribers and clinicians who dictate visits through an AI scribe and want the output converted into reviewable Canvas commands rather than copying entries by hand.
+
+## How to install
+
+```
+canvas install ai_scribe
+```
+
+## Configuration options
+
+No configuration required.
 
 ## Description
 

--- a/extensions/assistant/assistant/README.md
+++ b/extensions/assistant/assistant/README.md
@@ -6,6 +6,10 @@ It lives right in Canvas as an **"Assistant"** panel — in a patient chart, pra
 
 <img src="docs/img/chat-patient-chart.png" alt="Assistant panel open in a patient chart: 'Chatting about: Reagan Demo', with answers about active conditions and medications" width="480">
 
+## Problem it solves
+
+Answering a simple clinical question - what meds is this patient on, when was the last A1C, who am I seeing tomorrow - usually means clicking through several chart screens, and prepping for a day of visits means doing that patient by patient. This plugin lets a clinician ask in plain English and gets an answer pulled straight from the chart, including a one-paragraph prep digest per scheduled patient, without leaving Canvas. Write actions stay gated behind explicit approval so it speeds up lookups without taking unsupervised action.
+
 ## What it can do
 
 Ask the kinds of questions you'd otherwise click through several screens to answer:

--- a/extensions/bmi_coding_automation/README.md
+++ b/extensions/bmi_coding_automation/README.md
@@ -8,6 +8,22 @@ For any patient 20 years or older, the BMI Coding Automation extension will auto
 
 If patient has an existing Z68 code, the extension will update existing diagnosis code, making it easy to track progress over time.
 
+## Problem it solves
+
+BMI Z68 codes are easy to forget and tedious to look up by hand, so they often go unrecorded even when the height and weight are already in the chart. This plugin replaces the manual step of calculating BMI and matching it to the correct Z68 code, recording the diagnosis from the vitals already entered.
+
+## Who it's for
+
+Prescribers and clinical staff who document vitals and want BMI Z68 codes recorded consistently for patients 20 and older, and the billing and coding staff who rely on those codes.
+
+## How to install
+
+```
+canvas install bmi_coding_automation
+```
+
+The SDK commands for vitals, updateDiagnosis, and diagnose must be enabled on the instance.
+
 ### Important Note!
 
 The SDK Command needs to be turned for vitals, updateDiagnosis, and diagnose

--- a/extensions/bp_cpt2/README.md
+++ b/extensions/bp_cpt2/README.md
@@ -4,6 +4,14 @@
 
 This AI agent automatically adds appropriate CPT and HCPCS billing codes based on blood pressure measurements recorded in Canvas. It responds to two types of events: when vitals are committed and when notes are locked.
 
+## Problem it solves
+
+CPT-II and HCPCS quality codes for blood pressure are tied to specific systolic and diastolic ranges and to whether a treatment plan was documented, so picking the right code by hand is error-prone and often skipped. This plugin replaces that manual lookup and entry, reading the recorded BP and the note documentation and adding or updating the matching billing codes.
+
+## Who it's for
+
+Prescribers managing hypertension and the billing and coding staff responsible for CPT-II and HCPCS quality reporting, especially practices tracking blood pressure control measures.
+
 ## Functionality
 
 ### Billing Codes

--- a/extensions/bridge/README.md
+++ b/extensions/bridge/README.md
@@ -2,6 +2,27 @@
 
 # Bridge Integration for Telehealth Clinics
 
+## Problem it solves
+
+Clinics running on both Canvas and Bridge would otherwise re-enter each patient in Bridge by hand and toggle between two systems to find the same person's record. This plugin keeps the patient list in sync automatically and adds a banner link from the Canvas chart straight to the matching Bridge record, so staff stop double-entering patients and stop hunting across tools.
+
+## How to install
+
+```
+canvas install bridge
+```
+
+Requires the Bridge connection secrets to be set before it can sync (see Configuration options).
+
+## Configuration options
+
+Set these as plugin secrets after install:
+
+- `BRIDGE_SECRET_API_KEY` - API key for the Bridge account, sent on every request.
+- `BRIDGE_API_BASE_URL` - base URL for the Bridge API. Falls back to the Bridge sandbox when unset.
+- `BRIDGE_UI_BASE_URL` - base URL used to build the patient link shown in the Canvas banner. Falls back to the Bridge sandbox when unset.
+- `CANVAS_BASE_URL` - the instance URL, stored on the Bridge patient record as metadata.
+
 ### Canvas + Bridge
 
 -   The Canvas + Bridge integration extension automatically syncs your patients from Canvas to Bridge whenever a patient is created or updated.

--- a/extensions/capture/capture/README.md
+++ b/extensions/capture/capture/README.md
@@ -9,6 +9,18 @@ three things to add — all auto-associated with the current patient:
 3. **Profile picture** — capture/upload a single image and set it as the patient's avatar
    (`Patient.photo`).
 
+## Problem it solves
+
+Getting a paper form, an exam photo, or a new headshot into the right patient's chart usually means scanning to a separate device, emailing files around, or uploading through a flow that loses the link to the patient. This plugin lets staff photograph or upload right from the chart, assemble multi-page documents into one PDF in the browser, and file them as the correct FHIR record without any external storage step.
+
+## How to install
+
+```
+canvas install capture
+```
+
+Requires the Canvas FHIR API secrets to be set before it can save records (see Secrets).
+
 ## Demo & user guide
 
 📹 **Walkthrough video:** https://www.loom.com/share/a3fb326483464d84992c587b2a849c5e

--- a/extensions/carry-forward/README.md
+++ b/extensions/carry-forward/README.md
@@ -2,6 +2,16 @@
 
 A Canvas plugin that enables efficient clinical documentation by automatically carrying forward commands from previous encounters into new notes.
 
+## How to install
+
+```
+canvas install carry_forward
+```
+
+## Configuration options
+
+No configuration required.
+
 ## Overview
 
 The Carry Forward plugin adds action buttons to the note header that allow clinicians to quickly populate new notes with relevant information from previous encounters. This reduces documentation time and ensures continuity of care by intelligently carrying forward diagnoses, medications, orders, and other clinical data.

--- a/extensions/cash_pay_profile_field/README.md
+++ b/extensions/cash_pay_profile_field/README.md
@@ -23,6 +23,20 @@ nothing. Saved values repaint on reopen because the field is editable.
 Downstream consumers (reports, workflow plugins, integrations) can read the
 value from patient metadata under the `cash_pay_patient` key.
 
+## Problem it solves
+
+Practices that see both insured and self-pay patients have no built-in place on the profile to mark who pays cash, so staff track it in note text, spreadsheets, or memory. That makes it hard to pull the cash-pay population for reporting or to drive different workflows. This plugin gives that status a single structured field on the profile that other plugins and reports can read.
+
+## Who it's for
+
+Front-desk and billing staff who set a patient's payment status, and the practices running mixed insured and self-pay models that need to identify cash-pay patients for reporting or downstream automation.
+
+## How to install
+
+```
+canvas install cash_pay_profile_field
+```
+
 ## Screenshots
 
 The field appears in the **Patient demographics** section of the Profile tab:

--- a/extensions/chart-collision-detector/chart_collision_detector/README.md
+++ b/extensions/chart-collision-detector/chart_collision_detector/README.md
@@ -5,6 +5,12 @@ chart-collision-detector
 
 The Chart Collision Detector is a Canvas application plugin that monitors patient chart access and warns providers when multiple users are simultaneously viewing the same patient's chart. This helps prevent conflicts and confusion that can arise from concurrent chart access and editing.
 
+## How to install
+
+```
+canvas install chart_collision_detector
+```
+
 ## Features
 
 - **Real-time Collision Detection**: Automatically detects when multiple providers are viewing the same patient chart

--- a/extensions/claim_coding_agent/README.md
+++ b/extensions/claim_coding_agent/README.md
@@ -1,5 +1,31 @@
 # Experimental Claim Coding Agent
 
+## What it does
+
+This plugin watches Perform commands in a note and adds billing line items for the encounter as they are entered. It sets the charge (CPT or internal code), links the diagnosis codes already on the note, sets units, and applies modifiers, using LLM inference to inform the coding. It is intended to be chained with Hyperscribe so charges build up alongside the documentation.
+
+## Problem it solves
+
+Coding a claim by hand after a visit is slow and easy to get wrong: someone has to read the note, match charges to the diagnoses, pick units, and add modifiers, often well after the encounter when context has faded. This plugin moves that work into the visit itself, drafting the billing line items as commands are performed so the claim is closer to complete by the time the note is done.
+
+## Who it's for
+
+Billing and coding staff, and the prescribers and clinicians who document encounters in Canvas, at practices that want claim coding drafted in real time rather than reconciled later. It is an experimental example, best suited to teams piloting LLM-assisted coding alongside Hyperscribe.
+
+## How to install
+
+```
+canvas install claim_coding_agent
+```
+
+This plugin requires the `OPENAI_SECRET_KEY` secret to be set before it will function. See Configuration options.
+
+## Configuration options
+
+| Secret | Description |
+|---|---|
+| `OPENAI_SECRET_KEY` | OpenAI API key used for the LLM inference that informs claim coding. Required. |
+
 ## Description
 Uses the new billing line item effects along with LLM inference to manage billing line items for an encounter, intended for chaining with Hyperscribe. It manages:
 - Charges (CPT or internal codes)

--- a/extensions/command-validation/command_validation/README.md
+++ b/extensions/command-validation/command_validation/README.md
@@ -2,6 +2,28 @@
 
 Validates commands before commit to ensure data completeness and quality.
 
+## What it does
+
+This plugin checks certain Canvas commands at commit time and blocks the commit if required data is missing. It will not let a questionnaire be committed while any question is still unanswered, and it will not let a prescription, refill, or prescription adjustment be committed without a days-supply value greater than zero. When a check fails, the staff member sees a clear message explaining what to fix.
+
+## Problem it solves
+
+Incomplete questionnaires and prescriptions with a missing days supply slip through and cause downstream rework: pharmacies reject scripts, reporting gaps appear, and someone has to chase the chart back open to fix it after the fact. This plugin catches the gap at the moment of commit instead of relying on staff to remember every required field or on a later manual audit.
+
+## Who it's for
+
+Prescribers and clinical staff who commit prescriptions, refills, and prescription adjustments, plus anyone who administers questionnaires during a visit. Practice administrators who want consistent, complete documentation also benefit.
+
+## How to install
+
+```
+canvas install command_validation
+```
+
+## Configuration options
+
+No configuration required.
+
 ## Handlers
 
 ### RequireAllQuestionsAnsweredHandler

--- a/extensions/conversational_messaging/README.md
+++ b/extensions/conversational_messaging/README.md
@@ -1,6 +1,10 @@
 Conversational Messaging
 ========================
 
+## Who it's for
+
+Providers, nurses, and front-desk staff who exchange secure messages with patients and want to read and reply to a full thread from inside the patient chart.
+
 ## Description
 
 This plugin adds a "Conversational Messaging" application to Canvas that opens in the right chart pane for the current patient. The experience consolidates inbound and outbound messages so staff can read and respond without leaving the chart.

--- a/extensions/cpt-billing-api/cpt_billing_api/README.md
+++ b/extensions/cpt-billing-api/cpt_billing_api/README.md
@@ -2,6 +2,22 @@
 
 A Canvas Medical plugin that provides a SimpleAPI endpoint for programmatically adding CPT billing line items to clinical notes.
 
+## Problem it solves
+
+Adding billing line items by hand for every note is slow and error-prone, and codes can be entered after they have expired or before they take effect. This plugin lets an external system push billing codes into a note through one authenticated call, validates each CPT code against the ChargeDescriptionMaster for existence and effective/expiration dates, and links the line item to the matching diagnoses automatically. That replaces manual code entry and the separate step of pairing each charge with the right ICD-10 assessment.
+
+## Who it's for
+
+Billing and revenue-cycle teams, and developers building integrations or automation that needs to post charges into Canvas notes. Practices that generate billing codes in an upstream system and want them written back into the EMR are the main audience.
+
+## How to install
+
+```
+canvas install cpt_billing_api
+```
+
+This plugin requires the `simpleapi-api-key` secret to be set before it will function (see Setup).
+
 ## Features
 
 - **SimpleAPI Endpoint**: RESTful API for adding billing codes to notes

--- a/extensions/custom-observation-management/custom_observation_management/README.md
+++ b/extensions/custom-observation-management/custom_observation_management/README.md
@@ -2,6 +2,14 @@
 
 A Canvas plugin for managing and visualizing patient observations with table and graph views.
 
+## Problem it solves
+
+Observations recorded over time are hard to read as a flat list in the chart, and there is no built-in way to load them from an outside source or trend a single measure visually. Staff end up scrolling through entries or rebuilding trends by hand in a spreadsheet. This plugin gives a filterable table and a graph view inside the patient chart, lets observations be created and queried through an API, and can drop a summary command into a note so the reading is documented where it belongs.
+
+## Who it's for
+
+Clinicians and care coordinators who review patient measurements such as vital signs or lab-style observations and want to see them grouped or trended at a glance. Developers integrating an external device or data source that needs to write observations into Canvas also use the API.
+
 ## Video
 
 Here is a video demonstrating this plugin in action: https://www.loom.com/share/a475c3cba69149f2b60851b6f9ec1da8

--- a/extensions/develop_health_ai_prior_auth/README.md
+++ b/extensions/develop_health_ai_prior_auth/README.md
@@ -1,6 +1,34 @@
 develop_health_ai_prior_auth
 ============================
 
+## What it does
+
+This plugin connects Canvas to Develop Health to verify medication benefits and run prior authorizations. It watches for questionnaire command activity and coverage changes in a patient chart and uses the Develop Health service to check what a medication will cost under the patient's plan and to handle the prior authorization paperwork for medications that require approval.
+
+## Problem it solves
+
+Checking a medication's coverage and getting prior authorization is slow manual work: staff call payers, fill out forms, and wait on hold to learn whether a drug is covered and what the patient will owe. This plugin moves that checking and form handling to the Develop Health service so the work happens against the chart instead of over the phone.
+
+## Who it's for
+
+Prescribers and the pharmacy or prior authorization staff who handle medication coverage and approvals for patients.
+
+## How to install
+
+```
+canvas install develop_health_ai_prior_auth
+```
+
+This plugin requires secrets to function. Set the values described under Configuration options before use.
+
+## Configuration options
+
+Set these secrets in the plugin settings:
+
+- `DEVELOP_HEALTH_API_BASE_URL`: base URL of the Develop Health API.
+- `DEVELOP_HEALTH_API_KEY`: API key for authenticating to Develop Health.
+- `DEVELOP_HEALTH_DRUG_LIST`: the drug list that scopes which medications are checked.
+
 ## Description
 
 A description of this plugin

--- a/extensions/encounter_list/README.md
+++ b/extensions/encounter_list/README.md
@@ -1,5 +1,13 @@
 # Encounter List Plugin
 
+## Problem it solves
+
+Finding every open encounter that still needs attention usually means clicking through individual charts and schedules to spot notes that are unsigned, have uncommitted commands, or are stuck in a claim queue. This plugin gathers all in-progress encounters into one filterable worklist, so staff can see what is outstanding across providers and locations without opening each chart.
+
+## Configuration options
+
+No configuration required.
+
 ## Overview
 
 The Encounter List plugin provides a comprehensive worklist view of open encounters. It displays all encounters that are currently in progress (NEW or UNLOCKED state), allowing healthcare providers to efficiently monitor and manage their active patient encounters with advanced filtering and navigation capabilities.

--- a/extensions/extend-lab-intake/README.md
+++ b/extensions/extend-lab-intake/README.md
@@ -2,6 +2,22 @@
 
 Automated lab report intake plugin using Extend AI for document classification and extraction.
 
+## Problem it solves
+
+Lab reports often arrive as faxed or scanned PDFs that staff must read, match to the right patient, transcribe into structured results, and file as a report. This plugin accepts the PDF, classifies and extracts the values automatically, matches the patient from the extracted demographics, and creates a FHIR DiagnosticReport, replacing the manual read-and-retype step.
+
+## Who it's for
+
+Front-desk and intake staff, medical assistants, and care coordinators who process incoming lab documents and file results to the correct patient chart.
+
+## How to install
+
+```
+canvas install extend_lab_intake
+```
+
+This plugin requires several secrets to function (Extend AI, Anthropic, AWS, Canvas FHIR, and the inbound token). See Required Secrets below.
+
 ## Overview
 
 This plugin receives lab report PDFs via HTTP POST, classifies and extracts structured data using Extend AI,

--- a/extensions/external-calendar-busy-blocks/README.md
+++ b/extensions/external-calendar-busy-blocks/README.md
@@ -2,6 +2,18 @@
 
 Subscribe Canvas to a provider's personal calendar (Google Calendar, Outlook, Apple iCloud) via the calendar's secret iCal/ICS URL. Every 15 minutes, the plugin fetches each connected feed and writes the busy times as "Busy" events on the provider's Canvas Admin calendar.
 
+## Problem it solves
+
+Providers who keep personal or external commitments in Google Calendar, Outlook, or Apple iCloud end up double-booked when those times are not reflected in Canvas. Without this plugin, someone has to copy each outside commitment into Canvas by hand and keep the two calendars in sync as plans change. This plugin pulls the busy times in automatically every 15 minutes so the Canvas schedule blocks the right slots, while keeping the personal event details private.
+
+## How to install
+
+```
+canvas install external_calendar_busy_blocks
+```
+
+This plugin declares secrets that must be set before it will function. See the Configuration options below.
+
 ## How it works
 
 Each provider opens the **Calendar Busy Blocks** application from the Canvas global menu, pastes their personal calendar's secret iCal URL, and clicks Save. A scheduled task runs every 15 minutes:

--- a/extensions/growth_charts/README.md
+++ b/extensions/growth_charts/README.md
@@ -1,6 +1,28 @@
 growth_charts
 =============
 
+## What it does
+
+This plugin plots a child's height, weight, head circumference, BMI, and related measurements onto standard pediatric growth charts directly inside the patient chart. It reads the patient's recorded observations and draws their values against WHO and CDC reference curves so staff can see the patient's percentile at a glance. Users can switch between WHO and CDC charts, change the unit of measurement, and print the chart from the modal.
+
+## Problem it solves
+
+Tracking a child's growth against population norms usually means hand-plotting measurements on paper charts or jumping to an outside tool, then re-entering values to read a percentile. This plugin pulls the patient's existing observations and renders the curves in Canvas, removing the manual plotting and lookup.
+
+## Who it's for
+
+Pediatricians, family medicine clinicians, and nursing staff who track growth in children and adolescents during well-child and routine visits.
+
+## How to install
+
+```
+canvas install growth_charts
+```
+
+## Configuration options
+
+No configuration required.
+
 ## Description
 
 This plugin enables you to input observations, such as height, weight, etc., into growth charts provided by WHO and CDC. These charts are designed for children and adolescents and help determine their current percentile, which shows how their measurements compare to others of the same age and sex.

--- a/extensions/hcc_capture/README.md
+++ b/extensions/hcc_capture/README.md
@@ -10,6 +10,14 @@ This Canvas extension facilitates the capture of HCC codes.
 - Annotates condition list items with an HCC tag based on a provided list,
   both in the patient summary and in the claim view.
 
+## Problem it solves
+
+Risk-adjusted HCC codes get missed because clinicians and coders cannot see which conditions carry an HCC while they document and code, and care gaps sit unvalidated until someone audits the chart. The manual workaround is a separate spreadsheet or after-visit review pass to reconcile diagnoses against an HCC reference list. This plugin puts the HCC tags and the open coding gaps directly in the chart, search, and claim so they are acted on during the visit.
+
+## Configuration options
+
+No configuration required.
+
 ## Installation
 
 `canvas install hcc_capture`

--- a/extensions/high-risk-medications/high_risk_medications/README.md
+++ b/extensions/high-risk-medications/high_risk_medications/README.md
@@ -2,6 +2,18 @@
 
 A comprehensive Canvas Medical plugin that helps clinicians identify and monitor high-risk medications through real-time alerts, search annotations, and patient dashboards.
 
+## Problem it solves
+
+High-risk medications such as warfarin, insulin, digoxin, and methotrexate require close monitoring, but a clinician prescribing or refilling them has no built-in cue that the drug carries extra risk. Catching these cases otherwise depends on the prescriber remembering each agent and manually checking the active medication list. This plugin flags high-risk drugs at the point of search, posts a patient banner, and keeps a live list so the risk is visible without anyone tracking it by hand.
+
+## How to install
+
+```
+canvas install high_risk_medications
+```
+
+The `HIGH_RISK_PATTERNS` secret must be set in plugin settings.
+
 ## Overview
 
 This plugin provides multiple integrated features to improve medication safety:

--- a/extensions/lab-order-automated-task/README.md
+++ b/extensions/lab-order-automated-task/README.md
@@ -7,3 +7,9 @@ When ordering labs, staff follow up is often necessary. You may want to alert ph
 This plugin automates the creation of a task based on lab orders. It is a simple implementation that responds to all lab orders using the `LAB_ORDER_COMMAND__POST_COMMIT` event and creates a task titled **Follow up with patient regarding lab order**. The task is assigned to the staff member who committed the command.
 
 The conditions that trigger the task, as well as task attributes (title, assignee, due date) can be updated to fit your specific lab workflows
+
+## How to install
+
+```
+canvas install lab_order_create_task
+```

--- a/extensions/log_note_locks_and_unlocks/README.md
+++ b/extensions/log_note_locks_and_unlocks/README.md
@@ -4,6 +4,28 @@
 
 The `LogNoteLocksAndUnlocks` class is an event handler that logs changes in the state of a note. It listens for `NOTE_STATE_CHANGE_EVENT_CREATED` events and logs messages when a note is locked, unlocked, or transitions to any other state.
 
+## What it does
+
+This plugin watches for changes to a note's state and writes a log line each time one happens. When a note is locked it records that it was locked, when a note is unlocked it records that it was unlocked, and for any other state it records the new state code and the note's ID.
+
+## Problem it solves
+
+Note locking and unlocking activity is normally invisible unless someone checks each chart by hand. This plugin gives a running log of those state changes so the events can be reviewed in plugin logs instead of reconstructed manually from individual notes. It is a reference example for working with note state change events.
+
+## Who it's for
+
+Plugin developers learning how to handle note state change events, and Canvas administrators or compliance staff who want a log trail of when notes are locked and unlocked.
+
+## How to install
+
+```
+canvas install log_note_locks_and_unlocks
+```
+
+## Configuration options
+
+No configuration required.
+
 ## Event Handling
 
 The handler is triggered by the `NOTE_STATE_CHANGE_EVENT_CREATED` event. It inspects the `state` and `note_id` from the event context and logs messages accordingly.

--- a/extensions/nabla/README.md
+++ b/extensions/nabla/README.md
@@ -2,6 +2,13 @@
 
 # Nabla Ambient AI Assistant
 
+## How to install
+
+```
+canvas install nabla
+```
+
+Set the required secrets before use (see Configuration).
 
 ## Description
 

--- a/extensions/note-command-api/note_command_api/README.md
+++ b/extensions/note-command-api/note_command_api/README.md
@@ -8,6 +8,14 @@ SimpleAPI endpoints for creating, retrieving, and managing Canvas notes. This pl
 - A GET endpoint that retrieves note data with enhanced command attributes
 - A POST endpoint that changes note states
 
+## Problem it solves
+
+External systems that need to create notes, read note contents with full command detail, or move a note through its states (lock, sign, push charges, check in, and so on) otherwise have no direct path into Canvas notes and rely on manual work inside the UI. This plugin exposes those operations as authenticated HTTP endpoints so another system can drive note creation, retrieval, and state changes programmatically.
+
+## Who it's for
+
+Developers and integration teams building external systems or automations that need to create Canvas notes, pull note and command data, or change note states without a person working in the chart.
+
 ## Features
 
 - **Create notes** with flexible identifier options (lookup by ID or name)

--- a/extensions/note_template_button/README.md
+++ b/extensions/note_template_button/README.md
@@ -20,6 +20,10 @@ This useful and flexible extension is great starting point for organizations tha
 - Default a Brief ROS instead of blank
 - Default a Brief Physical exam instead of blank
 
+## Configuration options
+
+No configuration required.
+
 ## Installation
 
 `canvas install note_template_button`

--- a/extensions/order_tracking/README.md
+++ b/extensions/order_tracking/README.md
@@ -8,6 +8,10 @@ Orders are removed from the dashboard when a result has been linked. **There is 
 
 ![Order Tracking Plugin](assets/order-tracking.png)
 
+## Problem it solves
+
+Lab orders, imaging orders, and referrals can sit open for days waiting on results, and there is no single place to see everything still outstanding. Staff fall back on memory, spreadsheets, or clicking through individual charts to find what needs follow-up, and orders slip through. This plugin gathers all open orders across the three types into one filterable worklist, removing each order automatically once a result is linked, so follow-up does not depend on manual tracking.
+
 ## Features
 
 - **Multi-Order Type Support**: Tracks lab orders, imaging orders, and referrals

--- a/extensions/pediatric_patient_chart_customizations/README.md
+++ b/extensions/pediatric_patient_chart_customizations/README.md
@@ -7,6 +7,20 @@ chart with the goal of creating a more focused workspace for clinical users.
 Use the context of the patient to surface the right choices more often and
 minimize or eliminate irrelevant options.
 
+## Who it's for
+
+Pediatricians and pediatric clinic staff who chart on patients under 18, and plugin developers who want a worked example of tailoring chart layout and search results to a patient's age.
+
+## How to install
+
+```
+canvas install pediatric_patient_chart_customizations
+```
+
+## Configuration options
+
+No configuration required.
+
 ### Components
 
 1. `protocols/pediatric_chart_layout.py` - Rearranges the patient summary

--- a/extensions/pmp/ne_pdmp/README.md
+++ b/extensions/pmp/ne_pdmp/README.md
@@ -7,3 +7,13 @@ A prescription drug monitoring program (PDMP or PMP) is an electronic database t
 This extension will launch the [Nebraska PDMP](https://secure.cynchealth.org/) in a new window from the Apps menu in the User Action Panel.
 
 Visit [here](https://dhhs.ne.gov/Pages/PDMP-Enhancements.aspx) for more information about the Nebraska PDMP.
+
+## How to install
+
+```bash
+canvas install ne_pdmp
+```
+
+## Configuration options
+
+No configuration required.

--- a/extensions/pmp/ny_pmp/README.md
+++ b/extensions/pmp/ny_pmp/README.md
@@ -1,5 +1,15 @@
 # New York PMP
 
+## How to install
+
+```
+canvas install ny_pmp
+```
+
+## Configuration options
+
+No configuration required.
+
 ## Description
 
 A prescription drug monitoring program (PDMP or PMP) is an electronic database that tracks controlled substance prescriptions. Information from PDMPs can help clinicians identify patients who may be at risk for overdose and provide potentially lifesaving information and interventions. 

--- a/extensions/pmp/wi_pdmp/README.md
+++ b/extensions/pmp/wi_pdmp/README.md
@@ -5,3 +5,13 @@
 A prescription drug monitoring program (PDMP or PMP) is an electronic database that tracks controlled substance prescriptions. Information from PDMPs can help clinicians identify patients who may be at risk for overdose and provide potentially lifesaving information and interventions. 
 
 This extension will launch the [Wisconsin PDMP](https://pdmp.wi.gov/) in a new window from the Apps menu in the User Action Panel.
+
+## How to install
+
+```bash
+canvas install wi_pdmp
+```
+
+## Configuration options
+
+No configuration required.

--- a/extensions/portal-content/portal_content/README.md
+++ b/extensions/portal-content/portal_content/README.md
@@ -2,6 +2,18 @@
 
 Unified patient portal plugin that consolidates educational materials, imaging reports, lab reports, and visit notes into a single configurable plugin.
 
+## Problem it solves
+
+Patients often have to look in several places to find their education handouts, imaging results, lab results, and visit summaries, and a practice typically wires up each of those portal surfaces separately. This plugin brings all four into one portal area with consistent access rules, so patients get a single place to read their own records and the practice configures which content types are turned on from one plugin.
+
+## How to install
+
+```
+canvas install portal_content
+```
+
+This plugin requires the `CLIENT_ID` and `CLIENT_SECRET` secrets for FHIR API access before it will function. See Configuration for the full secret list.
+
 ## Features
 
 - **Educational Materials**: View educational materials shared by providers

--- a/extensions/prapare/README.md
+++ b/extensions/prapare/README.md
@@ -14,6 +14,20 @@ The questionnaire also scores responses. Scores range from 0 to 22, with 0 indic
 
 Learn more by visiting the [PRAPARE website](https://prapare.org/).
 
+## Who it's for
+
+Care teams at community health centers and primary care practices who screen patients for social drivers of health - care coordinators, social workers, and clinicians who administer the PRAPARE assessment and need a score and narrative recorded in the chart.
+
+## How to install
+
+```
+canvas install prapare
+```
+
+## Configuration options
+
+No configuration required.
+
 ### Important Note!
 
 The CANVAS_MANIFEST.json is used when installing your plugin. Please ensure it gets updated if you add, remove, or rename protocols.

--- a/extensions/pre-lock-validation/pre_lock_validation/README.md
+++ b/extensions/pre-lock-validation/pre_lock_validation/README.md
@@ -2,6 +2,28 @@
 
 Validates pre-lock conditions before allowing a note to be locked. This plugin uses the `NOTE_STATE_CHANGE_EVENT_PRE_CREATE` event to intercept note state transitions and enforce business rules.
 
+## What it does
+
+When a user tries to lock a note, this plugin checks the note before the lock goes through. It blocks the lock and shows an error if the note has no committed vitals, or if any commands are still staged (not yet committed). The user has to fix what the message points to before they can lock.
+
+## Problem it solves
+
+Notes get locked with vitals missing or with half-finished commands left in a staged state, and the gaps are only caught later during chart review or coding. Catching those gaps after the fact means reopening the note and chasing down the clinician. This plugin stops the lock at the point of the mistake so the note cannot close with those gaps in it.
+
+## Who it's for
+
+Clinicians and prescribers who lock encounter notes, and the practices that need vitals recorded and all commands committed on every locked note.
+
+## How to install
+
+```
+canvas install pre_lock_validation
+```
+
+## Configuration options
+
+No configuration required.
+
 ## Event Reference
 
 This plugin responds to `NOTE_STATE_CHANGE_EVENT_PRE_CREATE`, which fires before a note state change is created. Returning an `EventValidationError` effect blocks the state change and displays the error to the user.

--- a/extensions/provider-calendaring/provider_scheduling/README.md
+++ b/extensions/provider-calendaring/provider_scheduling/README.md
@@ -2,6 +2,10 @@
 
 A Canvas plugin for managing provider availability calendars and viewing schedule utilization metrics.
 
+## Problem it solves
+
+Defining when each provider is open for appointments, and then judging how well that time gets used, usually means juggling separate calendar setup and pulling booking numbers by hand into a spreadsheet. This plugin keeps both in one place: staff build recurring availability and administrative-time templates, and a dashboard compares available hours against booked appointments so clinics can see unbooked capacity per provider without manual tallying.
+
 ## Applications
 
 This plugin provides two applications accessible from the provider menu:

--- a/extensions/provider_availability/provider_availability/README.md
+++ b/extensions/provider_availability/provider_availability/README.md
@@ -3,7 +3,19 @@ provider-availability
 
 ## Description
 
-Provider availability engine with rule-based scheduling, real-time slot calculation, and an admin configuration UI. Manages open appointment slots across providers, locations, and visit types — including one-off blocks, recurring blocks with hold types, appointment buffers, and timezone-aware calendar sync.
+Provider availability engine with rule-based scheduling, real-time slot calculation, and an admin configuration UI. Manages open appointment slots across providers, locations, and visit types - including one-off blocks, recurring blocks with hold types, appointment buffers, and timezone-aware calendar sync.
+
+## Problem it solves
+
+Keeping each provider's bookable hours correct across locations, visit types, recurring time off, and appointment buffers usually means hand-editing calendars and re-checking for conflicts every time something changes. Mistakes show up as double-bookings or slots that should have been blocked. This plugin computes bookable slots from each provider's rules and existing appointments, syncs those rules to Canvas calendar events, and adds buffer time automatically when appointments are booked, rescheduled, or canceled - so scheduling staff set the rules once instead of maintaining calendars by hand.
+
+## How to install
+
+```
+canvas install provider_availability
+```
+
+Set the `simpleapi-api-key` and `allowed-staff-keys` secrets before use (see Configuration).
 
 ## Screenshots
 

--- a/extensions/provider_clinical_summary_companion/provider_clinical_summary_companion/README.md
+++ b/extensions/provider_clinical_summary_companion/provider_clinical_summary_companion/README.md
@@ -2,6 +2,10 @@
 
 A patient-scope provider companion app that renders a compact, read-only clinical summary of the open patient — social determinants, conditions, medications, allergies, vitals, immunizations, and surgical history — and keeps itself fresh over a WebSocket when the chart changes server-side.
 
+## Problem it solves
+
+Getting a quick read on a patient means clicking through separate chart sections for conditions, medications, allergies, vitals, immunizations, and history, then re-checking them whenever something is committed mid-visit. This plugin replaces that clicking with one read-only summary that pulls all of those sections together and refreshes the affected section in place as the chart changes, so the provider does not have to reload or hunt for what moved.
+
 ## What providers see
 
 ![Patient clinical summary in the provider companion](screenshots/companion-pt-summary.png)

--- a/extensions/provider_my_panel_companion/provider_my_panel_companion/README.md
+++ b/extensions/provider_my_panel_companion/provider_my_panel_companion/README.md
@@ -2,6 +2,10 @@
 
 A mobile-friendly patient panel that lives on the provider companion main page. Shows the logged-in provider every patient whose active care team includes them, with last visit, next visit, and a running count of open tasks.
 
+## Problem it solves
+
+A provider working from a phone has no quick way to see just their own patients along with when each was last seen, when they are due back, and how many tasks are still open. Answering that today means running separate searches and counting tasks by hand. This plugin assembles that panel view in one screen on the provider companion, pulled from active care-team membership, so providers stop stitching the picture together across multiple screens.
+
 ## What providers see
 
 ![My Panel in the provider companion](screenshots/my-panel.png)

--- a/extensions/provider_patient_messages_companion/provider_patient_messages_companion/README.md
+++ b/extensions/provider_patient_messages_companion/provider_patient_messages_companion/README.md
@@ -2,6 +2,10 @@
 
 A mobile-friendly messaging surface with live WebSocket updates. Ships in two surfaces: a global-scope **My Messages** thread list on the provider companion main page and a patient-scope **Messages** launcher on the patient page.
 
+## Problem it solves
+
+Providers working from a phone or tablet have no quick way to see and answer messages from the patients on their panel: the standard inbox is built for the desktop, and there is no panel-scoped thread list on the companion. This plugin puts an SMS-style messaging surface in the provider companion, with live updates, so a provider can read and reply to their panel's messages from a mobile-friendly screen instead of switching back to the full Canvas web app.
+
 ## What providers see
 
 ![Patient messaging in the provider companion](screenshots/patient-messaging.png)

--- a/extensions/provider_register_patient_companion/provider_register_patient_companion/README.md
+++ b/extensions/provider_register_patient_companion/provider_register_patient_companion/README.md
@@ -1,6 +1,10 @@
 # provider_register_patient_companion
 
-A global companion tool for registering a new patient from the provider companion launcher. Collects the minimum fields Canvas needs to create a record — first name, last name, date of birth, sex at birth, phone — warns about likely duplicates before it commits, and drops the provider on the new patient's companion page once the record exists.
+A global companion tool for registering a new patient from the provider companion launcher. Collects the minimum fields Canvas needs to create a record - first name, last name, date of birth, sex at birth, phone - warns about likely duplicates before it commits, and drops the provider on the new patient's companion page once the record exists.
+
+## Problem it solves
+
+Registering a patient at the bedside normally means leaving the companion view, opening the full patient-creation screen, and entering more than is needed just to get started - and duplicate records pile up because no one checks for an existing match first. This plugin keeps registration inside the companion flow with only the fields Canvas requires, runs a name-plus-date-of-birth and phone-number duplicate check before it creates anything, and lands the provider on the new patient's page when done, replacing the slower context switch and the after-the-fact duplicate cleanup.
 
 ## What providers see
 

--- a/extensions/provider_schedule_companion/provider_schedule_companion/README.md
+++ b/extensions/provider_schedule_companion/provider_schedule_companion/README.md
@@ -2,6 +2,10 @@
 
 A mobile-friendly "at-a-glance" schedule that lives on the provider companion main page. Opens the logged-in provider's own upcoming visits in a modal with day, week, and month views.
 
+## Problem it solves
+
+A provider checking their own day from a phone otherwise has to open the full scheduling view and pick themselves out of everyone else's appointments. This plugin puts the logged-in provider's own visits, and only theirs, one tap away in the companion launcher with day, week, and month views.
+
 ## What providers see
 
 ![My Schedule in the provider companion](screenshots/my-schedule.png)

--- a/extensions/provider_task_dashboard_companion/provider_task_dashboard_companion/README.md
+++ b/extensions/provider_task_dashboard_companion/provider_task_dashboard_companion/README.md
@@ -2,6 +2,10 @@
 
 A mobile-friendly task triage surface that lets the logged-in provider browse tasks with filters, read and post comments, assign tasks to themselves, and mark their own tasks complete. Ships in two surfaces: a global-scope **Task Dashboard** on the provider companion main page and a patient-scope **Tasks** launcher on the patient page.
 
+## Problem it solves
+
+Providers working from a phone or tablet have no quick way to see, comment on, and clear their tasks without going back to the full desktop task list. They end up letting tasks pile up or handling them later at a workstation. This plugin puts a touch-friendly task view in the provider companion so a provider can filter to their own open tasks, read and post comments, claim a task, and mark it complete on the spot.
+
 ## What providers see
 
 ![Task Dashboard in the provider companion](screenshots/task-dashboard.png)

--- a/extensions/psychiatry-questionnaires/README.md
+++ b/extensions/psychiatry-questionnaires/README.md
@@ -2,6 +2,14 @@
 
 Canvas plugin that installs two validated psychiatry screening questionnaires commonly used in behavioral health and psychiatric settings.
 
+## Problem it solves
+
+Standing up validated screening instruments like ACE and PCL-5 by hand means rebuilding each question, response option, LOINC code, and scoring rule in the questionnaire editor. This plugin ships both instruments preconfigured so they are available in charting right after install, with no manual setup.
+
+## Configuration options
+
+No configuration required.
+
 ## Included Questionnaires
 
 ### ACE (Adverse Childhood Experiences)

--- a/extensions/scheduling-with-rooms/scheduling_with_rooms/README.md
+++ b/extensions/scheduling-with-rooms/scheduling_with_rooms/README.md
@@ -15,6 +15,22 @@ The Scheduling Admin app exposes a visit-type configuration matrix
 concurrent-slot capacity) persisted under the `scheduling_with_rooms`
 Custom Data namespace.
 
+## Problem it solves
+
+Booking a visit that needs a room means coordinating two calendars at once: the provider's and the room's. Done by hand, staff book the patient, then separately block the room, and have to remember to free the room if the appointment is cancelled, which is easy to miss and leads to double-booked or phantom-held rooms. This plugin books the provider and the room together and deletes the linked room event automatically when the patient appointment is cancelled.
+
+## Who it's for
+
+Front-desk and scheduling staff at clinics where visits consume a shared physical resource, such as procedure rooms, infusion chairs, or imaging suites. It fits practices that need provider and room availability reconciled in a single booking step, including pediatric, specialty, and multi-room primary care groups.
+
+## How to install
+
+```
+canvas install scheduling_with_rooms
+```
+
+The `FHIR_BASE_URL`, `FHIR_CLIENT_ID`, `FHIR_CLIENT_SECRET`, `SCHEDULABLE_STAFF_ROLES`, and `SCHEDULE_DURATIONS` secrets must be set in plugin settings.
+
 ## Components
 
 | Component                                            | Purpose                                                                |

--- a/extensions/surface_epipen_alternatives/README.md
+++ b/extensions/surface_epipen_alternatives/README.md
@@ -5,4 +5,14 @@ Surface EpiPen Alternatives
 
 At times an organization may want to highlight to providers alternative medications or generic versions of the same medication because of patient cost, effectiveness, reduced side effects, or other reasons. This extension reorders medication search results to prioritze lower cost EpiPen alternatives. 
 
+## How to install
+
+```
+canvas install surface_epipen_alternatives
+```
+
+## Configuration options
+
+No configuration required.
+
 

--- a/extensions/task_webhook_notification/README.md
+++ b/extensions/task_webhook_notification/README.md
@@ -14,6 +14,18 @@ The payload includes the following:
 
 Customize the event trigger and payload to fit your needs.
 
+## Who it's for
+
+Engineering and operations teams who integrate Canvas with an external system - a ticketing tool, a notification service, or a custom workflow app - and need it to react the moment a task is created or updated rather than polling for changes.
+
+## How to install
+
+```
+canvas install task_webhook_notification
+```
+
+Set the required secrets before use (see Configuration).
+
 ### Important Note!
 
 There are two plugin secrets to set:

--- a/extensions/total_energy_needs/README.md
+++ b/extensions/total_energy_needs/README.md
@@ -6,6 +6,18 @@ Knowing a patient's caloric needs can be especially important for providers in t
 
 This extension includes the Activity Factor for Energy Needs Questionnaire and displays a patient's TDEE as a banner in the patient chart. The TDEE is based on the Mifflin-St Jeor equation which factors in a patients sex, age, height, weight, and current activity level. The banner calculation will update whenever a new activity level questionnaire, height, or weight is recorded.
 
+## How to install
+
+```
+canvas install total_energy_needs
+```
+
+The `CURRENT_ACTIVITY_LEVEL_QUESTION_CODE` secret must be set in plugin settings.
+
+## Configuration options
+
+- `CURRENT_ACTIVITY_LEVEL_QUESTION_CODE`: the question code identifying the activity-level response in the Activity Factor for Energy Needs questionnaire. The plugin reads this code to pull the patient's current activity level, which sets the multiplier applied to the BMR when computing TDEE.
+
 ## Important Note!
 
 The CANVAS_MANIFEST.json is used when installing your plugin. Please ensure it gets updated if you add, remove, or rename protocols.

--- a/extensions/training_case_example/README.md
+++ b/extensions/training_case_example/README.md
@@ -5,6 +5,34 @@ Training Case Example
 
 The `training_case_example` extension shows how to define a clinical case programmatically so it can be replicated consistently, effortlessly, and with time-dynamic values.
 
+## What it does
+
+When a new patient is created, this extension checks the patient's last name. If it matches a known training case, the extension creates a note for that patient and fills it with predefined chart data. The included Afib case adds a reason for visit, a history of present illness, and abnormal vitals so the chart looks like a real atrial fibrillation presentation.
+
+## Problem it solves
+
+Building realistic practice charts by hand is slow and inconsistent. Each person doing a training or demo setup enters slightly different data, and the values do not stay current over time. This extension generates the same case the same way every time from code, removing the manual data entry.
+
+## Who it's for
+
+Teams building training environments and demo instances - implementation staff, sales engineers, and anyone preparing Canvas instances who needs repeatable example patient charts.
+
+## How to install
+
+```bash
+canvas install training_case_example
+```
+
+This extension reads secrets to call the Note API and related services. Set them before use (see Configuration options).
+
+## Configuration options
+
+This extension declares these secrets in its manifest:
+
+- `CLIENT_ID` and `CLIENT_SECRET` - credentials used to authenticate to the Note API when creating the case note.
+- `FHIR_BASE_URL` and `FHIR_API_KEY` - base URL and key for FHIR access.
+- `OPENAI_API_KEY` - key for OpenAI access.
+
 ## Usage
 
 There are many different ways to trigger creation of a new patient case. For this example, we're going respond to new patient creation event created manually by a user, and the patient's last name will define the case that will be generated. Currently implemented cases are:

--- a/extensions/visualizations/scoring_visualizer/README.md
+++ b/extensions/visualizations/scoring_visualizer/README.md
@@ -12,3 +12,21 @@ For any scored questionnaire:
 - Identify trends and progress over time
 
 ![Questionnaire Scoring Visualizer](https://images.prismic.io/canvas-website/aCep9idWJ-7kSPla_gad2_scoring.png?auto=format,compress)
+
+## Problem it solves
+
+Scored questionnaires such as PHQ-9, GAD-7, or social determinant screens produce a number at each visit, but those numbers sit in separate observations with no way to see the trend. To judge whether a patient is improving, a clinician has to open each past result and compare values in their head. This plugin charts the recorded scores over time in one view so the direction of change is visible at a glance.
+
+## Who it's for
+
+Clinicians who track patient progress with repeat-administered scored questionnaires: behavioral health and primary care providers using depression and anxiety screens, and care teams reviewing social determinant or other survey scores across visits.
+
+## How to install
+
+```
+canvas install scoring_visualizer
+```
+
+## Configuration options
+
+No configuration required.

--- a/extensions/visualizations/vitals_visualizer/README.md
+++ b/extensions/visualizations/vitals_visualizer/README.md
@@ -2,6 +2,10 @@
 
 A patient-vitals trend visualizer. Opens a modal with time-series line charts of the values collected in the Vital Signs command. Accessible from two surfaces: an action button in the chart summary, and a patient-scope companion launcher.
 
+## Problem it solves
+
+A patient's vitals accumulate one panel at a time, and the chart shows them as a list of dated readings. Spotting whether weight, blood pressure, or oxygen saturation is trending up or down means reading down the column and comparing numbers by eye, or exporting them to plot elsewhere. This plugin charts each vital as a time series in a single modal, so the trend across visits is visible without manual tallying.
+
 ## What providers see
 
 ### Open Visualizer (action button)

--- a/extensions/vitalstream/vitalstream/README.md
+++ b/extensions/vitalstream/vitalstream/README.md
@@ -3,6 +3,22 @@ VitalStream by Caretaker Medical
 
 This plugin provides an integration for the VitalStream device by Caretaker Medical, enabling real-time vital signs monitoring within Canvas Medical.
 
+## Problem it solves
+
+Continuous vitals from a monitoring device normally live outside the chart, so staff read them off the device and retype periodic values into the note by hand. That is slow and error-prone during a treatment session. This plugin streams the device readings straight into the chart and, on save, computes windowed averages at chosen time marks and records them as Observations, so the readings reach the patient record without manual transcription.
+
+## Who it's for
+
+Clinical staff who run device-monitored treatment sessions - for example nurses and providers administering Spravato (esketamine) or other treatments that require timed blood pressure and vitals checks, where readings must land in the chart.
+
+## How to install
+
+```bash
+canvas install vitalstream
+```
+
+This plugin requires the `AUTHORIZED_SERIAL_NUMBERS` secret to function. Set it before use (see Configuration).
+
 ## Features
 
 - **Real-time Vital Signs Display**: Receives continuous vital sign measurements from VitalStream devices via WebSocket, displaying them in a live feed within the patient chart.

--- a/extensions/zoom_in_chart/README.md
+++ b/extensions/zoom_in_chart/README.md
@@ -4,6 +4,14 @@
 
 This plugin adds an action button to a note when an appointment is a telehealth visit that is set up with a Zoom meeting. The action button will launch the Zoom telehealth visit directly in the right hand pane of the browswer in the patient's chart (rather than opening in the Zoom desktop app). This plugin uses the [Zoom Meeting SDK for web](https://developers.zoom.us/docs/meeting-sdk/web/) to integrate the meeting directly into the browser.
 
+## Problem it solves
+
+Starting a telehealth visit normally means leaving the chart, switching to the Zoom desktop app, and finding the right meeting, which breaks the provider's flow and pulls focus away from the patient's record. This plugin replaces that app switch with a button on the note that opens the Zoom visit in the chart's side pane, keeping the visit and the chart on one screen.
+
+## Who it's for
+
+Prescribers and clinical staff who run telehealth appointments in Canvas and want to join the Zoom visit without leaving the patient's chart.
+
 ### Setup
 
 The Zoom SDK requires that an application is registered in able to use the features in a browser. The Zoom account used must either hold the `Owner` or `Admin` role in order to create an application. For our purposes here, we are setting up a Zoom application in Development mode.


### PR DESCRIPTION
Adds the missing text sections from the open-source plugin publishing checklist (What it does / Problem it solves / Who it's for / How to install / Configuration options) to 53 reference-plugin READMEs. Each section is grounded in the plugin's code and `CANVAS_MANIFEST.json`; install commands use the manifest name.

**Documentation only - no code changes. No screenshots added.**

- **15 plugins now have all six required sections** (none was missing a screenshot): scoring_visualizer, growth_charts, scheduling_with_rooms, cash_pay_profile_field, provider_availability, encounter_list, provider_my_panel_companion, provider_register_patient_companion, provider_patient_messages_companion, provider_task_dashboard_companion, provider_clinical_summary_companion, provider_schedule_companion, assistant, conversational_messaging, order_tracking.
- **38 plugins have their text sections completed** and still need a screenshot embedded to fully meet the checklist.

Each plugin's original author is best placed to confirm the "Problem it solves" / "Who it's for" framing - flag anything that misreads your plugin and it is a one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)