### PR TITLE
Fix scheduling-with-rooms: honor recurrence end date + stop duplicate calendars

### DIFF
--- a/extensions/scheduling-with-rooms/scheduling_with_rooms/api/calendar.py
+++ b/extensions/scheduling-with-rooms/scheduling_with_rooms/api/calendar.py
@@ -7,6 +7,9 @@ from canvas_sdk.effects.calendar import CalendarType
 from canvas_sdk.effects.simple_api import Response
 from canvas_sdk.handlers.simple_api import SimpleAPIRoute, StaffSessionAuthMixin
 from canvas_sdk.v1.data import Calendar
+from django.db.models import Q
+
+from scheduling_with_rooms.utils.calendar_availability import parse_calendar_title
 
 
 def _json_response(body: dict, status: int) -> Response:
@@ -16,6 +19,45 @@ def _json_response(body: dict, status: int) -> Response:
         status_code=status,
         content_type="application/json",
     )
+
+
+def _existing_calendar_id(
+    provider: str | None,
+    calendar_type: CalendarType,
+    location_name: str | None,
+) -> str | None:
+    """Return the id of an existing calendar for this staff + type + location.
+
+    Binds on the staff UUID embedded in the calendar ``description`` plus the
+    type and location parsed from the title — the same resilient lookup the
+    scheduler uses (``_staff_calendars``). The previous exact-title match broke
+    whenever the staff's display name in the title differed from the posted
+    ``providerName`` (e.g. a credential suffix like "MD"), so the retrieve
+    always missed and a brand-new calendar was minted on every call — that's
+    what produced ~50 duplicate "John Harris MD: Admin" calendars.
+
+    Returns the highest-pk match for determinism when duplicates already exist,
+    or ``None`` when nothing matches (caller falls back / creates).
+    """
+    if not provider:
+        return None
+
+    pid = str(provider)
+    pid_hex = pid.replace("-", "")
+    type_str = str(calendar_type)
+    target_loc = (location_name or "").strip().lower()
+
+    candidates = Calendar.objects.filter(
+        Q(description__icontains=pid) | Q(description__icontains=pid_hex),
+        title__icontains=f": {type_str}",
+    ).order_by("pk")
+
+    match_id: str | None = None
+    for cal in candidates:
+        _, _, cal_location = parse_calendar_title(cal.title)
+        if (cal_location or "").strip().lower() == target_loc:
+            match_id = str(cal.id)
+    return match_id
 
 
 class CalendarAPI(StaffSessionAuthMixin, SimpleAPIRoute):
@@ -39,15 +81,20 @@ class CalendarAPI(StaffSessionAuthMixin, SimpleAPIRoute):
         elif type == "Admin":
             calendar_type = CalendarType.Administrative
 
