### PR TITLE
Add customer-facing CARD.md to 7 plugins with placeholder READMEs

### DIFF
--- a/extensions/compound-medication-loader/CARD.md
+++ b/extensions/compound-medication-loader/CARD.md
@@ -1,0 +1,26 @@
+# Compound Medication Loader
+
+Load your entire compound-medication formulary into Canvas from a single CSV, instead of adding each preparation one at a time.
+
+## The problem
+
+Adding compound medications through the Prescribe command one entry at a time is slow. A practice with a real compound formulary - hormone creams, magic mouthwashes, custom topical preparations - can have dozens or hundreds of entries, and re-doing that work by hand invites duplicates and mistakes.
+
+## What it does
+
+Gives staff two ways to load compound medications in bulk:
+
+- **Upload page** - drag in a CSV, review the parsed rows with errors and duplicates flagged before you commit, then load them all at once.
+- **Programmatic endpoint** - load from a script using a per-instance access token, for one-off migrations or syncing from another source.
+
+Both paths validate every row, flag anything already in Canvas, and let you safely re-run the load without creating duplicates.
+
+## Who it's for
+
+Clinical and admin staff at practices that maintain a compound formulary - functional-medicine clinics, pain management, ketamine and psychedelic-medicine clinics, dermatology, or anywhere providers prescribe practice-specific custom compounds at scale.
+
+## Good to know
+
+- Duplicate detection runs before you load, so you see what already exists up front.
+- Re-running a load is safe - existing entries are skipped by default.
+- The programmatic endpoint stays disabled until you set an access token, so nothing is exposed by default.

--- a/extensions/order_sets/CARD.md
+++ b/extensions/order_sets/CARD.md
@@ -1,0 +1,21 @@
+# Order Sets
+
+Apply a predefined bundle of lab, imaging, and point-of-care orders to a patient chart with one click, instead of adding each test one at a time.
+
+## The problem
+
+Placing the same group of orders over and over - a diabetes workup, a sports-physical panel, a standard chest workup - is slow and error-prone. Providers have to remember every test, look up codes, and re-enter the same diagnoses and comments every visit.
+
+## What it does
+
+Bundles common orders into reusable templates any active provider can apply in seconds. Admins curate practice-wide shared sets; each provider keeps their own personal favorites. Preview a set and deselect individual items before confirming, or use Quick Order to place everything at once. Optional diagnosis codes attach to every order in the set, and lab tests are pulled live from the instance's configured lab partners.
+
+## Who it's for
+
+Primary care, urgent care, and specialty clinics whose providers repeatedly order the same group of tests. Admins maintain the shared sets; individual providers maintain their own favorites.
+
+## Good to know
+
+- Works across lab, imaging, and point-of-care orders in one workflow.
+- Shared sets are practice-wide; personal favorites are private to each provider.
+- An optional admin list controls who can edit shared sets; until it is set, only a set's creator can change it.

