### PR TITLE
questionnaire_scoring_dashboard: group trends by questionnaire code, remove date filter

### DIFF
--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/CANVAS_MANIFEST.json
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.157.0",
-    "plugin_version": "0.2.0",
+    "plugin_version": "0.2.1",
     "name": "questionnaire_scoring_dashboard",
     "description": "Patient-scoped dashboard of scored-questionnaire trends with per-graph insert into notes.",
     "components": {

--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/api/routes.py
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/api/routes.py
@@ -16,10 +16,7 @@ from questionnaire_scoring_dashboard.commands.scoring_trend import ScoringTrendC
 from questionnaire_scoring_dashboard.config import resolve_instrument
 from questionnaire_scoring_dashboard.data.notes import fetch_open_note_rows
 from questionnaire_scoring_dashboard.data.observations import fetch_survey_rows
-from questionnaire_scoring_dashboard.services.metrics import (
-    compute_metrics,
-    filter_by_range,
-)
+from questionnaire_scoring_dashboard.services.metrics import compute_metrics
 from questionnaire_scoring_dashboard.services.notes_select import choose_notes
 from questionnaire_scoring_dashboard.services.scoring import build_series
 from questionnaire_scoring_dashboard.services.svg_chart import (
@@ -41,16 +38,15 @@ def _max_for(label: str) -> int | None:
     return resolve_instrument(label).max_score
 
 
-def _build_payload(patient_id: str, start: str | None, end: str | None) -> dict:
-    """Series + metrics per instrument, filtered to [start, end]."""
+def _build_payload(patient_id: str) -> dict:
+    """Series + metrics per instrument (all available history)."""
     series = build_series(fetch_survey_rows(patient_id))
     today = date.today()
     payload: dict[str, dict] = {}
     for label, points in series.items():
-        ranged = filter_by_range(points, start, end)
         payload[label] = {
-            "series": ranged,
-            "metrics": compute_metrics(ranged, as_of=today),
+            "series": points,
+            "metrics": compute_metrics(points, as_of=today),
             "max_score": _max_for(label),
         }
     return payload
@@ -73,9 +69,7 @@ class ScoringDashboardAPI(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/data")
     def data(self) -> list[Response | Effect]:
         patient_id = self.request.query_params.get("patient", "")
-        start = self.request.query_params.get("start") or None
-        end = self.request.query_params.get("end") or None
-        payload = _build_payload(patient_id, start, end)
+        payload = _build_payload(patient_id)
         return [JSONResponse(payload, status_code=HTTPStatus.OK)]
 
     @api.get("/style.css")
@@ -118,10 +112,8 @@ class ScoringDashboardAPI(StaffSessionAuthMixin, SimpleAPI):
                 )
             ]
 
-        start = body.get("start") or None
-        end = body.get("end") or None
         series = build_series(fetch_survey_rows(patient_id))
-        points = filter_by_range(series.get(instrument, []), start, end)
+        points = series.get(instrument, [])
         metrics = compute_metrics(points, as_of=date.today())
         max_score = _max_for(instrument)
 
@@ -172,14 +164,12 @@ class ScoringDashboardAPI(StaffSessionAuthMixin, SimpleAPI):
                 )
             ]
 
-        start = body.get("start") or None
-        end = body.get("end") or None
         series = build_series(fetch_survey_rows(patient_id))
         today = date.today()
         rows: list[dict] = []
         svg_series: list[tuple[str, list[dict]]] = []
         for instrument in instruments:
-            points = filter_by_range(series.get(instrument, []), start, end)
+            points = series.get(instrument, [])
             if not points:
                 continue
             metrics = compute_metrics(points, as_of=today)

--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/data/observations.py
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/data/observations.py
@@ -16,12 +16,18 @@ def fetch_survey_rows(patient_id: str) -> list[dict]:
     Attaches each row's note date-of-service (`note_dos`) so the trend can date
     a score by when it was administered. Questionnaire-result observations often
     have no `effective_datetime`, so the note DOS is the reliable clinical date.