-        calendar_id = (
-            Calendar.objects.for_calendar_name(
-                provider_name=provider_name,
-                calendar_type=calendar_type,
-                location=location_name if location_name else None,
+        # Resilient lookup by staff UUID + type + location (survives display-name
+        # formatting differences). Fall back to the legacy exact-title match for
+        # calendars created before descriptions carried the staff UUID.
+        calendar_id = _existing_calendar_id(provider, calendar_type, location_name)
+        if not calendar_id:
+            calendar_id = (
+                Calendar.objects.for_calendar_name(
+                    provider_name=provider_name,
+                    calendar_type=calendar_type,
+                    location=location_name if location_name else None,
+                )
+                .values_list("id", flat=True)
+                .last()
             )
-            .values_list("id", flat=True)
-            .last()
-        )
 
         if calendar_id:
             return [_json_response({"calendarId": str(calendar_id)}, 200)]

--- a/extensions/scheduling-with-rooms/scheduling_with_rooms/utils/calendar_availability.py
+++ b/extensions/scheduling-with-rooms/scheduling_with_rooms/utils/calendar_availability.py
@@ -58,10 +58,18 @@ def event_occurs_on_date(event: Event, target_date: datetime.date) -> bool:
     if target_date < event.starts_at.date():
         return False
 
+    # Recurrence end date. Canvas stores this in the separate
+    # ``recurrence_ends_at`` column, NOT as an UNTIL= inside the RRULE string
+    # (the rule is often just "FREQ=DAILY"). Without honoring this column a
+    # time-bounded block — e.g. an "Out of Office" that ends June 6 — recurs
+    # forever and silently zeroes out availability for every later date.
+    if event.recurrence_ends_at and target_date > event.recurrence_ends_at.date():
+        return False
+
     rule = _parse_rrule(event.recurrence)
     freq = rule.get("FREQ", "")
 
-    # UNTIL check.
+    # UNTIL check (when the end date is embedded in the RRULE string instead).
     until_str = rule.get("UNTIL")
     if until_str:
         try:
@@ -81,14 +89,21 @@ def event_occurs_on_date(event: Event, target_date: datetime.date) -> bool:
 
     if freq == "WEEKLY":
         byday = rule.get("BYDAY", "")
-        if byday:
-            allowed_days = {
-                _DAY_MAP[d.strip()]
-                for d in byday.split(",")
-                if d.strip() in _DAY_MAP
-            }
-            if target_date.weekday() not in allowed_days:
-                return False
+        allowed_days = {
+            _DAY_MAP[d.strip()]
+            for d in byday.split(",")
+            if d.strip() in _DAY_MAP
+        }
+        # A FREQ=WEEKLY rule with no (parseable) BYDAY recurs on the same
+        # weekday as the event's start — RFC 5545 DTSTART semantics. The SDK
+        # only writes BYDAY when recurrence_days is set, so a weekly event
+        # created from just a start datetime has none. Without this fallback
+        # the rule matches every day of the week, so a Tue/Thu "Out of Office"
+        # block silently zeroed out Mon/Wed/Fri availability too.
+        if not allowed_days:
+            allowed_days = {event.starts_at.weekday()}
+        if target_date.weekday() not in allowed_days:
+            return False
 
         if interval > 1:
             weeks_diff = (target_date - event.starts_at.date()).days // 7
@@ -366,6 +381,12 @@ def get_blocking_calendar_events(
         tz = ZoneInfo("UTC")
 
     blocks: list[tuple[datetime.datetime, datetime.datetime]] = []
+    # Track the source calendar/event for each block so the log can pinpoint
+    # which admin calendar is zeroing out availability (a real admin block vs.
+    # a misclassified Clinic calendar).
+    block_sources: list[
+        tuple[datetime.datetime, datetime.datetime, str, Any, Any, str]
+    ] = []
     # See note in get_availability_windows: keyed on cal.pk, not cal.id.
     events_by_cal: dict = {}
     if admin_calendars:
@@ -373,21 +394,39 @@ def get_blocking_calendar_events(
             calendar__in=admin_calendars, is_cancelled=False
         ):
             events_by_cal.setdefault(ev.calendar_id, []).append(ev)
+    log.info(
+        "blocking_events: provider=%s (%s) matched %d admin calendar(s): %s",
+        provider_id,
+        staff_name,
+        len(admin_calendars),
+        [(str(c.id), c.title) for c in admin_calendars],
+    )
     for cal in admin_calendars:
         for event in events_by_cal.get(cal.pk, []):
             if event_occurs_on_date(event, date_obj):
                 window = _event_window_on_date(event, date_obj, tz)
                 if window:
                     blocks.append(window)
+                    block_sources.append(
+                        (window[0], window[1], cal.title, cal.id, event.id, event.recurrence or "")
+                    )
 
     blocks.sort(key=lambda w: w[0])
+    block_sources.sort(key=lambda b: b[0])
     log.info(
         "blocking_events: provider=%s (%s), date=%s, %d admin blocks: %s",
         provider_id,
         staff_name,
         target_date,
         len(blocks),
-        [(b[0].strftime("%H:%M"), b[1].strftime("%H:%M")) for b in blocks],
+        [
+            (
+                b[0].strftime("%H:%M"),
+                b[1].strftime("%H:%M"),
+                "calendar=%r calendar_id=%s event=%s rrule=%r" % (b[2], b[3], b[4], b[5]),
+            )
+            for b in block_sources
+        ],
     )
     return blocks
 

--- a/extensions/scheduling-with-rooms/tests/api/test_calendar.py
+++ b/extensions/scheduling-with-rooms/tests/api/test_calendar.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import MagicMock, patch
 
-from scheduling_with_rooms.api.calendar import CalendarAPI, _json_response
+from canvas_sdk.effects.calendar import CalendarType
+
+from scheduling_with_rooms.api.calendar import (
+    CalendarAPI,
+    _existing_calendar_id,
+    _json_response,
+)
 
 
 def _handler(body=None):
@@ -14,13 +20,18 @@ def _handler(body=None):
     return h
 
 
+def _no_description_match(mock_cal):
+    """Make the description-based lookup return no candidates."""
+    mock_cal.objects.filter.return_value.order_by.return_value = []
+
+
 def test_json_response_returns_response_with_status():
     resp = _json_response({"hi": "there"}, 200)
     # Status was applied
     assert resp.status_code == 200
 
 
-def test_post_returns_existing_calendar():
+def test_post_returns_existing_calendar_via_legacy_title():
     h = _handler({
         "provider": "prov-1",
         "providerName": "Bob",
@@ -29,12 +40,39 @@ def test_post_returns_existing_calendar():
         "type": "Clinic",
     })
 
-    with patch(
-        "scheduling_with_rooms.api.calendar.Calendar"
-    ) as mock_cal:
+    with patch("scheduling_with_rooms.api.calendar.Calendar") as mock_cal:
+        _no_description_match(mock_cal)
         mock_cal.objects.for_calendar_name.return_value.values_list.return_value.last.return_value = "existing-id"
         result = h.post()
         assert len(result) == 1
+
+
+def test_post_returns_existing_calendar_via_description_uuid():
+    # The description-UUID lookup matches even when the stored title carries a
+    # credential suffix the posted providerName lacks — so no duplicate is made.
+    h = _handler({
+        "provider": "staff-uuid-123",
+        "providerName": "John Harris",  # title says "John Harris MD"
+        "location": "loc-1",
+        "locationName": "Transformative Wellness",
+        "type": "Admin",
+    })
+
+    existing = MagicMock()
+    existing.id = "existing-admin-cal"
+    existing.title = "John Harris MD: Admin: Transformative Wellness"
+    existing.description = "staff-uuid-123"
+
+    with patch("scheduling_with_rooms.api.calendar.Calendar") as mock_cal, patch(
+        "scheduling_with_rooms.api.calendar.CalendarEffect"
+    ) as mock_effect:
+        mock_cal.objects.filter.return_value.order_by.return_value = [existing]
+        result = h.post()
+        # Existing calendar reused — only the JSON response, no create effect.
+        assert len(result) == 1
+        mock_effect.assert_not_called()
+        # Legacy exact-title lookup never needed.
+        mock_cal.objects.for_calendar_name.assert_not_called()
 
 
 def test_post_creates_new_calendar_clinic():
@@ -52,6 +90,7 @@ def test_post_creates_new_calendar_clinic():
     ) as mock_cal, patch(
         "scheduling_with_rooms.api.calendar.CalendarEffect"
     ) as mock_effect:
+        _no_description_match(mock_cal)
         mock_cal.objects.for_calendar_name.return_value.values_list.return_value.last.return_value = None
         mock_effect.return_value.create.return_value = MagicMock(name="effect")
         result = h.post()
@@ -70,6 +109,7 @@ def test_post_creates_new_calendar_admin():
     ) as mock_cal, patch(
         "scheduling_with_rooms.api.calendar.CalendarEffect"
     ) as mock_effect:
