### PR TITLE
lab_order_favorites: scope insert picker to encounter/chart-review notes

### DIFF
--- a/extensions/lab_order_favorites/lab_order_favorites/CANVAS_MANIFEST.json
+++ b/extensions/lab_order_favorites/lab_order_favorites/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.157.0",
-    "plugin_version": "0.2.0",
+    "plugin_version": "0.3.0",
     "name": "lab_order_favorites",
     "description": "Create and reuse lab order favorites (single test or multi-test panels) as staged lab order commands, with personal/shared visibility, tags, search, and CSV bulk upload.",
     "components": {
@@ -35,11 +35,15 @@
             },
             {
                 "class": "lab_order_favorites.protocols.favorites_api:OpenNotesAPI",
-                "description": "List a patient's open notes for the insert target picker"
+                "description": "List a patient's open encounter and chart review notes for the insert target picker"
             },
             {
                 "class": "lab_order_favorites.protocols.favorites_api:InsertFavoriteAPI",
                 "description": "Validate a favorite and insert it as a staged lab order command"
+            },
+            {
+                "class": "lab_order_favorites.protocols.favorites_api:CreateChartReviewAPI",
+                "description": "Create a chart review note and stage selected favorites when no open encounter note exists"
             }
         ],
         "applications": [

--- a/extensions/lab_order_favorites/lab_order_favorites/protocols/favorites_api.py
+++ b/extensions/lab_order_favorites/lab_order_favorites/protocols/favorites_api.py
@@ -6,16 +6,18 @@ Backs both applications:
 """
 
 import json
+from datetime import datetime, timezone
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from canvas_sdk.commands import LabOrderCommand
 from canvas_sdk.effects import Effect
+from canvas_sdk.effects.note.note import Note as NoteEffect
 from canvas_sdk.effects.simple_api import HTMLResponse, JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPIRoute, StaffSessionAuthMixin
 from canvas_sdk.templates import render_to_string
 from canvas_sdk.v1.data import CurrentNoteStateEvent, Note, Patient
-from canvas_sdk.v1.data.note import NoteStates
+from canvas_sdk.v1.data.note import NoteStates, NoteTypeCategories
 from logger import log
 
 API_BASE = "/plugin-io/api/lab_order_favorites"
@@ -28,6 +30,10 @@ from lab_order_favorites.services.lab_catalog import (
     list_tests_for_partner,
     resolve_partner,
 )
+from lab_order_favorites.services.notes import (
+    chart_review_note_type_id,
+    default_practice_location_id,
+)
 from lab_order_favorites.services.providers import list_ordering_providers, resolve_provider
 
 OPEN_NOTE_STATES = [
@@ -38,6 +44,11 @@ OPEN_NOTE_STATES = [
     NoteStates.RESTORED,
     NoteStates.UNDELETED,
 ]
+
+# Lab orders can only be staged into notes where they belong: encounter (visit)
+# notes and chart review notes. Messages and letters never lock, so a state-only
+# filter would surface them even though a lab order cannot be inserted there.
+INSERT_TARGET_CATEGORIES = [NoteTypeCategories.ENCOUNTER, NoteTypeCategories.REVIEW]
 
 
 class _FavoritesHelpers:
@@ -441,50 +452,9 @@ class InsertFavoriteAPI(_FavoritesHelpers, StaffSessionAuthMixin, SimpleAPIRoute
         if note_uuid not in open_note_ids:
             return [JSONResponse({"error": "Selected note is not an open note for this patient", "success": False}, status_code=400)]
 
-        service = self._service()
-        editor_keys = self._editor_keys()
-        inserted: list[dict[str, Any]] = []
-        skipped: list[dict[str, Any]] = []
-        effects: list[Effect] = []
-
-        for favorite_id in favorite_ids:
-            favorite = service.get_favorite(favorite_id, staff_id)
-            if favorite is None:
-                skipped.append({"favorite_id": favorite_id, "name": favorite_id, "reason": "not_found", "can_edit": False})
-                continue
-
-            can_edit = _can_edit(favorite["is_shared"], favorite.get("created_by_id"), staff_id, editor_keys)
-            order_codes = [t.get("order_code", "") for t in favorite["tests"] if t.get("order_code")]
-            availability = check_availability(favorite["lab_partner_id"], order_codes)
-
-            if not availability["partner_found"] or not availability["partner_active"]:
-                reason = "partner_missing" if not availability["partner_found"] else "partner_inactive"
-                skipped.append({"favorite_id": favorite_id, "name": favorite["name"], "reason": reason, "can_edit": can_edit, "owner_name": favorite.get("created_by_name")})
-                continue
-            if availability["stale"]:
-                skipped.append({"favorite_id": favorite_id, "name": favorite["name"], "reason": "stale_codes", "stale_codes": availability["stale"], "can_edit": can_edit, "owner_name": favorite.get("created_by_name")})
-                continue
-
-            # Use the favorite's default ordering provider when it still resolves
-            # to a valid provider; otherwise fall back to the inserting staff
-            # member. Either can be changed in the lab order command.
-            saved_provider = str(favorite.get("ordering_provider_key") or "")
-            ordering_provider_key = staff_id
-            if saved_provider:
-                provider, _reason = resolve_provider(saved_provider)
-                ordering_provider_key = provider["id"] if provider else staff_id
-            effects.append(
-                LabOrderCommand(
-                    note_uuid=note_uuid,
-                    lab_partner=favorite["lab_partner_id"],
-                    tests_order_codes=availability["valid"],
-                    ordering_provider_key=ordering_provider_key,
-                    diagnosis_codes=favorite.get("diagnosis_codes") or [],
-                    fasting_required=bool(favorite.get("fasting_required", False)),
-                    comment=favorite.get("comment") or "",
-                ).originate()
-            )
-            inserted.append({"favorite_id": favorite_id, "name": favorite["name"], "test_count": len(availability["valid"])})
+        inserted, skipped, effects = _stage_favorites(
+            self._service(), favorite_ids, staff_id, note_uuid, self._editor_keys()
+        )
 
         log.info(f"Inserted {len(inserted)} lab order(s), skipped {len(skipped)}, into note {note_uuid}")
         message_parts = []
@@ -506,6 +476,159 @@ class InsertFavoriteAPI(_FavoritesHelpers, StaffSessionAuthMixin, SimpleAPIRoute
             ),
             *effects,
         ]
+
+
+class CreateChartReviewAPI(_FavoritesHelpers, StaffSessionAuthMixin, SimpleAPIRoute):
+    """Create a chart review note and stage the selected favorites into it.
+
+    Used by the patient app when the patient has no open encounter note to add
+    lab orders to. The note is created with the acting user as provider, the
+    current time as the service date, and the provider's default location -
+    matching the New Note button - then each favorite is staged into it in the
+    same action via a self-assigned note UUID.
+    """
+
+    PATH = "/routes/create-review"
+
+    def post(self) -> list[Response | Effect]:
+        staff_id = self._staff_id()
+        if not staff_id:
+            return [JSONResponse({"error": "Staff ID not found", "success": False}, status_code=400)]
+
+        try:
+            body = self._json_body()
+        except ValueError:
+            return [JSONResponse({"error": "Invalid JSON in request body", "success": False}, status_code=400)]
+
+        favorite_ids = _requested_favorite_ids(body)
+        patient_id = str(body.get("patient_id", "")).strip()
+        if not favorite_ids or not patient_id:
+            return [JSONResponse({"error": "favorite_ids and patient_id are required", "success": False}, status_code=400)]
+
+        # Patient.id is a UUIDField - a non-UUID value would raise ValidationError,
+        # so validate the format before touching the database.
+        try:
+            UUID(patient_id)
+        except (ValueError, AttributeError, TypeError):
+            return [JSONResponse({"error": "Patient not found", "success": False}, status_code=404)]
+        if not Patient.objects.filter(id=patient_id).exists():
+            return [JSONResponse({"error": "Patient not found", "success": False}, status_code=404)]
+
+        note_type_id = chart_review_note_type_id()
+        if not note_type_id:
+            return [JSONResponse({"error": "No chart review note type is configured on this instance", "success": False}, status_code=400)]
+
+        location_id = default_practice_location_id(staff_id)
+        if not location_id:
+            return [JSONResponse({"error": "No active practice location is configured on this instance", "success": False}, status_code=400)]
+
+        # Assign the note UUID up front so the staged lab orders can target the
+        # note being created in this same action.
+        note_uuid = str(uuid4())
+        inserted, skipped, effects = _stage_favorites(
+            self._service(), favorite_ids, staff_id, note_uuid, self._editor_keys()
+        )
+
+        if not effects:
+            # Every selected favorite was skipped - don't create an empty review.
+            return [
+                JSONResponse(
+                    {
+                        "chart_review_created": False,
+                        "message": "No valid lab orders to stage",
+                        "inserted": [],
+                        "skipped": skipped,
+                        "success": True,
+                    }
+                )
+            ]
+
+        note_effect = NoteEffect(
+            instance_id=note_uuid,
+            note_type_id=note_type_id,
+            datetime_of_service=datetime.now(timezone.utc),
+            patient_id=patient_id,
+            practice_location_id=location_id,
+            provider_id=staff_id,
+        ).create()
+
+        log.info(
+            f"Created chart review {note_uuid}, staged {len(inserted)} lab order(s), skipped {len(skipped)}"
+        )
+        return [
+            JSONResponse(
+                {
+                    "chart_review_created": True,
+                    "note_uuid": note_uuid,
+                    "message": f"Chart review created with {len(inserted)} lab order(s) staged",
+                    "inserted": inserted,
+                    "skipped": skipped,
+                    "success": True,
+                }
+            ),
+            note_effect,
+            *effects,
+        ]
+
+
+def _stage_favorites(
+    service: FavoritesService,
+    favorite_ids: list[str],
+    staff_id: str,
+    note_uuid: str,
+    editor_keys: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[Effect]]:
+    """Validate each favorite and build a staged LabOrderCommand for the note.
+
+    Returns ``(inserted, skipped, effects)``. A favorite is skipped (no effect
+    built) when it no longer resolves, its partner is missing/inactive, or its
+    saved test codes are stale. Shared with both the open-note insert and the
+    chart review fallback so the validation rules stay identical.
+    """
+    inserted: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    effects: list[Effect] = []
+
+    for favorite_id in favorite_ids:
+        favorite = service.get_favorite(favorite_id, staff_id)
+        if favorite is None:
+            skipped.append({"favorite_id": favorite_id, "name": favorite_id, "reason": "not_found", "can_edit": False})
+            continue
+
+        can_edit = _can_edit(favorite["is_shared"], favorite.get("created_by_id"), staff_id, editor_keys)
+        order_codes = [t.get("order_code", "") for t in favorite["tests"] if t.get("order_code")]
+        availability = check_availability(favorite["lab_partner_id"], order_codes)
+
+        if not availability["partner_found"] or not availability["partner_active"]:
+            reason = "partner_missing" if not availability["partner_found"] else "partner_inactive"
+            skipped.append({"favorite_id": favorite_id, "name": favorite["name"], "reason": reason, "can_edit": can_edit, "owner_name": favorite.get("created_by_name")})
+            continue
+        if availability["stale"]:
+            skipped.append({"favorite_id": favorite_id, "name": favorite["name"], "reason": "stale_codes", "stale_codes": availability["stale"], "can_edit": can_edit, "owner_name": favorite.get("created_by_name")})
+            continue
+
+        # Use the favorite's default ordering provider when it still resolves to a
+        # valid provider; otherwise fall back to the inserting staff member.
+        # Either can be changed in the lab order command.
+        saved_provider = str(favorite.get("ordering_provider_key") or "")
+        ordering_provider_key = staff_id
+        if saved_provider:
+            provider, _reason = resolve_provider(saved_provider)
+            ordering_provider_key = provider["id"] if provider else staff_id
+        effects.append(
+            LabOrderCommand(
+                note_uuid=note_uuid,
+                lab_partner=favorite["lab_partner_id"],
+                tests_order_codes=availability["valid"],
+                ordering_provider_key=ordering_provider_key,
+                diagnosis_codes=favorite.get("diagnosis_codes") or [],
+                fasting_required=bool(favorite.get("fasting_required", False)),
+                comment=favorite.get("comment") or "",
+            ).originate()
+        )
+        inserted.append({"favorite_id": favorite_id, "name": favorite["name"], "test_count": len(availability["valid"])})
+
+    return inserted, skipped, effects
 
 
 def _resolve_provider_on_body(body: dict[str, Any]) -> JSONResponse | None:
@@ -603,7 +726,11 @@ def _open_notes_for_patient(patient_id: str):  # type: ignore[no-untyped-def]
     ).values_list("note_id", flat=True)
 
     return (
-        Note.objects.filter(dbid__in=open_note_ids, patient=patient)
+        Note.objects.filter(
+            dbid__in=open_note_ids,
+            patient=patient,
+            note_type_version__category__in=INSERT_TARGET_CATEGORIES,
+        )
         .select_related("note_type_version")
         .order_by("-modified")
     )

--- a/extensions/lab_order_favorites/lab_order_favorites/services/notes.py
+++ b/extensions/lab_order_favorites/lab_order_favorites/services/notes.py
@@ -1,0 +1,43 @@
+"""Lookups for the fallback chart review note.
+
+When a patient has no open encounter note to stage lab orders into, the
+patient-scoped app creates a chart review note instead. These helpers find the
+note type to use and the location to stamp on the new note - the same defaults
+the New Note button applies.
+"""
+
+from canvas_sdk.v1.data.note import NoteType, NoteTypeCategories
+from canvas_sdk.v1.data.practicelocation import PracticeLocation
+from canvas_sdk.v1.data.staff import Staff
+
+
+def chart_review_note_type_id() -> str | None:
+    """Return the id of the active chart review note type, or None.
+
+    Canvas ships a system-managed chart review note type (category 'review').
+    Pick the lowest-ranked active, visible one so it matches what a user would
+    reach from the New Note menu.
+    """
+    note_type = (
+        NoteType.objects.filter(
+            category=NoteTypeCategories.REVIEW, is_active=True, is_visible=True
+        )
+        .order_by("rank", "dbid")
+        .first()
+    )
+    return str(note_type.id) if note_type else None
+
+
+def default_practice_location_id(provider_id: str) -> str | None:
+    """Return the location id for a new note created by ``provider_id``.
+
+    Mirrors the New Note button: use the acting provider's primary practice
+    location, falling back to the first active location on the instance.
+    """
+    staff = Staff.objects.filter(id=provider_id).select_related("primary_practice_location").first()
+    if staff:
+        primary = staff.primary_practice_location
+        if primary:
+            return str(primary.id)
+    location = PracticeLocation.objects.filter(active=True).order_by("dbid").first()
+    return str(location.id) if location else None

--- a/extensions/lab_order_favorites/lab_order_favorites/templates/favorites.html
+++ b/extensions/lab_order_favorites/lab_order_favorites/templates/favorites.html
@@ -54,8 +54,13 @@
   <div id="list"><div class="empty">Loading...</div></div>
 
   <div class="insert-box" id="insert-box" style="display:none">
-    <label>Insert into note</label>
-    <select id="note-select"><option value="">Loading open notes...</option></select>
+    <div id="note-picker">
+      <label>Insert into note</label>
+      <select id="note-select"><option value="">Loading open notes...</option></select>
+    </div>
+    <div id="no-note-msg" class="notice" style="display:none">
+      No open note. A chart review will be created for these lab orders.
+    </div>
     <button class="primary" id="insert-btn" disabled>Insert lab orders</button>
   </div>
 </div>
@@ -64,6 +69,7 @@
 const API = "{{ api_base }}";
 const PATIENT_ID = "{{ patient_id }}";
 let favorites = [];
+let openNotes = [];   // patient's open encounter + chart review notes
 const selectedIds = new Set();
 const fixState = {};   // favId -> { stale: [...], replace: {code: test} }
 const fixTimers = {};
@@ -138,29 +144,59 @@ function toggleSelect(id) {
 function updateInsertBar() {
   const n = selectedIds.size;
   document.getElementById("insert-box").style.display = n ? "block" : "none";
+  const hasNotes = openNotes.length > 0;
+  document.getElementById("note-picker").style.display = hasNotes ? "block" : "none";
+  document.getElementById("no-note-msg").style.display = hasNotes ? "none" : "block";
   const btn = document.getElementById("insert-btn");
-  btn.textContent = n === 1 ? "Insert lab order" : `Insert ${n} lab orders`;
-  btn.disabled = !(n && document.getElementById("note-select").value);
+  if (hasNotes) {
+    btn.textContent = n === 1 ? "Insert lab order" : `Insert ${n} lab orders`;
+    btn.disabled = !(n && document.getElementById("note-select").value);
+  } else {
+    // No open encounter note - the action creates a chart review and inserts.
+    btn.textContent = n === 1 ? "Create chart review & insert" : `Create chart review & insert ${n}`;
+    btn.disabled = !n;
+  }
 }
 
 async function loadNotes() {
   const r = await fetch(`${API}/routes/notes?patient_id=${encodeURIComponent(PATIENT_ID)}`);
   const d = await r.json();
+  openNotes = d.notes || [];
   const sel = document.getElementById("note-select");
   sel.innerHTML = "";
-  if (!d.notes || !d.notes.length) {
-    sel.innerHTML = '<option value="">No open notes - create a note first</option>';
-    return;
-  }
-  d.notes.forEach(n => {
+  openNotes.forEach(n => {
     const o = document.createElement("option");
     o.value = n.id; o.textContent = n.title + (n.modified ? " (" + n.modified.slice(0, 10) + ")" : "");
     sel.appendChild(o);
   });
+  updateInsertBar();
 }
 
 document.getElementById("note-select").onchange = updateInsertBar;
-document.getElementById("insert-btn").onclick = () => doInsert([...selectedIds]);
+document.getElementById("insert-btn").onclick = () => {
+  const ids = [...selectedIds];
+  if (openNotes.length) { doInsert(ids); } else { doCreateReview(ids); }
+};
+
+async function doCreateReview(ids) {
+  if (!ids.length) { return; }
+  const btn = document.getElementById("insert-btn");
+  btn.disabled = true; btn.textContent = "Creating chart review...";
+  const r = await fetch(`${API}/routes/create-review`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ favorite_ids: ids, patient_id: PATIENT_ID })
+  });
+  const d = await r.json();
+  if (!d.success) { updateInsertBar(); msg(d.error || "Could not create chart review", "err"); return; }
+  selectedIds.clear();
+  document.getElementById("insert-box").style.display = "none";
+  // Refresh so a newly created chart review becomes a target for later orders.
+  await loadNotes();
+  renderList();
+  renderResults(d);
+  window.scrollTo({ top: 0, behavior: "smooth" });
+}
 
 async function doInsert(ids) {
   const noteUuid = document.getElementById("note-select").value;
@@ -190,9 +226,16 @@ function renderResults(d) {
     const ok = document.createElement("div");
     ok.className = "notice ok";
     // textContent (not innerHTML) - names are inert here.
-    ok.textContent = `${d.inserted.length} lab order(s) staged in the selected note: ` +
+    const where = d.chart_review_created ? "a new chart review" : "the selected note";
+    ok.textContent = `${d.inserted.length} lab order(s) staged in ${where}: ` +
       d.inserted.map(i => i.name).join(", ");
     box.appendChild(ok);
+  } else if (d.chart_review_created === false && (d.skipped || []).length) {
+    // Asked to create a chart review but every favorite was skipped - no note made.
+    const warn = document.createElement("div");
+    warn.className = "notice err";
+    warn.textContent = "No chart review was created - none of the selected favorites could be ordered.";
+    box.appendChild(warn);
   }
   (d.skipped || []).forEach(s => box.appendChild(skipRow(s)));
 }

--- a/extensions/lab_order_favorites/pyproject.toml
+++ b/extensions/lab_order_favorites/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "lab-order-favorites"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.12"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/extensions/lab_order_favorites/tests/protocols/test_favorites_api.py
+++ b/extensions/lab_order_favorites/tests/protocols/test_favorites_api.py
@@ -7,6 +7,7 @@ import pytest
 
 from lab_order_favorites.protocols import favorites_api
 from lab_order_favorites.protocols.favorites_api import (
+    CreateChartReviewAPI,
     CSVImportAPI,
     CSVTemplateAPI,
     FavoritesAPI,
@@ -921,3 +922,148 @@ def test_open_notes_helper_builds_filtered_queryset():
     assert notes.filter.call_args.kwargs["patient"] is patient
     # The open-note state filter is the safety gate (no staging into locked/signed notes).
     assert states.filter.call_args.kwargs["state__in"] == favorites_api.OPEN_NOTE_STATES
+    # Only encounter and chart review notes are insert targets - messages/letters,
+    # which never lock, are excluded by category.
+    assert (
+        notes.filter.call_args.kwargs["note_type_version__category__in"]
+        == favorites_api.INSERT_TARGET_CATEGORIES
+    )
+
+
+# --- CreateChartReviewAPI ---
+
+def test_create_review_requires_staff(make_request):
+    handler = _route(CreateChartReviewAPI, make_request(staff_id="", body={}))
+    [resp] = handler.post()
+    assert resp.status_code == 400
+
+
+def test_create_review_invalid_json(make_request, make_staff):
+    staff = make_staff()
+    request = make_request(staff_id=str(staff.id))
+    request.json = MagicMock(side_effect=ValueError("bad"))
+    request.body = b"x"
+    handler = _route(CreateChartReviewAPI, request)
+    [resp] = handler.post()
+    assert resp.status_code == 400
+
+
+def test_create_review_requires_fields(make_request, make_staff):
+    staff = make_staff()
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body={"patient_id": ""}))
+    [resp] = handler.post()
+    assert resp.status_code == 400
+
+
+def test_create_review_rejects_non_uuid_patient(make_request, make_staff):
+    staff = make_staff()
+    body = {"favorite_ids": ["x"], "patient_id": "not-a-uuid"}
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body=body))
+    [resp] = handler.post()
+    assert resp.status_code == 404
+
+
+def test_create_review_patient_not_found(make_request, make_staff):
+    staff = make_staff()
+    pid = "11111111-1111-1111-1111-111111111111"
+    body = {"favorite_ids": ["x"], "patient_id": pid}
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body=body))
+    with patch.object(favorites_api, "Patient") as P:
+        P.objects.filter.return_value.exists.return_value = False
+        [resp] = handler.post()
+    assert resp.status_code == 404
+
+
+def test_create_review_no_chart_review_type_configured(make_request, make_staff):
+    staff = make_staff()
+    pid = "11111111-1111-1111-1111-111111111111"
+    body = {"favorite_ids": ["x"], "patient_id": pid}
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body=body))
+    with patch.object(favorites_api, "Patient") as P, \
+         patch.object(favorites_api, "chart_review_note_type_id", return_value=None):
+        P.objects.filter.return_value.exists.return_value = True
+        [resp] = handler.post()
+    assert resp.status_code == 400
+    assert "chart review note type" in _body(resp)["error"]
+
+
+def test_create_review_no_active_location(make_request, make_staff):
+    staff = make_staff()
+    pid = "11111111-1111-1111-1111-111111111111"
+    body = {"favorite_ids": ["x"], "patient_id": pid}
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body=body))
+    with patch.object(favorites_api, "Patient") as P, \
+         patch.object(favorites_api, "chart_review_note_type_id", return_value="review-type-id"), \
+         patch.object(favorites_api, "default_practice_location_id", return_value=None):
+        P.objects.filter.return_value.exists.return_value = True
+        [resp] = handler.post()
+    assert resp.status_code == 400
+    assert "practice location" in _body(resp)["error"]
+
+
+def test_create_review_creates_note_and_stages_orders(make_request, make_staff, make_partner):
+    staff = make_staff()
+    partner = make_partner(tests=[("001", "Glucose"), ("002", "Lipid")])
+    fav = _make_favorite(staff, partner, ["001", "002"])
+    pid = "11111111-1111-1111-1111-111111111111"
+    body = {"favorite_ids": [fav["id"]], "patient_id": pid}
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body=body))
+
+    fake_cmd = MagicMock()
+    fake_cmd.originate.return_value = "ORDER_EFFECT"
+    fake_note = MagicMock()
+    fake_note.create.return_value = "NOTE_EFFECT"
+    with patch.object(favorites_api, "Patient") as P, \
+         patch.object(favorites_api, "chart_review_note_type_id", return_value="review-type-id"), \
+         patch.object(favorites_api, "default_practice_location_id", return_value="loc-id"), \
+         patch.object(favorites_api, "NoteEffect", return_value=fake_note) as note_cls, \
+         patch.object(favorites_api, "LabOrderCommand", return_value=fake_cmd) as cmd_cls:
+        P.objects.filter.return_value.exists.return_value = True
+        result = handler.post()
+
+    data = _body(result[0])
+    assert data["success"] is True
+    assert data["chart_review_created"] is True
+    assert len(data["inserted"]) == 1
+    assert data["skipped"] == []
+    # The note create effect comes first, then the staged lab order(s).
+    assert result[1] == "NOTE_EFFECT"
+    assert result[2] == "ORDER_EFFECT"
+
+    # The note is created with the acting user as provider, plus the resolved
+    # chart review type and default location.
+    _, nkwargs = note_cls.call_args
+    assert nkwargs["note_type_id"] == "review-type-id"
+    assert nkwargs["practice_location_id"] == "loc-id"
+    assert nkwargs["provider_id"] == str(staff.id)
+    assert nkwargs["patient_id"] == pid
+    assert nkwargs["datetime_of_service"] is not None
+    assert str(nkwargs["instance_id"]) == data["note_uuid"]
+
+    # The lab order is staged into the note being created in the same action.
+    _, ckwargs = cmd_cls.call_args
+    assert ckwargs["note_uuid"] == data["note_uuid"]
+    assert ckwargs["tests_order_codes"] == ["001", "002"]
+    assert ckwargs["ordering_provider_key"] == str(staff.id)
+
+
+def test_create_review_skips_all_does_not_create_note(make_request, make_staff):
+    staff = make_staff()
+    pid = "11111111-1111-1111-1111-111111111111"
+    # An unknown favorite id resolves to nothing, so there is nothing to stage.
+    body = {"favorite_ids": ["does-not-exist"], "patient_id": pid}
+    handler = _route(CreateChartReviewAPI, make_request(staff_id=str(staff.id), body=body))
+    with patch.object(favorites_api, "Patient") as P, \
+         patch.object(favorites_api, "chart_review_note_type_id", return_value="review-type-id"), \
+         patch.object(favorites_api, "default_practice_location_id", return_value="loc-id"), \
+         patch.object(favorites_api, "NoteEffect") as note_cls:
+        P.objects.filter.return_value.exists.return_value = True
+        result = handler.post()
+
+    # No note effect emitted, only the JSON response.
+    assert len(result) == 1
+    data = _body(result[0])
+    assert data["success"] is True
+    assert data["chart_review_created"] is False
+    assert len(data["skipped"]) == 1
+    note_cls.assert_not_called()

--- a/extensions/lab_order_favorites/tests/services/test_notes.py
+++ b/extensions/lab_order_favorites/tests/services/test_notes.py
@@ -1,0 +1,99 @@
+"""Tests for the chart review note-creation helpers."""
+
+from typing import Any
+
+from lab_order_favorites.services.notes import (
+    chart_review_note_type_id,
+    default_practice_location_id,
+)
+
+
+def _make_review_type(**kwargs: Any):  # type: ignore[no-untyped-def]
+    from canvas_sdk.v1.data.note import NoteType, NoteTypeCategories
+
+    defaults = dict(
+        category=NoteTypeCategories.REVIEW,
+        name="Chart Review",
+        is_active=True,
+        is_visible=True,
+        rank=1,
+    )
+    defaults.update(kwargs)
+    return NoteType.objects.create(**defaults)
+
+
+def _make_location(**kwargs: Any):  # type: ignore[no-untyped-def]
+    from canvas_sdk.v1.data.practicelocation import PracticeLocation
+
+    defaults = dict(
+        full_name="Main Clinic",
+        active=True,
+        bill_through_organization=False,
+        include_zz_qualifier=False,
+    )
+    defaults.update(kwargs)
+    return PracticeLocation.objects.create(**defaults)
+
+
+# --- chart_review_note_type_id ---
+
+def test_chart_review_note_type_id_none_when_absent():
+    assert chart_review_note_type_id() is None
+
+
+def test_chart_review_note_type_id_returns_active_review_type():
+    review = _make_review_type()
+    assert chart_review_note_type_id() == str(review.id)
+
+
+def test_chart_review_note_type_id_picks_lowest_rank():
+    _make_review_type(name="Second", rank=5)
+    first = _make_review_type(name="First", rank=1)
+    assert chart_review_note_type_id() == str(first.id)
+
+
+def test_chart_review_note_type_id_ignores_inactive_and_hidden():
+    _make_review_type(name="Inactive", is_active=False)
+    _make_review_type(name="Hidden", is_visible=False)
+    assert chart_review_note_type_id() is None
+
+
+def test_chart_review_note_type_id_ignores_other_categories():
+    from canvas_sdk.v1.data.note import NoteType, NoteTypeCategories
+
+    NoteType.objects.create(
+        category=NoteTypeCategories.ENCOUNTER,
+        name="Office Visit",
+        is_active=True,
+        is_visible=True,
+        rank=1,
+    )
+    assert chart_review_note_type_id() is None
+
+
+# --- default_practice_location_id ---
+
+def test_default_location_uses_provider_primary(make_staff):
+    loc = _make_location(full_name="Provider Home")
+    staff = make_staff()
+    staff.primary_practice_location = loc
+    staff.save()
+    assert default_practice_location_id(str(staff.id)) == str(loc.id)
+
+
+def test_default_location_falls_back_to_first_active(make_staff):
+    # The staff has no primary location, so the first active location is used.
+    active = _make_location(full_name="Active")
+    staff = make_staff()
+    assert default_practice_location_id(str(staff.id)) == str(active.id)
+
+
+def test_default_location_none_when_no_active_location(make_staff):
+    staff = make_staff()
+    _make_location(full_name="Closed", active=False)
+    assert default_practice_location_id(str(staff.id)) is None
+
+
+def test_default_location_unknown_staff_falls_back():
+    active = _make_location(full_name="Active")
+    assert default_practice_location_id("00000000-0000-0000-0000-000000000000") == str(active.id)


### PR DESCRIPTION
## Problem

In the Lab Favorites patient app, the **Insert into note** picker filtered notes only by *state* (unlocked). Messages and letters never lock, so they always appeared in the dropdown - even though a lab order cannot be staged into them.

## Change

- **Filter the picker** to unlocked **encounter** notes and already-open **chart review** notes (the two note categories a staged lab order belongs in). Messages, letters, inpatient, etc. are excluded.
- **Chart review fallback:** when the patient has no open note in those categories, the app offers to create a chart review note - acting user as provider, current datetime, the provider's default practice location (falling back to the first active location) - and stages the selected lab order(s) into it in one action via a self-assigned note UUID.
- **Refactor:** extracted the per-favorite staging into a shared `_stage_favorites` helper used by both the open-note insert and the chart review fallback, so validation stays identical.

## Notes

- Same `StaffSessionAuthMixin` auth and favorite-scoping as the existing routes; the new route fails closed (errors) when no chart review note type or active location is configured.
- Bumps plugin `0.2.0` -> `0.3.0`.

## Tests

147 passing, 100% coverage on plugin code. New tests cover the category filter, the new `CreateChartReviewAPI` route (success, all-skipped-no-note, missing note type/location, patient validation), and the note-creation helpers against the test DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)