+
+    Also pulls the observation's coding `code` (`codings__code`) in the same
+    query (one LEFT JOIN, no N+1). The code is the version-stable questionnaire
+    identifier: when a questionnaire is edited, Canvas appends a "(vN)" suffix to
+    its name but leaves the code unchanged, so the scoring service groups on the
+    code to keep every version of an instrument on a single trend.
     """
     rows = list(
         Observation.objects.for_patient(patient_id)
         .filter(category="survey")
         .exclude(entered_in_error__isnull=False)
-        .values("note_id", "value", "effective_datetime", "created", "name")
+        .values("note_id", "value", "effective_datetime", "created", "name", "codings__code")
     )
     note_ids = {row["note_id"] for row in rows if row["note_id"]}
     dos_by_note: dict[int, object] = {}
@@ -34,4 +40,5 @@ def fetch_survey_rows(patient_id: str) -> list[dict]:
     for row in rows:
         dos = dos_by_note.get(row["note_id"])
         row["note_dos"] = dos.isoformat() if dos else None
+        row["code"] = row.get("codings__code")
     return rows

--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/services/metrics.py
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/services/metrics.py
@@ -11,23 +11,6 @@ from datetime import date
 import arrow
 
 
-def filter_by_range(
-    points: list[dict], start: str | None, end: str | None
-) -> list[dict]:
-    """Return points whose date is within [start, end] inclusive.
-
-    start/end are "YYYY-MM-DD" strings or None (unbounded).
-    """
-    result = []
-    for point in points:
-        if start is not None and point["date"] < start:
-            continue
-        if end is not None and point["date"] > end:
-            continue
-        result.append(point)
-    return result
-
-
 def compute_metrics(points: list[dict], as_of: date) -> dict:
     """Compute the four data-only metrics for a sorted point list.
 

--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/services/scoring.py
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/services/scoring.py
@@ -6,9 +6,36 @@ so it can be unit-tested without any database.
 
 from __future__ import annotations
 
+import re
+
 import arrow
 
-from questionnaire_scoring_dashboard.config import resolve_instrument
+from questionnaire_scoring_dashboard.config import Instrument, resolve_instrument
+
+# Canvas appends a "(vN)" suffix to a questionnaire's name each time it is
+# edited (e.g. "PHQ-2 (v28)"). The suffix is the only part of the name that
+# changes across versions, so we strip it to recover the stable instrument name.
+_VERSION_SUFFIX = re.compile(r"\s*\(v\d+\)\s*$")
+
+
+def _base_name(name: str) -> str:
+    """Strip Canvas's trailing version suffix: 'PHQ-2 (v28)' -> 'PHQ-2'."""
+    return _VERSION_SUFFIX.sub("", name).strip()
+
+
+def _resolve(base_name: str, code: str) -> Instrument:
+    """Resolve to a known Instrument by the version-stripped name, falling back
+    to the questionnaire coding when the name is unrecognized.
+
+    config.resolve_instrument returns a generic Instrument(name, None) when no
+    known instrument matches; a populated max_score marks a real match.
+    """
+    inst = resolve_instrument(base_name)
+    if inst.max_score is None and code:
+        by_code = resolve_instrument(code)
+        if by_code.max_score is not None:
+            return by_code
+    return inst
 
 
 def _row_date(row: dict) -> str:
@@ -32,19 +59,45 @@ def _to_float(value: str | None) -> float | None:
 
 
 def build_series(rows: list[dict]) -> dict[str, list[dict]]:
-    """Group rows by resolved instrument label, drop non-numeric values,
-    and sort each instrument's points ascending by date.
+    """Group scored rows into one trend per instrument, dropping non-numeric
+    values and sorting each instrument's points ascending by date.
+
+    Instruments are keyed by their questionnaire coding `code` (stable across
+    versions), so "PHQ-2" and "PHQ-2 (v28)" - which share a code - land on one
+    trend. Two guards keep the grouping honest:
+
+    - A code shared by more than one distinct instrument name is a generic
+      scoring code (e.g. several questionnaires all coded "default_score") and
+      must NOT collapse unrelated instruments together; those fall back to the
+      version-stripped name.
+    - A row with no coding falls back to its version-stripped name.
 
     Returns: {label: [{"date": "YYYY-MM-DD", "value": float}, ...]}
     """
-    series: dict[str, list[dict]] = {}
+    parsed: list[dict] = []
+    names_per_code: dict[str, set[str]] = {}
     for row in rows:
         value = _to_float(row.get("value"))
         if value is None:
             continue
-        label = resolve_instrument(row.get("name") or "").label
-        point = {"date": _row_date(row), "value": value}
-        series.setdefault(label, []).append(point)
+        base = _base_name(row.get("name") or "")
+        code = (row.get("code") or "").strip()
+        parsed.append(
+            {"code": code, "base": base, "point": {"date": _row_date(row), "value": value}}
+        )
+        if code:
+            names_per_code.setdefault(code, set()).add(base)
+
+    # A grouping key per row: the code when it uniquely identifies one
+    # instrument, otherwise the version-stripped name.
+    series: dict[str, list[dict]] = {}
+    for item in parsed:
+        code = item["code"]
+        if code and len(names_per_code[code]) == 1:
+            label = _resolve(item["base"], code).label
+        else:
+            label = _resolve(item["base"], "").label
+        series.setdefault(label, []).append(item["point"])
 
     # Sort by date and collapse to one point per date (an instrument can be
     # double-scored on the same day - e.g. a native instance score plus this

--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/templates/dashboard.html
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/templates/dashboard.html
@@ -24,15 +24,6 @@
         </div>
       </div>
       <div>
-        <div class="ctl-label">Date range</div>
-        <select class="dd-select" id="rangeSelect">
-          <option value="3">Last 3 months</option>
-          <option value="6">Last 6 months</option>
-          <option value="12" selected>Last 1 year</option>
-          <option value="0">All time</option>
-        </select>
-      </div>
-      <div>
         <div class="ctl-label">View</div>
         <div class="viewtog" id="viewtog">
           <span class="vbtn" data-view="compare">Compare</span>
@@ -67,16 +58,8 @@
   <script>
     const ALL_INSTRUMENTS = {{ instruments_json|safe }};
     const PATIENT_QS = new URLSearchParams(window.location.search).get('patient') || '';
-    const state = { selected: new Set(ALL_INSTRUMENTS.slice(0, 4)), months: 12, view: 'individual' };
+    const state = { selected: new Set(ALL_INSTRUMENTS.slice(0, 4)), view: 'individual' };
     let charts = {};
-
-    function rangeBounds() {
-      if (!state.months) return { start: '', end: '' };
-      const end = new Date();
-      const start = new Date(); start.setMonth(start.getMonth() - state.months);
-      const fmt = d => d.toISOString().slice(0, 10);
-      return { start: fmt(start), end: fmt(end) };
-    }
 
     function renderInst() {
       const panel = document.getElementById('instPanel'); panel.innerHTML = '';
@@ -139,8 +122,7 @@
 
     async function refresh() {
       renderInst();
-      const { start, end } = rangeBounds();
-      const qs = new URLSearchParams({ patient: PATIENT_QS, start, end });
+      const qs = new URLSearchParams({ patient: PATIENT_QS });
       const data = await fetch('data?' + qs.toString()).then(r => r.json());
       document.getElementById('empty').style.display = ALL_INSTRUMENTS.length ? 'none' : 'block';
       const names = [...state.selected].filter(n => data[n]);
@@ -186,9 +168,6 @@
       }
     });
 
-    document.getElementById('rangeSelect').onchange = e => {
-      state.months = +e.target.value; refresh();
-    };
     document.getElementById('viewtog').onclick = e => {
       if (!e.target.dataset.view) return;
       [...document.querySelectorAll('#viewtog .vbtn')].forEach(b => b.classList.remove('on'));
@@ -196,9 +175,7 @@
     };
     document.getElementById('clearBtn').onclick = () => {
       state.selected = new Set();
-      state.months = 12;
       state.view = 'individual';
-      document.getElementById('rangeSelect').value = '12';
       document.querySelectorAll('#viewtog .vbtn').forEach(b => b.classList.toggle('on', b.dataset.view === 'individual'));
       refresh();
     };
@@ -224,15 +201,14 @@
     };
     document.getElementById('pickCancel').onclick = () => document.getElementById('picker').style.display = 'none';
     document.getElementById('pickConfirm').onclick = async () => {
-      const { start, end } = rangeBounds();
       const note_uuid = document.getElementById('noteSelect').value;
       if (pendingCompare) {
         const instruments = [...state.selected];
         await fetch('insert-compare', { method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ patient: PATIENT_QS, instruments, start, end, note_uuid }) });
+          body: JSON.stringify({ patient: PATIENT_QS, instruments, note_uuid }) });
       } else {
         await fetch('insert', { method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ patient: PATIENT_QS, instrument: pendingInstrument, start, end, note_uuid }) });
+          body: JSON.stringify({ patient: PATIENT_QS, instrument: pendingInstrument, note_uuid }) });
       }
       document.getElementById('picker').style.display = 'none';
     };

--- a/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/templates/style.css
+++ b/extensions/questionnaire_scoring_dashboard/questionnaire_scoring_dashboard/templates/style.css
@@ -3,7 +3,7 @@
 html,body{margin:0;font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--ink);}
 html,body{height:100%;}
 body{overflow-y:auto;}
-.wrap{max-width:1180px;margin:0 auto;padding:18px 22px 40px;}
+.wrap{max-width:1180px;margin:0 auto;padding:18px 22px 72px;}
 .pagehead h1{font-size:22px;margin:0 0 4px;font-weight:600;}
 .note{font-size:12px;color:var(--faint);margin:0 0 16px;}
 .controls{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-bottom:18px;display:flex;flex-wrap:wrap;gap:18px;align-items:flex-end;}

--- a/extensions/questionnaire_scoring_dashboard/tests/data/test_observations.py
+++ b/extensions/questionnaire_scoring_dashboard/tests/data/test_observations.py
@@ -12,7 +12,8 @@ def test_fetch_survey_rows_filters_and_attaches_note_dos(mock_obs, mock_note):
     qs.filter.return_value = qs
     qs.exclude.return_value = qs
     qs.values.return_value = [
-        {"note_id": 1, "value": "16", "effective_datetime": None, "created": None, "name": "PHQ-9"}
+        {"note_id": 1, "value": "16", "effective_datetime": None, "created": None,
+         "name": "PHQ-9", "codings__code": "44261-6"}
     ]
     dos = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
     mock_note.objects.filter.return_value.values_list.return_value = [(1, dos)]
@@ -22,8 +23,13 @@ def test_fetch_survey_rows_filters_and_attaches_note_dos(mock_obs, mock_note):
     mock_obs.objects.for_patient.assert_called_once_with("patient-123")
     qs.filter.assert_called_once_with(category="survey")
     qs.exclude.assert_called_once_with(entered_in_error__isnull=False)
+    # The coding code is pulled in the same query (one LEFT JOIN, no N+1).
+    qs.values.assert_called_once_with(
+        "note_id", "value", "effective_datetime", "created", "name", "codings__code"
+    )
     mock_note.objects.filter.assert_called_once_with(dbid__in={1})
     assert rows[0]["note_dos"] == dos.isoformat()
+    assert rows[0]["code"] == "44261-6"
 
 
 @patch("questionnaire_scoring_dashboard.data.observations.Note")
@@ -34,9 +40,11 @@ def test_fetch_survey_rows_handles_no_note(mock_obs, mock_note):
     qs.filter.return_value = qs
     qs.exclude.return_value = qs
     qs.values.return_value = [
-        {"note_id": None, "value": "5", "effective_datetime": None, "created": None, "name": "AUDIT"}
+        {"note_id": None, "value": "5", "effective_datetime": None, "created": None,
+         "name": "AUDIT", "codings__code": None}
     ]
 
     rows = fetch_survey_rows("p1")
     assert rows[0]["note_dos"] is None
+    assert rows[0]["code"] is None
     mock_note.objects.filter.assert_not_called()

--- a/extensions/questionnaire_scoring_dashboard/tests/services/test_metrics.py
+++ b/extensions/questionnaire_scoring_dashboard/tests/services/test_metrics.py
@@ -1,24 +1,10 @@
 from datetime import date
 
-from questionnaire_scoring_dashboard.services.metrics import (
-    compute_metrics,
-    filter_by_range,
-)
+from questionnaire_scoring_dashboard.services.metrics import compute_metrics
 
 
 def _pts(*pairs):
     return [{"date": d, "value": v} for d, v in pairs]
-
-
-def test_filter_by_range_inclusive_bounds():
-    pts = _pts(("2026-01-01", 1), ("2026-02-01", 2), ("2026-03-01", 3))
-    out = filter_by_range(pts, "2026-01-15", "2026-02-15")
-    assert [p["value"] for p in out] == [2]
-
-
-def test_filter_by_range_none_bounds_returns_all():
-    pts = _pts(("2026-01-01", 1), ("2026-02-01", 2))
-    assert filter_by_range(pts, None, None) == pts
 
 
 def test_compute_metrics_full():

--- a/extensions/questionnaire_scoring_dashboard/tests/services/test_scoring.py
+++ b/extensions/questionnaire_scoring_dashboard/tests/services/test_scoring.py
@@ -1,13 +1,14 @@
 from questionnaire_scoring_dashboard.services.scoring import build_series
 
 
-def _row(name, value, eff=None, created="2026-01-01T00:00:00+00:00", note_id=None):
+def _row(name, value, eff=None, created="2026-01-01T00:00:00+00:00", note_id=None, code=None):
     return {
         "name": name,
         "value": value,
         "effective_datetime": eff,
         "created": created,
         "note_id": note_id,
+        "code": code,
     }
 
 
@@ -75,5 +76,46 @@ def test_build_series_dedupes_one_point_per_date():
 def test_build_series_resolves_loinc_code_named_observation():
     # If a scored observation is named by its LOINC code, it still maps to the instrument.
     rows = [_row("44249-1", "12", eff="2026-01-01T00:00:00+00:00")]
+    series = build_series(rows)
+    assert "PHQ-9" in series
+
+
+def test_build_series_merges_versioned_questionnaire_names():
+    # When a questionnaire is edited, Canvas appends "(vN)" to the name but keeps
+    # the code. Both versions must collapse onto one trend, not split into two.
+    rows = [
+        _row("PHQ-2", "5", eff="2026-01-01T00:00:00+00:00", code="55758-7"),
+        _row("PHQ-2 (v28)", "2", eff="2026-02-01T00:00:00+00:00", code="55758-7"),
+    ]
+    series = build_series(rows)
+    assert list(series.keys()) == ["PHQ-2"]
+    assert [p["value"] for p in series["PHQ-2"]] == [5.0, 2.0]
+
+
+def test_build_series_merges_versions_when_name_only_differs_by_suffix():
+    # Even with no coding, the version suffix alone is stripped so versions merge.
+    rows = [
+        _row("Custom Scale", "1", eff="2026-01-01T00:00:00+00:00"),
+        _row("Custom Scale (v3)", "2", eff="2026-02-01T00:00:00+00:00"),
+    ]
+    series = build_series(rows)
+    assert list(series.keys()) == ["Custom Scale"]
+    assert len(series["Custom Scale"]) == 2
+
+
+def test_build_series_keeps_instruments_sharing_a_generic_code_separate():
+    # Some questionnaires share a generic scoring code (e.g. "default_score").
+    # A shared code must NOT merge two distinct instruments into one trend.
+    rows = [
+        _row("Falls Risk Assessment", "80", eff="2026-01-01T00:00:00+00:00", code="default_score"),
+        _row("Insomnia Severity Index", "12", eff="2026-01-01T00:00:00+00:00", code="default_score"),
+    ]
+    series = build_series(rows)
+    assert set(series.keys()) == {"Falls Risk Assessment", "Insomnia Severity Index"}
+
+
+def test_build_series_resolves_label_by_code_when_name_unknown():
+    # Name is unrecognized but the coding maps to a known instrument's max score.
+    rows = [_row("Local depression form", "12", eff="2026-01-01T00:00:00+00:00", code="44249-1")]
     series = build_series(rows)
     assert "PHQ-9" in series


### PR DESCRIPTION
## What

Two fixes from live testing of the scoring dashboard.

### 1. Versioned questionnaires split one instrument into multiple trends
When a questionnaire is edited, Canvas appends a `(vN)` suffix to its name but
leaves the coding unchanged. The dashboard grouped trends by observation **name**,
so `PHQ-2` and `PHQ-2 (v28)` showed as two dropdown entries and two graphs.

Trends are now grouped by the questionnaire coding **code** (stable across
versions), per the repo guidance to look up questionnaires by code, not name.
Two guards keep the grouping correct:
- A code shared by more than one distinct instrument name (e.g. a generic
  `default_score` used by both Falls Risk Assessment and Insomnia Severity Index)
  falls back to the version-stripped name, so unrelated instruments are not merged.
- An observation with no coding falls back to its version-stripped name.

The coding `system` string is ignored, since the same code can be stored as both
`http://loinc.org` and `LOINC`.

### 2. Date-range filter made graphs look empty
The filter defaulted to "Last 1 year", which excluded older history, so graphs
appeared empty until "All time" was selected. The date-range control is removed;
the dashboard now always shows full history. The questionnaire selector and the
Compare/Individual toggle are unchanged. Bottom padding was increased so the last
chart row clears the viewport.

## How it was verified
- 46 unit tests pass, 100% line and branch coverage.
- mypy clean (no new errors).
- Runner sandbox pre-deploy checks clean.
- Grouping logic run against real instance data: every version of an instrument
  collapses onto one trend, and instruments sharing a generic scoring code stay
  separate.

## Files
- `data/observations.py` - fetch the coding code in the existing query (one LEFT JOIN, no N+1)
- `services/scoring.py` - group by code with version-strip + guards
- `services/metrics.py`, `api/routes.py`, `templates/dashboard.html` - remove the date filter
- `templates/style.css` - bottom padding
- `CANVAS_MANIFEST.json` - 0.2.0 -> 0.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