+        _no_description_match(mock_cal)
         mock_cal.objects.for_calendar_name.return_value.values_list.return_value.last.return_value = None
         mock_effect.return_value.create.return_value = MagicMock(name="effect")
         result = h.post()
@@ -88,7 +128,43 @@ def test_post_unknown_type_defaults_to_clinic():
     ) as mock_cal, patch(
         "scheduling_with_rooms.api.calendar.CalendarEffect"
     ) as mock_effect:
+        _no_description_match(mock_cal)
         mock_cal.objects.for_calendar_name.return_value.values_list.return_value.last.return_value = None
         mock_effect.return_value.create.return_value = MagicMock(name="effect")
         result = h.post()
         assert len(result) == 2
+
+
+# _existing_calendar_id --------------------------------------------------
+
+def test_existing_calendar_id_no_provider_returns_none():
+    assert _existing_calendar_id(None, CalendarType.Administrative, "Loc") is None
+
+
+def test_existing_calendar_id_matches_on_location():
+    cal_match = MagicMock()
+    cal_match.id = "match"
+    cal_match.title = "John Harris MD: Admin: Transformative Wellness"
+    cal_other = MagicMock()
+    cal_other.id = "other-loc"
+    cal_other.title = "John Harris MD: Admin: Some Other Clinic"
+
+    with patch("scheduling_with_rooms.api.calendar.Calendar") as mock_cal:
+        mock_cal.objects.filter.return_value.order_by.return_value = [cal_other, cal_match]
+        result = _existing_calendar_id(
+            "staff-uuid", CalendarType.Administrative, "Transformative Wellness"
+        )
+        assert result == "match"
+
+
+def test_existing_calendar_id_no_location_match_returns_none():
+    cal = MagicMock()
+    cal.id = "wrong-loc"
+    cal.title = "John Harris MD: Admin: Other Location"
+
+    with patch("scheduling_with_rooms.api.calendar.Calendar") as mock_cal:
+        mock_cal.objects.filter.return_value.order_by.return_value = [cal]
+        result = _existing_calendar_id(
+            "staff-uuid", CalendarType.Administrative, "Transformative Wellness"
+        )
+        assert result is None