--- a/extensions/patient-visit-summary/patient_visit_summary/CARD.md
+++ b/extensions/patient-visit-summary/patient_visit_summary/CARD.md
@@ -1,0 +1,32 @@
+# Patient Visit Summary
+
+Turn any clinical note into a clean, print-ready visit summary - a patient-friendly handout in one click, or a fully customizable PDF that's saved back to the chart.
+
+## The problem
+
+Canvas's out-of-the-box note print is clinician-oriented and inflexible: it surfaces internal workflow fields, doesn't let staff control what's included, and the result isn't durably attached back to the chart. Practices end up with two recurring pain points - patients need a clean handout, and staff need a finalized, customizable record for legal, billing, audit, or portal distribution. The common workaround is copying the note into Word, reformatting by hand every visit, and printing from there.
+
+## What it does
+
+Adds two surfaces to the note:
+
+- **Patient Visit Summary** - a button in the note header opens a formatted, print-ready summary built straight from the note's data. Internal clinical-workflow fields are filtered out automatically, so the patient sees only what's useful to them.
+- **Customize & Print** - choose which sections to include, reorder them, add header, footer, or comment text, preview live, and generate a finalized PDF that's attached to the chart as a clinical document for later retrieval. Every saved version stays accessible for re-print.
+
+![Print-ready patient visit summary](https://raw.githubusercontent.com/Medical-Software-Foundation/canvas/main/extensions/patient-visit-summary/patient_visit_summary/docs/screenshots/02-visit-summary.png)
+
+![Customize & Print panel - toggle and reorder sections, add header and footer text, preview, and generate the PDF](https://raw.githubusercontent.com/Medical-Software-Foundation/canvas/main/extensions/patient-visit-summary/patient_visit_summary/docs/screenshots/04-customize-print-panel.png)
+
+## Who it's for
+
+Specialty-agnostic - the section coverage mirrors SOAP structure and works for primary care, behavioral health, and most specialty workflows. Three audiences benefit:
+
+- **Providers** finalizing a visit - generate a clean chart PDF and hand the patient a friendly summary at checkout.
+- **Clinical and administrative staff** who curate visit documentation for legal, billing, audit, or portal distribution.
+- **Plugin authors** building custom commands - their content is surfaced automatically, no coordination required.
+
+## Good to know
+
+- The patient-facing summary automatically strips internal clinical and billing workflow content.
+- Finalized PDFs are attached back to the chart and retrievable later; previous versions are kept per note.
+- Header logos are pulled from the practice location, so no plugin code changes are needed to brand the output.

--- a/extensions/portal-membership/portal_membership/CARD.md
+++ b/extensions/portal-membership/portal_membership/CARD.md
@@ -1,0 +1,31 @@
+# Patient Portal Membership
+
+Run patient memberships and recurring billing inside Canvas - sign-up, card updates, retries, and cancellation - all driven from the patient portal, with no separate billing tool to reconcile.
+
+## The problem
+
+Membership-based practices - direct primary care, concierge, weight management, behavioral health - need to charge a recurring fee that lives inside the patient's chart and portal, not in a separate tool staff reconcile by hand. Without that, practices run subscriptions in a third-party dashboard, manually flag membership status on each chart, chase declined cards over email, and handle signups and cancellations by phone.
+
+## What it does
+
+Collapses the whole membership workflow into Canvas and the patient portal:
+
+- Patients self-serve enrollment, plan management, card updates, and cancellation from the portal
+- Providers see membership status on the chart banner at the point of care
+- Staff get a read-only directory of all members in the provider menu
+- A daily billing job handles recurring charges, automatic retries on failure, auto-cancellation, and the staff off-boarding task - without anyone leaving Canvas
+
+## Who it's for
+
+Practices that bill patients on a recurring cadence and want that workflow inside Canvas:
+
+- Direct primary care - monthly or annual fees in lieu of fee-for-service
+- Concierge primary care - annual retainers with portal-driven enrollment
+- Membership-based specialty practices - weight management, hormone replacement, behavioral health, longevity
+- Cash-pay or hybrid practices running a paid membership tier alongside insurance
+
+## Good to know
+
+- Membership tiers, pricing, and discount codes are configurable.
+- Failed charges retry automatically, with auto-cancellation and a staff task after repeated failures.
+- The staff directory is read-only by design - patients manage their own memberships from the portal.

--- a/extensions/role-based-homepage/role_based_homepage/CARD.md
+++ b/extensions/role-based-homepage/role_based_homepage/CARD.md
@@ -1,0 +1,29 @@
+# Role-Based Homepage
+
+Send each staff member straight to the screen that matters for their job the moment they log in - providers to the schedule, billers to revenue, panel managers to the patient list.
+
+## The problem
+
+Out of the box, everyone lands on the same default homepage after login, so most people start each day by clicking away to the screen they actually use. Teams that want role-appropriate landing pages otherwise have to build and maintain a separate plugin per role or per customer.
+
+## What it does
+
+Routes each user to the right starting page based on their staff role. You decide which role goes where with a single piece of configuration - no code changes to adjust the routing. If someone holds several roles, the most senior one decides where they land, and an optional catch-all covers everyone else.
+
+## Who it's for
+
+Any practice that wants different staff to start on different screens. It works across every role, clinical and administrative:
+
+- Providers and clinical support to the schedule
+- Front desk and office managers to the schedule
+- Panel and cohort managers to the patient list
+- Billing and finance to revenue
+- Developers and integration admins to data integration
+
+The mapping is fully configurable - that list is just a sensible starting point.
+
+## Good to know
+
+- Routing is set with one configuration value, so you can adjust it any time without a new release.
+- A role can be sent to a built-in page or to a custom plugin application.
+- This only changes the landing page. It is not a security boundary - Canvas authorization still governs access to every page.

--- a/extensions/telehealth-disclaimer/CARD.md
+++ b/extensions/telehealth-disclaimer/CARD.md
@@ -1,0 +1,21 @@
+# Telehealth Disclaimer
+
+Automatically add your telehealth attestation to every telehealth note, so the required language is always documented without the clinician lifting a finger.
+
+## The problem
+
+Telehealth visits usually require a documented attestation covering modality, consent, identity verification, and standard of care. When clinicians have to paste that language into every note by hand, it gets skipped, abbreviated, or worded inconsistently - a compliance gap that only surfaces in an audit.
+
+## What it does
+
+The moment a telehealth visit note is created, the plugin drops your disclaimer into the note's Plan section automatically. It renders on screen and in the printed or PDF note alongside the rest of the plan. Notes that aren't telehealth are left untouched.
+
+## Who it's for
+
+Any practice that runs telehealth visits and wants consistent, automatic attestation on every note. The disclaimer wording is yours to set, so you can supply your own legal or compliance language.
+
+## Good to know
+
+- The disclaimer text is configurable - set your own, or use the built-in default.
+- It triggers only on telehealth-flagged note types, so nothing changes for in-person visits.
+- No change to the clinician's workflow - the language appears on its own.

--- a/extensions/vitals-dashboard/CARD.md
+++ b/extensions/vitals-dashboard/CARD.md
@@ -1,0 +1,28 @@
+# Vitals Dashboard
+
+A cardiology-focused vitals capture surface and trend dashboard, built as a tab right in the patient chart.
+
+## The problem
+
+Canvas's built-in vitals command is too narrow for a cardiology day clinic: one blood-pressure position per command, no dry weight, no per-void urine output, and no structured way to capture edema. Cardiology workflows - orthostatic BP for syncope, dry-versus-current weight and urine output for CHF fluid management - end up scattered across free text, where they can't be trended or exported cleanly.
+
+## What it does
+
+Adds a **Vitals** tab to the patient chart where clinical staff can:
+
+- Record standard and orthostatic blood pressure and heart rate across laying, sitting, and standing
+- Capture current and dry weight, urine output with a running total, O2 saturation, respiration, temperature, pain score, and edema notes
+- View recent vitals over 24 hours, 7, 30, or 90 days as tables and trend charts
+- Carry the last session forward as defaults, and export to CSV or a print-ready report
+
+Every measurement is also saved as a native record on the chart, so it flows into the chart-summary sidebar and document exports.
+
+## Who it's for
+
+Cardiology day-clinic staff - nurses, medical assistants, and providers - who routinely capture orthostatic vitals, weight trends, and urine output. Useful anywhere the standard vitals surface is too narrow: CHF, syncope, autonomic workups, and post-procedure observation.
+
+## Good to know
+
+- No secrets or external services to configure.
+- The dashboard is the source of truth; the chart note and exported records are documentation generated from it.
+- A measurement can be marked entered-in-error and excluded from trends while staying visible in the audit table.


### PR DESCRIPTION
## What

Adds a customer-facing `CARD.md` alongside the developer `README.md` for the seven plugins whose READMEs currently leak authoring placeholders onto their public pages. No existing files are changed.

- `telehealth-disclaimer`
- `compound-medication-loader`
- `vitals-dashboard`
- `portal-membership`
- `role-based-homepage`
- `order_sets`
- `patient-visit-summary`

## Why

The website's plugin pages fetch a plugin's markdown by URL (`card_markdown_url`) and render it with a markdown component that is not HTML-comment-aware. As a result, dev-oriented README content - `<!-- ... -->` placeholder comments, `TBD`/`TODO` notes, SDK internals - can surface as visible text on the public page. A dedicated `CARD.md` separates the two audiences:

- `README.md` stays the developer document.
- `CARD.md` is the polished, benefit-led version intended for the public plugin page.

## Notes

- Each card is plain-language, Canvas voice, with no placeholders or broken image references.
- Six cards are text-only (no real UI screenshot exists yet). `patient-visit-summary` keeps two real screenshots using absolute `raw.githubusercontent.com` URLs so they render off-repo.
- After merge, each plugin's Prismic Card Markdown URL must be repointed to its `CARD.md` (manual step, not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)