--- a/extensions/scheduling-with-rooms/tests/utils/test_calendar_availability.py
+++ b/extensions/scheduling-with-rooms/tests/utils/test_calendar_availability.py
@@ -70,41 +70,41 @@ def test_parse_rrule_empty_parts_skipped():
 # event_occurs_on_date ---------------------------------------------------
 
 def test_event_occurs_on_date_no_starts_at():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = None
     assert event_occurs_on_date(event, datetime.date(2026, 5, 7)) is False
 
 
 def test_event_occurs_on_date_no_recurrence_match():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 7, 9, 0)
     event.recurrence = None
     assert event_occurs_on_date(event, datetime.date(2026, 5, 7)) is True
 
 
 def test_event_occurs_on_date_no_recurrence_no_match():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 7, 9, 0)
     event.recurrence = None
     assert event_occurs_on_date(event, datetime.date(2026, 5, 8)) is False
 
 
 def test_event_occurs_on_date_target_before_start():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 7, 9, 0)
     event.recurrence = "FREQ=DAILY"
     assert event_occurs_on_date(event, datetime.date(2026, 5, 1)) is False
 
 
 def test_event_occurs_on_date_until_passed():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 1, 9, 0)
     event.recurrence = "FREQ=DAILY;UNTIL=20260505T235959"
     assert event_occurs_on_date(event, datetime.date(2026, 5, 10)) is False
 
 
 def test_event_occurs_on_date_until_invalid_continues():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 1, 9, 0)
     event.recurrence = "FREQ=DAILY;UNTIL=BAD"
     # Should still match daily.
@@ -112,14 +112,14 @@ def test_event_occurs_on_date_until_invalid_continues():
 
 
 def test_event_occurs_on_date_daily_interval_one():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 1, 9, 0)
     event.recurrence = "FREQ=DAILY"
     assert event_occurs_on_date(event, datetime.date(2026, 5, 5)) is True
 
 
 def test_event_occurs_on_date_daily_interval_three_match():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 1, 9, 0)
     event.recurrence = "FREQ=DAILY;INTERVAL=3"
     # Days 1, 4, 7, ...
@@ -128,7 +128,7 @@ def test_event_occurs_on_date_daily_interval_three_match():
 
 
 def test_event_occurs_on_date_weekly_byday_match():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     # 2026-05-04 is a Monday.
     event.starts_at = datetime.datetime(2026, 5, 4, 9, 0)
     event.recurrence = "FREQ=WEEKLY;BYDAY=MO,WE"
@@ -138,15 +138,25 @@ def test_event_occurs_on_date_weekly_byday_match():
     assert event_occurs_on_date(event, datetime.date(2026, 5, 5)) is False
 
 
-def test_event_occurs_on_date_weekly_no_byday_always_matches():
-    event = MagicMock()
+def test_event_occurs_on_date_weekly_no_byday_uses_start_weekday():
+    # A FREQ=WEEKLY rule with no BYDAY must recur only on the event's start
+    # weekday (RFC 5545 DTSTART semantics), not every day of the week. The SDK
+    # omits BYDAY when an event is created without explicit recurrence_days, so
+    # this is the common case for "Out of Office" blocks created from a start
+    # datetime — matching every day silently zeroed out other days' slots.
+    event = MagicMock(recurrence_ends_at=None)
+    # 2026-05-04 is a Monday.
     event.starts_at = datetime.datetime(2026, 5, 4, 9, 0)
     event.recurrence = "FREQ=WEEKLY"
+    # Following Monday — matches the start weekday.
     assert event_occurs_on_date(event, datetime.date(2026, 5, 11)) is True
+    # Tuesday / Wednesday — different weekday, must NOT match.
+    assert event_occurs_on_date(event, datetime.date(2026, 5, 5)) is False
+    assert event_occurs_on_date(event, datetime.date(2026, 5, 6)) is False
 
 
 def test_event_occurs_on_date_weekly_interval_skip():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 4, 9, 0)
     event.recurrence = "FREQ=WEEKLY;INTERVAL=2"
     # 1 week later (skipped) — should not match
@@ -156,23 +166,46 @@ def test_event_occurs_on_date_weekly_interval_skip():
 
 
 def test_event_occurs_on_date_unsupported_freq():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 1, 9, 0)
     event.recurrence = "FREQ=YEARLY"
     assert event_occurs_on_date(event, datetime.date(2027, 5, 1)) is False
 
 
+def test_event_occurs_on_date_recurrence_ends_at_stops_series():
+    # Canvas stores the recurrence end in the recurrence_ends_at column, not as
+    # an UNTIL inside the RRULE. A bounded "Out of Office" (ends June 6) must
+    # NOT recur past that date — otherwise it zeroes out availability forever.
+    event = MagicMock()
+    event.starts_at = datetime.datetime(2026, 6, 1, 8, 0)
+    event.recurrence = "RRULE:FREQ=DAILY"
+    event.recurrence_ends_at = datetime.datetime(2026, 6, 6, 4, 59)
+    # Within the window — still blocks.
+    assert event_occurs_on_date(event, datetime.date(2026, 6, 3)) is True
+    # After the recurrence end — must not block.
+    assert event_occurs_on_date(event, datetime.date(2026, 6, 15)) is False
+
+
+def test_event_occurs_on_date_no_recurrence_ends_at_runs_indefinitely():
+    # When recurrence_ends_at is unset, a daily rule keeps recurring.
+    event = MagicMock()
+    event.starts_at = datetime.datetime(2026, 6, 1, 8, 0)
+    event.recurrence = "RRULE:FREQ=DAILY"
+    event.recurrence_ends_at = None
+    assert event_occurs_on_date(event, datetime.date(2026, 6, 15)) is True
+
+
 # _event_window_on_date --------------------------------------------------
 
 def test_event_window_no_dates():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = None
     event.ends_at = None
     assert _event_window_on_date(event, datetime.date(2026, 5, 7), ZoneInfo("UTC")) is None
 
 
 def test_event_window_normal_day():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 4, 14, 0, tzinfo=datetime.timezone.utc)
     event.ends_at = datetime.datetime(2026, 5, 4, 18, 0, tzinfo=datetime.timezone.utc)
     win = _event_window_on_date(event, datetime.date(2026, 5, 7), ZoneInfo("UTC"))
@@ -182,7 +215,7 @@ def test_event_window_normal_day():
 
 
 def test_event_window_spans_midnight_caps():
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     # 23:00 local Monday → 02:00 local Tuesday
     event.starts_at = datetime.datetime(2026, 5, 4, 23, 0, tzinfo=datetime.timezone.utc)
     event.ends_at = datetime.datetime(2026, 5, 5, 2, 0, tzinfo=datetime.timezone.utc)
@@ -193,7 +226,7 @@ def test_event_window_spans_midnight_caps():
 
 def test_event_window_end_before_start_returns_none():
     # Same-day event with end <= start.
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.starts_at = datetime.datetime(2026, 5, 4, 18, 0, tzinfo=datetime.timezone.utc)
     event.ends_at = datetime.datetime(2026, 5, 4, 18, 0, tzinfo=datetime.timezone.utc)
     win = _event_window_on_date(event, datetime.date(2026, 5, 7), ZoneInfo("UTC"))
@@ -219,7 +252,7 @@ def test_get_availability_windows_keys_events_by_pk_not_id():
     cal.title = "Bob: Clinic: Loc"
     cal.timezone = "UTC"
 
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.calendar_id = 99  # FK column = pk
     event.starts_at = datetime.datetime(2026, 5, 7, 9, 0, tzinfo=datetime.timezone.utc)
     event.ends_at = datetime.datetime(2026, 5, 7, 17, 0, tzinfo=datetime.timezone.utc)
@@ -405,7 +438,7 @@ def test_get_availability_windows_full_path():
     cal.title = "Bob: Clinic: Loc"
     cal.timezone = "UTC"
 
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.calendar_id = 42  # FK column stores the pk
     event.starts_at = datetime.datetime(2026, 5, 7, 9, 0, tzinfo=datetime.timezone.utc)
     event.ends_at = datetime.datetime(2026, 5, 7, 17, 0, tzinfo=datetime.timezone.utc)
@@ -535,7 +568,7 @@ def test_get_blocking_calendar_events_returns_blocks():
     cal.id = "cal-1"
     cal.title = "Bob: admin"
 
-    event = MagicMock()
+    event = MagicMock(recurrence_ends_at=None)
     event.calendar_id = 7
     event.starts_at = datetime.datetime(2026, 5, 7, 12, 0, tzinfo=datetime.timezone.utc)
     event.ends_at = datetime.datetime(2026, 5, 7, 13, 0, tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
## Problem

`scheduling_with_rooms` was returning **zero availability** for providers (John Harris, Tina Cunningham) whose calendars were actually correct. The home-app calendar showed them available; the scheduler showed nothing.

Root cause was a recurrence-expansion bug, surfaced via added diagnostics. Two related correctness bugs and one calendar-duplication bug are fixed here.

## Changes

### 1. Honor `Event.recurrence_ends_at` — the outage fix
`event_occurs_on_date` only checked for an `UNTIL=` embedded in the RRULE string. But Canvas stores the recurrence end in the separate `recurrence_ends_at` column, and the rule is often just `FREQ=DAILY`. So a time-bounded "Out of Office" block (e.g. ends June 6) recurred **forever**, zeroing out every later date. The home app reads the column; the scheduler didn't — now it does.

### 2. Weekly-without-BYDAY uses the start weekday (defensive)
A `FREQ=WEEKLY` rule with no parseable `BYDAY` now recurs only on the event's start weekday (RFC 5545 DTSTART semantics) instead of every day. The SDK only writes `BYDAY` when `recurrence_days` is set, so a weekly block created from just a start datetime previously matched all 7 days.

### 3. `CalendarAPI` retrieve no longer mints duplicate calendars
The create-or-retrieve used an **exact title** match built from the posted `providerName`. When the stored title carried a credential suffix the name lacked (`John Harris MD` vs `John Harris`), the retrieve always missed and created a new calendar on every call — producing ~50 duplicate `John Harris MD: Admin` calendars. Retrieve now binds on the **staff UUID in `description` + type + parsed location** (the same key the scheduler uses), with the legacy exact-title lookup kept as a fallback.

> Note: the SDK `Calendar` effect has no `delete()`, so cleaning up the existing empty duplicates is a separate server-side task. This stops new ones.

### 4. Diagnostics
`get_blocking_calendar_events` now logs each block's source calendar id/title, event id, and rrule, plus the set of matched admin calendars — what made this triageable from logs.

## Testing
- Full suite: **321 passed**.
- New coverage: `recurrence_ends_at` gate, weekly-without-BYDAY start-weekday behavior, and the description-UUID calendar match (incl. legacy fallback + location disambiguation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)