### PR TITLE
provider_availability: add CSV bulk import for availability, blocks, and holds

### DIFF
--- a/extensions/provider_availability/provider_availability/CANVAS_MANIFEST.json
+++ b/extensions/provider_availability/provider_availability/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.107.0",
-    "plugin_version": "0.16.1",
+    "plugin_version": "0.17.2",
     "name": "provider_availability",
     "description": "Provider availability engine with rule-based scheduling, real-time slot calculation, and admin configuration UI",
     "components": {
@@ -12,6 +12,10 @@
             {
                 "class": "provider_availability.api.provision_api:ProvisionAPI",
                 "description": "API key-authenticated endpoint for provisioning provider calendars"
+            },
+            {
+                "class": "provider_availability.api.csv_import_api:CSVImportAPI",
+                "description": "Staff-session API for bulk availability import from a CSV file"
             },
             {
                 "class": "provider_availability.cron.cache_refresh:CacheRefreshTask",

--- a/extensions/provider_availability/provider_availability/README.md
+++ b/extensions/provider_availability/provider_availability/README.md
@@ -1,56 +1,125 @@
 provider-availability
 =====================
 
-## Description
+## What it does
 
-Provider availability engine with rule-based scheduling, real-time slot calculation, and an admin configuration UI. Manages open appointment slots across providers, locations, and visit types - including one-off blocks, recurring blocks with hold types, appointment buffers, and timezone-aware calendar sync.
+Provider availability engine for Canvas with rule-based scheduling, real-time slot calculation, and an admin configuration UI. It manages open appointment slots across providers, locations, and visit types - including one-off blocks, recurring blocks with same-day/next-day hold types, appointment buffers, and timezone-aware calendar sync. Availability, blocks, and holds can be configured one at a time in the admin UI or bulk-loaded for many staff at once from a CSV.
 
 ## Problem it solves
 
-Keeping each provider's bookable hours correct across locations, visit types, recurring time off, and appointment buffers usually means hand-editing calendars and re-checking for conflicts every time something changes. Mistakes show up as double-bookings or slots that should have been blocked. This plugin computes bookable slots from each provider's rules and existing appointments, syncs those rules to Canvas calendar events, and adds buffer time automatically when appointments are booked, rescheduled, or canceled - so scheduling staff set the rules once instead of maintaining calendars by hand.
+Defining when each provider is bookable - and keeping the Canvas calendar in sync as schedules change - is tedious to do by hand, especially across multiple locations, visit types, and many providers. Practices also need to block time (PTO, holidays, admin time) and reserve same-day or next-day slots without hand-editing calendars. This plugin centralizes all of that: a single admin panel to manage rules/blocks/holds, automatic Clinic/Administrative calendar sync, and a CSV bulk import to stand up or update an entire practice's schedule in one action.
+
+## Who it's for
+
+- **Practice administrators and schedulers** who manage provider open hours, blocked time, and same/next-day holds across locations and visit types.
+- **Implementation teams** standing up a new Canvas instance who need to load many providers' (and non-provider staff's) schedules quickly via CSV rather than one rule at a time.
 
 ## How to install
 
-```
-canvas install provider_availability
+Install the plugin with the Canvas CLI, targeting your instance:
+
+```bash
+uv run canvas install provider_availability --host <your-host>
 ```
 
-Set the `simpleapi-api-key` and `allowed-staff-keys` secrets before use (see Configuration).
+The core admin UI and calculation engine work with no secrets. To enable the API-key-authenticated provisioning endpoints and restrict who can edit availability, set the secrets below under **Settings > Plugins > provider_availability** in your Canvas instance (see [Configuration options](#configuration-options)).
+
+After install, open **Provider Availability** from the provider menu to manage schedules, or use the **Bulk Import** tab to upload a CSV (see [Bulk CSV import](#bulk-csv-import)).
+
+## Configuration options
+
+### Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `simpleapi-api-key` | API key for ProvisionAPI authentication |
+| `allowed-staff-keys` | Comma-separated staff key UUIDs allowed to edit rules in the admin UI (and to commit a bulk import). Empty = allow all staff (bootstrap). |
+
+### Practice and provider timezones
+
+Set a practice-level default timezone in the admin UI **Settings** tab, with optional per-provider overrides. All times are stored in UTC internally; changing a provider's timezone re-syncs all of their calendar events.
 
 ## Screenshots
 
-**Availability overview** — at-a-glance view of every provider's rules, blocks, and holds:
+**Availability overview** - at-a-glance view of every provider's rules, blocks, and holds:
 
 ![Availability overview](../screenshots/01-availability-overview.png)
 
-**Recurring availability rule** — flexible recurrence with `Every N Week(s) / Day(s)` (bi-weekly, every 17 days, etc.):
+**Recurring availability rule** - flexible recurrence with `Every N Week(s) / Day(s)` (bi-weekly, every 17 days, etc.):
 
 ![Recurring availability rule](../screenshots/02-recurring-rule.png)
 
-**Multi-date holiday batch** — All-day toggle plus a chip picker to queue several dates and save them in one action:
+**Multi-date holiday batch** - All-day toggle plus a chip picker to queue several dates and save them in one action:
 
 ![Multi-date holiday batch](../screenshots/03-holiday-batch.png)
 
 ## Features
 
-- **Admin UI**: Configure availability rules, blocks, and recurring blocks via an in-app panel (provider menu item)
-- **REST API**: Query available slots, list providers, and manage rules/blocks programmatically
-- **Calculation Engine**: Computes bookable time slots from weekly schedules, booking constraints, buffer times, and existing appointment conflicts
-- **Calendar Sync**: Syncs rules and blocks to Canvas Calendar Events (Clinic = available, Administrative = blocked)
-- **Hold Types**: Recurring blocks with same-day or next-day hold release on a rolling 30-day window
-- **Appointment Buffers**: Automatic pre/post buffer events on Administrative calendars when appointments are created/rescheduled/canceled
-- **Timezone Support**: Practice-level default with per-provider overrides; all times stored UTC internally. Changing a provider's timezone re-syncs all their calendar events.
-- **Cache-backed Storage**: Rules stored in plugin cache with TTL refresh every 5 minutes
+- **Admin UI**: Configure availability rules, blocks, and recurring blocks via an in-app panel (provider menu item), with Availability / Add-Edit / Settings / Bulk Import tabs.
+- **CSV Bulk Import**: Upload a CSV to load availability rules, one-off blocks, and recurring blocks for one or many staff at once, with per-row validation, overlap detection, and a preview before commit (see [Bulk CSV import](#bulk-csv-import)).
+- **REST API**: Query available slots, list providers, and manage rules/blocks programmatically.
+- **Calculation Engine**: Computes bookable time slots from weekly schedules, booking constraints, buffer times, and existing appointment conflicts.
+- **Calendar Sync**: Syncs rules and blocks to Canvas Calendar Events (Clinic = available, Administrative = blocked).
+- **Hold Types**: Recurring blocks with same-day or next-day hold release on a rolling 30-day window.
+- **Appointment Buffers**: Automatic pre/post buffer events on Administrative calendars when appointments are created/rescheduled/canceled.
+- **Timezone Support**: Practice-level default with per-provider overrides; all times stored UTC internally.
+- **Cache-backed Storage**: Rules stored in plugin cache with TTL refresh.
+
+## Bulk CSV import
+
+Open the **Provider Availability** admin (provider menu) and select the **Bulk Import** tab to bulk-load availability from a spreadsheet. The flow is upload -> validate/preview -> commit. Download the template from the tab (or `GET /csv/template`).
+
+### How rows become records
+
+Availability is nested (a rule has a weekly schedule of multiple day/time windows), so the CSV is flat: **one row per time window**. Rows are grouped into records server-side. Rows that share the same staff member and rule-level settings (location, visit type, buffer, booking, recurrence, effective dates) merge into a single rule whose weekly schedule accumulates each row's window. Set an explicit `group_key` to force rows to merge.
+
+Example: staff member X, Main Clinic, Monday 9-12 and 1-5 = two `rule` rows that merge into one rule with two Monday windows.
+
+Rows are keyed by `staff_key` (the Canvas Staff UUID), not NPI - so availability can be loaded for providers, non-provider staff, and any schedulable staff record. The staff key is the same identifier used by the `allowed-staff-keys` secret.
+
+### Row types (`type` column)
+
+| Type | Meaning | Key columns |
+|---|---|---|
+| `rule` | A bookable availability window | `day`, `start`, `end`, `location`, `visit_type`, buffer/booking columns |
+| `block` | A one-off unavailable date or range | `date`, `all_day`, `start`, `end`, `reason` |
+| `rblock` | A recurring unavailable window (incl. holds) | `day`, `start`, `end`, `reason`, `hold_type` |
+
+### Columns
+
+| Column | Applies to | Notes |
+|---|---|---|
+| `type` | all | `rule`, `block`, or `rblock` |
+| `staff_key` | all | Canvas Staff UUID. Validated against active staff. Works for providers and non-provider staff. |
+| `location` | rule, block, rblock | Location name (not ID). Blank = all locations. `\|`-separate for multiple. |
+| `visit_type` | rule | Visit-type name. Blank = all types. `\|`-separate for multiple. |
+| `day` | rule, rblock (weekly) | `monday`..`sunday`. Ignored when `recurrence_frequency=daily`. |
+| `start`, `end` | rule, rblock, timed block | `HH:MM` 24-hour; `start` must be before `end` |
+| `all_day` | block | `true`/`false`. When true, `start`/`end` are ignored. |
+| `date` | block | `YYYY-MM-DD` |
+| `reason` | block, rblock | Free text |
+| `hold_type` | rblock | `none`, `same_day`, or `next_day` (default `none`) |
+| `buffer_pre`, `buffer_post` | rule | Minutes (default 0 / 15) |
+| `min_lead_hours`, `slot_minutes` | rule | Default 24 / 15 |
+| `recurrence_frequency` | rule, rblock | `weekly` (default) or `daily` |
+| `recurrence_interval` | rule, rblock | Integer >= 1 (default 1) |
+| `effective_start`, `effective_end` | rule, rblock | `YYYY-MM-DD`, optional |
+| `group_key` | rule, rblock | Optional; forces rows to merge into one record |
+
+### Validation
+
+Each row is validated for format and required fields, then the staff key is checked against active staff and location/visit-type names are resolved to Canvas IDs (unknown staff keys or unresolved location/visit-type names become row errors). New rules are checked against existing saved rules for overlap; overlapping windows within one group are also flagged. Only clean records are committed. Cross-record overlaps within the same upload for the same provider are evaluated against saved rules once committed.
 
 ## Architecture
 
 | Component | Handler Type | Description |
 |-----------|-------------|-------------|
-| `ProviderAvailabilityApp` | Application | Provider menu item that opens the admin UI |
+| `ProviderAvailabilityApp` | Application | Provider menu item that opens the admin UI (includes the Bulk Import tab) |
 | `AvailabilityAPI` | SimpleAPI | REST endpoints for availability queries, rule/block CRUD, admin UI serving |
+| `CSVImportAPI` | SimpleAPI | Staff-session endpoints for the CSV bulk import (validate / commit / template) |
 | `UIApi` | SimpleAPI | Serves the admin HTML interface (Application iframe) |
 | `ProvisionAPI` | SimpleAPI | API key-authenticated provisioning and allowed-staff management |
-| `CacheRefreshTask` | CronTask | TTL refresh, lead-time block generation, hold block rolling window (every 5 min) |
+| `CacheRefreshTask` | CronTask | TTL refresh, lead-time block generation, hold block rolling window |
 | `OnStaffActivated` | Protocol | Creates Clinic calendar when a provider is activated |
 | `OnStaffDeactivated` | Protocol | Cleans up rules and calendar events when a provider is deactivated |
 | `OnPluginInstalled` | Protocol | Full sync of all cached rules/blocks to Calendar Events on install and redeploy |
@@ -94,6 +163,14 @@ Set the `simpleapi-api-key` and `allowed-staff-keys` secrets before use (see Con
 | GET | `/admin.css` | Admin UI stylesheet |
 | GET | `/admin.js` | Admin UI JavaScript |
 
+### CSVImportAPI (session-authenticated)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/csv/template` | Download the CSV template |
+| POST | `/csv/validate` | Upload a CSV (multipart `file`), returns per-row errors and previewed records |
+| POST | `/csv/commit` | Persist previewed records and sync calendar events (gated by `allowed-staff-keys`) |
+
 ### ProvisionAPI (API key-authenticated)
 
 | Method | Path | Description |
@@ -106,38 +183,28 @@ Set the `simpleapi-api-key` and `allowed-staff-keys` secrets before use (see Con
 | GET | `/provision/timezone` | Get practice timezone |
 | PUT | `/provision/timezone` | Set practice timezone |
 
-## Configuration
+## Data Model
 
-### Secrets
-
-| Secret | Purpose |
-|--------|---------|
-| `simpleapi-api-key` | API key for ProvisionAPI authentication |
-| `allowed-staff-keys` | Comma-separated staff IDs allowed to edit rules in the admin UI |
-
-### Data Model
-
-**ProviderAvailabilityRule** — Defines when a provider is available:
+**ProviderAvailabilityRule** - Defines when a provider is available:
 - Weekly schedule (time windows per day), location/visit type filters
 - Booking interval (min lead hours, slot granularity)
 - Buffer times (pre/post appointment minutes)
 - Effective date range, group ID for bulk edits
 
-**AdminBlock** — One-off time block when a provider is unavailable:
+**AdminBlock** - One-off time block when a provider is unavailable:
 - Start/end datetime, reason, location filter
 - Group ID for bulk edits
 
-**RecurringBlock** — Weekly recurring block with optional hold:
+**RecurringBlock** - Weekly or daily recurring block with optional hold:
 - Weekly schedule, reason, location filter, effective date range
 - Hold type: `none` (immediate block), `same_day` (releases day-of), `next_day` (releases day before)
 
-### Calendar Integration
+## Calendar Integration
 
 - **Clinic calendars**: Events define when a provider IS available for booking
 - **Administrative calendars**: Events define when a provider is NOT available
 - Buffer and blocking events are placed on Administrative calendars
 - Hold blocks are dynamically created/released on a rolling 30-day window
-
 
 ## Info
 

--- a/extensions/provider_availability/provider_availability/api/availability_api.py
+++ b/extensions/provider_availability/provider_availability/api/availability_api.py
@@ -18,6 +18,7 @@ from provider_availability.engine.calculator import (
     calculate_available_slots,
     get_available_slots_for_provider,
 )
+from provider_availability.engine.csv_import import generate_template_csv
 from provider_availability.engine.event_sync import (
     build_block_event_effects,
     build_delete_block_effects,
@@ -1517,6 +1518,7 @@ class AvailabilityAPI(StaffSessionAuthMixin, SimpleAPI):
             "visit_types": {"visit_types": visit_types, "count": len(visit_types)},
             "timezone": {"timezone": tz, "available": COMMON_TIMEZONES},
             "overview": {"providers": sorted_overview},
+            "csv_template": generate_template_csv(),
         }
 
     @api.post("/form-action")

--- a/extensions/provider_availability/provider_availability/api/csv_import_api.py
+++ b/extensions/provider_availability/provider_availability/api/csv_import_api.py
@@ -1,0 +1,233 @@
+"""Staff-session API for bulk availability import from a CSV file.
+
+Three endpoints power the upload UI:
+- ``GET  /csv/template``  download a CSV template
+- ``POST /csv/validate``  parse + validate an uploaded CSV, resolve names to
+  IDs, run overlap checks, and return a preview (per-row errors + records)
+- ``POST /csv/commit``    persist the previewed records and sync calendar events
+
+Validation checks each ``staff_key`` against the set of active staff and
+resolves location and visit-type names to Canvas IDs, in three batched lookups
+(one per entity type) to avoid N+1 queries. Committing reuses the same
+``save_*`` + calendar-sync path as the manual admin UI.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
+from logger import log
+
+from provider_availability.api.availability_api import _check_write_access
+from provider_availability.engine.csv_import import (
+    build_records,
+    generate_template_csv,
+    parse_csv,
+)
+from provider_availability.engine.event_sync import (
+    build_block_event_effects,
+    build_lead_time_block_effects,
+    build_recurring_block_sync_effects,
+    sync_provider_availability,
+)
+from provider_availability.engine.lookups import (
+    get_active_locations,
+    get_active_staff_ids,
+    get_scheduleable_visit_types,
+)
+from provider_availability.engine.models import (
+    AdminBlock,
+    ProviderAvailabilityRule,
+    RecurringBlock,
+)
+from provider_availability.engine.overlap import check_rule_overlap
+from provider_availability.engine.storage import (
+    get_rules_for_provider,
+    save_block,
+    save_recurring_block,
+    save_rule,
+)
+
+
+def _build_name_map(entries: list[dict]) -> dict[str, str]:
+    """Lowercased name -> id for a list of {id, name} lookup dicts."""
+    result: dict[str, str] = {}
+    for e in entries:
+        name = (e.get("name") or "").strip().lower()
+        if name:
+            result[name] = e["id"]
+    return result
+
+
+class CSVImportAPI(StaffSessionAuthMixin, SimpleAPI):
+    """Bulk availability import endpoints."""
+
+    PREFIX = "/csv"
+
+    @api.get("/template")
+    def download_template(self) -> list[Response | Effect]:
+        """Return the CSV template as a downloadable file."""
+        content = generate_template_csv()
+        return [
+            Response(
+                content.encode("utf-8"),
+                status_code=HTTPStatus.OK,
+                headers={
+                    "Content-Type": "text/csv",
+                    "Content-Disposition": 'attachment; filename="availability_template.csv"',
+                },
+                content_type="text/csv",
+            )
+        ]
+
+    @api.post("/validate")
+    def validate_upload(self) -> list[Response | Effect]:
+        """Parse and validate an uploaded CSV, returning a preview of records."""
+        form_data = self.request.form_data()
+        file_part = form_data.get("file")
+        if file_part is None or not file_part.is_file():
+            return [
+                JSONResponse(
+                    {"error": "No CSV file provided. Upload a file with field name 'file'."},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+
+        content = file_part.content.decode("utf-8-sig")
+        parsed = parse_csv(content)
+
+        valid_staff_ids = get_active_staff_ids()
+        location_map = _build_name_map(get_active_locations())
+        visit_type_map = _build_name_map(get_scheduleable_visit_types())
+
+        records, resolution_errors = build_records(
+            parsed.valid_rows, valid_staff_ids, location_map, visit_type_map
+        )
+
+        ok_records: list[dict] = []
+        overlap_errors: list[dict] = []
+        for rec in records:
+            if rec["kind"] == "rule":
+                rule = ProviderAvailabilityRule.from_dict(rec)
+                conflict = check_rule_overlap(rule)
+                if conflict:
+                    overlap_errors.append(
+                        {"row_number": min(rec["source_rows"]), "errors": [conflict]}
+                    )
+                    continue
+            ok_records.append(rec)
+
+        errors = self._collect_errors(parsed.error_rows, resolution_errors, overlap_errors)
+
+        rule_count = sum(1 for r in ok_records if r["kind"] == "rule")
+        block_count = sum(1 for r in ok_records if r["kind"] == "block")
+        rblock_count = sum(1 for r in ok_records if r["kind"] == "rblock")
+
+        log.info(
+            "csv validate: %d rows, %d records (%d rule / %d block / %d rblock), %d errors",
+            parsed.total_rows, len(ok_records), rule_count, block_count, rblock_count, len(errors),
+        )
+
+        return [
+            JSONResponse(
+                {
+                    "total_rows": parsed.total_rows,
+                    "record_count": len(ok_records),
+                    "rule_count": rule_count,
+                    "block_count": block_count,
+                    "rblock_count": rblock_count,
+                    "error_count": len(errors),
+                    "errors": errors,
+                    "records": ok_records,
+                }
+            )
+        ]
+
+    @api.post("/commit")
+    def commit_records(self) -> list[Response | Effect]:
+        """Persist previewed records and return calendar-sync effects."""
+        denied = _check_write_access(self.request, self.secrets)
+        if denied:
+            return denied
+
+        body = self.request.json()
+        records = body.get("records", [])
+        if not records:
+            return [
+                JSONResponse(
+                    {"error": "No records provided."},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+
+        effects: list[Effect] = []
+        providers_touched: set[str] = set()
+        created = {"rule": 0, "block": 0, "rblock": 0}
+        now = datetime.now(UTC).isoformat()
+
+        for rec in records:
+            kind = rec.get("kind")
+            if kind == "rule":
+                rec["updated_at"] = now
+                rule = ProviderAvailabilityRule.from_dict(rec)
+                save_rule(rule)
+                providers_touched.add(rule.provider_id)
+                created["rule"] = created["rule"] + 1
+            elif kind == "block":
+                block = AdminBlock.from_dict(rec)
+                save_block(block)
+                effects.extend(build_block_event_effects(block))
+                created["block"] = created["block"] + 1
+            elif kind == "rblock":
+                rblock = RecurringBlock.from_dict(rec)
+                save_recurring_block(rblock)
+                effects.extend(build_recurring_block_sync_effects(rblock))
+                created["rblock"] = created["rblock"] + 1
+
+        # Sync each touched provider's availability once, then refresh lead-time blocks.
+        for pid in providers_touched:
+            effects.extend(sync_provider_availability(pid))
+            for r in get_rules_for_provider(pid):
+                if r.is_active and r.booking_interval.min_lead_hours > 0:
+                    effects.extend(build_lead_time_block_effects(r))
+
+        log.info(
+            "csv commit: %d rules, %d blocks, %d recurring blocks",
+            created["rule"], created["block"], created["rblock"],
+        )
+
+        return [
+            *effects,
+            JSONResponse(
+                {
+                    "message": "Import complete",
+                    "created_rules": created["rule"],
+                    "created_blocks": created["block"],
+                    "created_recurring_blocks": created["rblock"],
+                }
+            ),
+        ]
+
+    @staticmethod
+    def _collect_errors(
+        structural: list,
+        resolution: list,
+        overlap: list[dict],
+    ) -> list[dict]:
+        """Merge the three error sources into one row-sorted list."""
+        merged: list[dict] = []
+        for e in structural:
+            merged.append(
+                {"row_number": e.row_number, "errors": e.errors, "data": e.raw_data}
+            )
+        for e in resolution:
+            merged.append(
+                {"row_number": e.row_number, "errors": e.errors, "data": e.raw_data}
+            )
+        merged.extend(overlap)
+        merged.sort(key=lambda item: item["row_number"])
+        return merged

--- a/extensions/provider_availability/provider_availability/engine/csv_import.py
+++ b/extensions/provider_availability/provider_availability/engine/csv_import.py
@@ -1,0 +1,557 @@
+"""CSV parsing, validation, and record grouping for bulk availability import.
+
+Parses a CSV of availability rows, validates each row structurally, and groups
+rows into ProviderAvailabilityRule / AdminBlock / RecurringBlock records.
+
+Three row types via the ``type`` column:
+- ``rule``   a bookable availability window (weekly or daily)
+- ``block``  a one-off unavailable date or time range
+- ``rblock`` a recurring unavailable window (weekly or daily), optional hold
+
+Note: does NOT use Python's ``csv`` module. The Canvas plugin sandbox does not
+allow it, so CSV parsing is implemented manually (see ``_parse_csv_line``).
+
+Rows are keyed by ``staff_key`` (the Canvas Staff UUID), which works for
+providers, non-provider staff, and any schedulable staff record - unlike NPI,
+which only providers have.
+
+Parsing, structural validation, and grouping are all DB-free so they can be unit
+tested without mocking Canvas data models. Validation of the staff key and
+name-to-ID resolution (location, visit type) happen in the API layer where
+batched DB access lives.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any
+
+DAYS_OF_WEEK = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
+
+ROW_TYPES = ("rule", "block", "rblock")
+VALID_FREQUENCIES = ("weekly", "daily")
+VALID_HOLD_TYPES = ("none", "same_day", "next_day")
+
+TIME_RE = re.compile(r"^([01][0-9]|2[0-3]):[0-5][0-9]$")
+
+TEMPLATE_HEADERS = (
+    "type",
+    "staff_key",
+    "location",
+    "visit_type",
+    "day",
+    "start",
+    "end",
+    "all_day",
+    "date",
+    "reason",
+    "hold_type",
+    "buffer_pre",
+    "buffer_post",
+    "min_lead_hours",
+    "slot_minutes",
+    "recurrence_frequency",
+    "recurrence_interval",
+    "effective_start",
+    "effective_end",
+    "group_key",
+)
+
+
+class RowError:
+    """A validation error for a single CSV row."""
+
+    def __init__(self, row_number: int, errors: list[str], raw_data: dict[str, str]) -> None:
+        self.row_number = row_number
+        self.errors = errors
+        self.raw_data = raw_data
+
+
+class ValidRow:
+    """A structurally-valid row ready for name resolution and grouping."""
+
+    def __init__(self, row_number: int, data: dict[str, str]) -> None:
+        self.row_number = row_number
+        self.data = data
+
+
+class ParseResult:
+    """The result of parsing and structurally validating a CSV file."""
+
+    def __init__(self) -> None:
+        self.valid_rows: list[ValidRow] = []
+        self.error_rows: list[RowError] = []
+        self.total_rows: int = 0
+
+
+# -- Low-level CSV parsing (sandbox-safe, no csv module) --------------------
+
+
+def _strip_bom(text: str) -> str:
+    """Strip a UTF-8 BOM if present."""
+    return text.lstrip("﻿")
+
+
+def _normalize_headers(headers: list[str]) -> list[str]:
+    """Lowercase and strip whitespace from headers."""
+    return [h.strip().lower() for h in headers]
+
+
+def _parse_csv_line(line: str) -> list[str]:
+    """Parse a single CSV line into fields, handling quoted values.
+
+    Handles comma-separated values, double-quoted fields (which may contain
+    commas or quotes), and escaped quotes (doubled ``""`` inside a quoted field).
+    """
+    fields: list[str] = []
+    current: list[str] = []
+    in_quotes = False
+    i = 0
+    length = len(line)
+
+    while i < length:
+        ch = line[i]
+
+        if in_quotes:
+            if ch == '"':
+                if i + 1 < length and line[i + 1] == '"':
+                    current.append('"')
+                    i = i + 2
+                    continue
+                else:
+                    in_quotes = False
+                    i = i + 1
+                    continue
+            else:
+                current.append(ch)
+                i = i + 1
+        else:
+            if ch == '"' and len(current) == 0:
+                in_quotes = True
+                i = i + 1
+            elif ch == ",":
+                fields.append("".join(current))
+                current = []
+                i = i + 1
+            elif ch in ("\r", "\n"):
+                i = i + 1
+            else:
+                current.append(ch)
+                i = i + 1
+
+    fields.append("".join(current))
+    return fields
+
+
+def _csv_escape(value: str) -> str:
+    """Escape a value for CSV output: quote if it contains a comma, quote, or newline."""
+    if '"' in value or "," in value or "\n" in value or "\r" in value:
+        return '"' + value.replace('"', '""') + '"'
+    return value
+
+
+# -- Field validators -------------------------------------------------------
+
+
+def _is_valid_time(value: str) -> bool:
+    return bool(TIME_RE.match(value))
+
+
+def _is_valid_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_int(value: str, field: str, minimum: int) -> tuple[int | None, str | None]:
+    """Parse a non-empty integer field. Returns (value, error)."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None, f"{field} must be a whole number"
+    if parsed < minimum:
+        return None, f"{field} must be >= {minimum}"
+    return parsed, None
+
+
+def _validate_window(row: dict[str, str]) -> list[str]:
+    """Validate start/end are HH:MM and start < end."""
+    errors: list[str] = []
+    start = row.get("start", "").strip()
+    end = row.get("end", "").strip()
+    if not _is_valid_time(start):
+        errors.append("start must be HH:MM (24-hour)")
+    if not _is_valid_time(end):
+        errors.append("end must be HH:MM (24-hour)")
+    if not errors and start >= end:
+        errors.append(f"start must be before end ({start} >= {end})")
+    return errors
+
+
+def _validate_recurrence(row: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    freq = (row.get("recurrence_frequency", "").strip() or "weekly").lower()
+    if freq not in VALID_FREQUENCIES:
+        errors.append(f"recurrence_frequency must be one of: {', '.join(VALID_FREQUENCIES)}")
+    interval = row.get("recurrence_interval", "").strip()
+    if interval:
+        _, err = _validate_int(interval, "recurrence_interval", 1)
+        if err:
+            errors.append(err)
+    return errors
+
+
+def _validate_optional_date(row: dict[str, str], field: str) -> list[str]:
+    val = row.get(field, "").strip()
+    if val and not _is_valid_date(val):
+        return [f"{field} must be YYYY-MM-DD"]
+    return []
+
+
+def _validate_optional_int(row: dict[str, str], field: str, minimum: int) -> list[str]:
+    val = row.get(field, "").strip()
+    if not val:
+        return []
+    _, err = _validate_int(val, field, minimum)
+    return [err] if err else []
+
+
+def _validate_rule_row(row: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    freq = (row.get("recurrence_frequency", "").strip() or "weekly").lower()
+    if freq == "weekly":
+        day = row.get("day", "").strip().lower()
+        if day not in DAYS_OF_WEEK:
+            errors.append(f"day must be one of: {', '.join(DAYS_OF_WEEK)}")
+    errors.extend(_validate_window(row))
+    errors.extend(_validate_recurrence(row))
+    for f in ("buffer_pre", "buffer_post", "min_lead_hours"):
+        errors.extend(_validate_optional_int(row, f, 0))
+    errors.extend(_validate_optional_int(row, "slot_minutes", 1))
+    errors.extend(_validate_optional_date(row, "effective_start"))
+    errors.extend(_validate_optional_date(row, "effective_end"))
+    return errors
+
+
+def _validate_block_row(row: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    block_date = row.get("date", "").strip()
+    if not block_date:
+        errors.append("date is required for a block row")
+    elif not _is_valid_date(block_date):
+        errors.append("date must be YYYY-MM-DD")
+    all_day = _truthy(row.get("all_day", ""))
+    if not all_day:
+        errors.extend(_validate_window(row))
+    return errors
+
+
+def _validate_rblock_row(row: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    freq = (row.get("recurrence_frequency", "").strip() or "weekly").lower()
+    if freq == "weekly":
+        day = row.get("day", "").strip().lower()
+        if day not in DAYS_OF_WEEK:
+            errors.append(f"day must be one of: {', '.join(DAYS_OF_WEEK)}")
+    errors.extend(_validate_window(row))
+    errors.extend(_validate_recurrence(row))
+    hold = row.get("hold_type", "").strip().lower()
+    if hold and hold not in VALID_HOLD_TYPES:
+        errors.append(f"hold_type must be one of: {', '.join(VALID_HOLD_TYPES)}")
+    errors.extend(_validate_optional_date(row, "effective_start"))
+    errors.extend(_validate_optional_date(row, "effective_end"))
+    return errors
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in ("true", "1", "yes", "y")
+
+
+def validate_row(row: dict[str, str]) -> list[str]:
+    """Validate a single CSV row structurally. Returns a list of error messages."""
+    row_type = row.get("type", "").strip().lower()
+    if row_type not in ROW_TYPES:
+        return [f"type must be one of: {', '.join(ROW_TYPES)}"]
+    if not row.get("staff_key", "").strip():
+        return ["staff_key is required"]
+
+    if row_type == "rule":
+        return _validate_rule_row(row)
+    if row_type == "block":
+        return _validate_block_row(row)
+    return _validate_rblock_row(row)
+
+
+def parse_csv(csv_content: str) -> ParseResult:
+    """Parse CSV content and structurally validate every row."""
+    csv_content = _strip_bom(csv_content)
+    lines = csv_content.splitlines()
+    result = ParseResult()
+    if not lines:
+        return result
+
+    raw_headers = _parse_csv_line(lines[0])
+    if not raw_headers:
+        return result
+    normalized_headers = _normalize_headers(raw_headers)
+
+    total = 0
+    for i, line in enumerate(lines[1:], start=2):
+        if not line.strip():
+            continue
+        total = total + 1
+        fields = _parse_csv_line(line)
+
+        row: dict[str, str] = {}
+        for idx, header in enumerate(normalized_headers):
+            if not header:
+                continue
+            value = fields[idx] if idx < len(fields) else ""
+            row[header] = value.strip()
+
+        errors = validate_row(row)
+        if errors:
+            result.error_rows.append(RowError(row_number=i, errors=errors, raw_data=row))
+        else:
+            result.valid_rows.append(ValidRow(row_number=i, data=row))
+
+    result.total_rows = total
+    return result
+
+
+# -- Record grouping (DB-free; takes pre-built name-to-id maps) --------------
+
+
+def _window(row: dict[str, str]) -> dict[str, str]:
+    return {"start": row["start"].strip(), "end": row["end"].strip()}
+
+
+def _windows_overlap(a: dict[str, str], b: dict[str, str]) -> bool:
+    return a["start"] < b["end"] and b["start"] < a["end"]
+
+
+def _resolve_names(
+    names: str,
+    name_map: dict[str, str],
+    field: str,
+) -> tuple[list[str], list[str]]:
+    """Resolve a ``|``-separated list of names to IDs via name_map.
+
+    Returns (ids, errors). Empty input resolves to an empty id list (means "all").
+    """
+    ids: list[str] = []
+    errors: list[str] = []
+    for raw in names.split("|"):
+        name = raw.strip()
+        if not name:
+            continue
+        resolved = name_map.get(name.lower())
+        if resolved is None:
+            errors.append(f"{field} '{name}' not found")
+        else:
+            ids.append(resolved)
+    return ids, errors
+
+
+def _rule_signature(
+    row: dict[str, str],
+    provider_id: str,
+    location_ids: list[str],
+    visit_types: list[str],
+) -> tuple:
+    """Grouping signature: rows sharing it merge into one rule/recurring-block."""
+    group_key = row.get("group_key", "").strip()
+    if group_key:
+        return (provider_id, group_key, row.get("type", ""))
+    freq = (row.get("recurrence_frequency", "").strip() or "weekly").lower()
+    return (
+        provider_id,
+        row.get("type", ""),
+        tuple(sorted(location_ids)),
+        tuple(sorted(visit_types)),
+        row.get("effective_start", "").strip(),
+        row.get("effective_end", "").strip(),
+        row.get("buffer_pre", "").strip(),
+        row.get("buffer_post", "").strip(),
+        row.get("min_lead_hours", "").strip(),
+        row.get("slot_minutes", "").strip(),
+        freq,
+        row.get("recurrence_interval", "").strip() or "1",
+        row.get("hold_type", "").strip().lower() or "none",
+    )
+
+
+def _or_none(value: str) -> str | None:
+    return value.strip() or None
+
+
+def build_records(
+    valid_rows: list[ValidRow],
+    valid_staff_ids: set[str],
+    location_map: dict[str, str],
+    visit_type_map: dict[str, str],
+) -> tuple[list[dict[str, Any]], list[RowError]]:
+    """Validate staff keys, resolve names to IDs, and group rows into records.
+
+    ``staff_key`` is used directly as the record's ``provider_id`` (it is the
+    Canvas Staff UUID). Each returned record is a dict ready for the matching
+    model ``from_dict``, tagged with ``kind`` (``rule``|``block``|``rblock``)
+    and the source row numbers. Rows with an unknown staff key or an
+    unresolvable location/visit type are returned as errors instead.
+    """
+    records: list[dict[str, Any]] = []
+    errors: list[RowError] = []
+
+    grouped: dict[tuple, dict[str, Any]] = {}
+
+    for vr in valid_rows:
+        row = vr.data
+        row_type = row["type"].strip().lower()
+
+        provider_id = row["staff_key"].strip()
+        if provider_id not in valid_staff_ids:
+            errors.append(
+                RowError(vr.row_number, [f"staff_key '{provider_id}' not found among active staff"], row)
+            )
+            continue
+
+        location_ids, loc_errs = _resolve_names(row.get("location", ""), location_map, "location")
+        row_errors = list(loc_errs)
+        visit_types: list[str] = []
+        if row_type == "rule":
+            visit_types, vt_errs = _resolve_names(row.get("visit_type", ""), visit_type_map, "visit_type")
+            row_errors.extend(vt_errs)
+        if row_errors:
+            errors.append(RowError(vr.row_number, row_errors, row))
+            continue
+
+        if row_type == "block":
+            records.append(_build_block_record(vr, provider_id, location_ids))
+            continue
+
+        sig = _rule_signature(row, provider_id, location_ids, visit_types)
+        if sig not in grouped:
+            grouped[sig] = _new_group(row_type, row, provider_id, location_ids, visit_types)
+        group = grouped[sig]
+
+        window = _window(row)
+        add_err = _add_window_to_group(group, row, window)
+        if add_err:
+            errors.append(RowError(vr.row_number, [add_err], row))
+        else:
+            group["source_rows"].append(vr.row_number)
+
+    records.extend(grouped.values())
+    return records, errors
+
+
+def _new_group(
+    row_type: str,
+    row: dict[str, str],
+    provider_id: str,
+    location_ids: list[str],
+    visit_types: list[str],
+) -> dict[str, Any]:
+    freq = (row.get("recurrence_frequency", "").strip() or "weekly").lower()
+    interval_str = row.get("recurrence_interval", "").strip()
+    interval = int(interval_str) if interval_str else 1
+    group: dict[str, Any] = {
+        "kind": row_type,
+        "source_rows": [],
+        "provider_id": provider_id,
+        "location_ids": location_ids,
+        "weekly_schedule": {},
+        "time_windows": [],
+        "recurrence_frequency": freq,
+        "recurrence_interval": interval,
+        "reason": row.get("reason", "").strip(),
+        "effective_start": _or_none(row.get("effective_start", "")),
+        "effective_end": _or_none(row.get("effective_end", "")),
+        "is_active": True,
+    }
+    if row_type == "rule":
+        group["visit_types"] = visit_types
+        buffer_pre = row.get("buffer_pre", "").strip()
+        buffer_post = row.get("buffer_post", "").strip()
+        group["buffer_minutes"] = {
+            "pre": int(buffer_pre) if buffer_pre else 0,
+            "post": int(buffer_post) if buffer_post else 15,
+        }
+        min_lead = row.get("min_lead_hours", "").strip()
+        slot = row.get("slot_minutes", "").strip()
+        group["booking_interval"] = {
+            "min_lead_hours": int(min_lead) if min_lead else 24,
+            "slot_granularity_minutes": int(slot) if slot else 15,
+        }
+    else:  # rblock
+        group["hold_type"] = row.get("hold_type", "").strip().lower() or "none"
+    return group
+
+
+def _add_window_to_group(
+    group: dict[str, Any],
+    row: dict[str, str],
+    window: dict[str, str],
+) -> str | None:
+    """Add a time window to a group, guarding against overlaps. Returns an error string or None."""
+    if group["recurrence_frequency"] == "daily":
+        existing = group["time_windows"]
+        for w in existing:
+            if _windows_overlap(w, window):
+                return f"window {window['start']}-{window['end']} overlaps another window in the same daily group"
+        existing.append(window)
+        return None
+    day = row["day"].strip().lower()
+    day_windows = group["weekly_schedule"].setdefault(day, [])
+    for w in day_windows:
+        if _windows_overlap(w, window):
+            return f"window {window['start']}-{window['end']} overlaps another {day} window in the same group"
+    day_windows.append(window)
+    return None
+
+
+def _build_block_record(vr: ValidRow, provider_id: str, location_ids: list[str]) -> dict[str, Any]:
+    row = vr.data
+    block_date = row["date"].strip()
+    all_day = _truthy(row.get("all_day", ""))
+    if all_day:
+        start_iso = f"{block_date}T00:00:00"
+        end_iso = f"{block_date}T23:59:59"
+    else:
+        start_iso = f"{block_date}T{row['start'].strip()}:00"
+        end_iso = f"{block_date}T{row['end'].strip()}:00"
+    return {
+        "kind": "block",
+        "source_rows": [vr.row_number],
+        "provider_id": provider_id,
+        "location_ids": location_ids,
+        "start": start_iso,
+        "end": end_iso,
+        "all_day": all_day,
+        "reason": row.get("reason", "").strip(),
+    }
+
+
+# -- Template ---------------------------------------------------------------
+
+
+def generate_template_csv() -> str:
+    """Generate a CSV template with headers and one example of each row type."""
+    examples = [
+        ["rule", "11111111-1111-1111-1111-111111111111", "Main Clinic", "", "monday", "09:00", "12:00", "", "", "",
+         "", "0", "15", "24", "15", "weekly", "1", "2026-07-01", "", ""],
+        ["rule", "11111111-1111-1111-1111-111111111111", "Main Clinic", "", "monday", "13:00", "17:00", "", "", "",
+         "", "0", "15", "24", "15", "weekly", "1", "2026-07-01", "", ""],
+        ["block", "11111111-1111-1111-1111-111111111111", "", "", "", "", "", "true", "2026-07-04", "Independence Day",
+         "", "", "", "", "", "", "", "", "", ""],
+        ["rblock", "11111111-1111-1111-1111-111111111111", "", "", "monday", "12:00", "13:00", "", "", "Lunch",
+         "none", "", "", "", "", "weekly", "1", "", "", ""],
+    ]
+    header_line = ",".join(_csv_escape(h) for h in TEMPLATE_HEADERS)
+    lines = [header_line]
+    for ex in examples:
+        lines.append(",".join(_csv_escape(v) for v in ex))
+    return "\r\n".join(lines) + "\r\n"

--- a/extensions/provider_availability/provider_availability/engine/lookups.py
+++ b/extensions/provider_availability/provider_availability/engine/lookups.py
@@ -27,6 +27,17 @@ def get_active_providers() -> list[dict[str, Any]]:
     return results
 
 
+def get_active_staff_ids() -> set[str]:
+    """Return the set of all active staff UUIDs (not just providers).
+
+    Availability can be scheduled for any active staff record, so the CSV
+    importer keys on the staff UUID rather than NPI (which only providers have).
+    """
+    ids = {str(s.id) for s in Staff.objects.filter(active=True)}
+    log.info("get_active_staff_ids: found %d active staff", len(ids))
+    return ids
+
+
 def get_active_locations() -> list[dict[str, Any]]:
     """Return all active practice locations for the location dropdown."""
     results: list[dict[str, Any]] = []

--- a/extensions/provider_availability/provider_availability/static/js/admin.js
+++ b/extensions/provider_availability/provider_availability/static/js/admin.js
@@ -619,8 +619,8 @@ window.addEventListener('beforeunload', function(e) {
   }
 });
 
-var _tabIndexMap = { 'availability': 0, 'editor': 1, 'settings': 2 };
-var _tabPanelMap = { 'panel-availability': 'availability', 'panel-editor': 'editor', 'panel-settings': 'settings' };
+var _tabIndexMap = { 'availability': 0, 'editor': 1, 'settings': 2, 'bulk-import': 3 };
+var _tabPanelMap = { 'panel-availability': 'availability', 'panel-editor': 'editor', 'panel-settings': 'settings', 'panel-bulk-import': 'bulk-import' };
 
 function _isEditorVisible() {
   var edPanel = document.getElementById('panel-editor');
@@ -650,6 +650,8 @@ function showTab(name) {
       if (!_skipDirtyCheck) resetForm();
     } else if (name === 'settings') {
       renderSettingsPanel();
+    } else if (name === 'bulk-import') {
+      bulkReset();
     } else {
       if (!_skipDirtyCheck) loadOverview();
     }
@@ -679,6 +681,160 @@ function dismissMsg() {
   const elBot = document.getElementById('status-msg-bottom');
   if (elTop) elTop.innerHTML = '';
   if (elBot) elBot.innerHTML = '';
+}
+
+/* ---------- Bulk CSV Import ---------- */
+const CSV_BASE = '/plugin-io/api/provider_availability/csv';
+var _bulkFile = null;
+var _bulkRecords = null;
+
+function bulkFileSelect(event) {
+  _bulkFile = (event.target.files && event.target.files[0]) || null;
+  var btn = document.getElementById('bulk-validate-btn');
+  if (btn) btn.disabled = !_bulkFile;
+  var err = document.getElementById('bulk-upload-error');
+  if (err) err.style.display = 'none';
+}
+
+function bulkShowStep(step) {
+  ['upload', 'preview', 'results'].forEach(function(s) {
+    var el = document.getElementById('bulk-step-' + s);
+    if (el) el.style.display = (s === step) ? 'block' : 'none';
+  });
+}
+
+function bulkReset() {
+  _bulkFile = null;
+  _bulkRecords = null;
+  var input = document.getElementById('bulk-file');
+  if (input) input.value = '';
+  var btn = document.getElementById('bulk-validate-btn');
+  if (btn) btn.disabled = true;
+  var err = document.getElementById('bulk-upload-error');
+  if (err) err.style.display = 'none';
+  bulkShowStep('upload');
+}
+
+function bulkDownloadTemplate() {
+  var csv = (window.__PRELOADED__ && window.__PRELOADED__.csv_template) || '';
+  if (!csv) { showMsg('Template unavailable', 'error'); return; }
+  var blob = new Blob([csv], { type: 'text/csv' });
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = 'availability_template.csv';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function bulkShowError(msg) {
+  var el = document.getElementById('bulk-upload-error');
+  if (el) { el.textContent = msg; el.style.display = 'block'; }
+}
+
+async function bulkUploadValidate() {
+  if (!_bulkFile) return;
+  var btn = document.getElementById('bulk-validate-btn');
+  if (btn) btn.disabled = true;
+  try {
+    var fd = new FormData();
+    fd.append('file', _bulkFile);
+    var resp = await fetch(CSV_BASE + '/validate', { method: 'POST', body: fd, credentials: 'same-origin' });
+    if (!resp.ok) {
+      var e = await resp.json().catch(function() { return { error: 'Upload failed' }; });
+      bulkShowError(e.error || 'Upload failed');
+      if (btn) btn.disabled = false;
+      return;
+    }
+    var result = await resp.json();
+    _bulkRecords = result.records || [];
+    bulkRenderPreview(result);
+    bulkShowStep('preview');
+  } catch (err) {
+    bulkShowError('Upload failed: ' + err.message);
+    if (btn) btn.disabled = false;
+  }
+}
+
+function _bulkStat(num, label, color) {
+  return '<div style="text-align:center;"><div style="font-size:26px;font-weight:700;color:' + color +
+    ';">' + num + '</div><div style="font-size:12px;color:var(--text-muted);text-transform:uppercase;">' +
+    label + '</div></div>';
+}
+
+function bulkRenderPreview(result) {
+  var summary = document.getElementById('bulk-summary');
+  if (summary) {
+    summary.innerHTML =
+      _bulkStat(result.total_rows, 'Rows', 'var(--text)') +
+      _bulkStat(result.record_count, 'Records', '#2e7d32') +
+      _bulkStat(result.rule_count, 'Rules', 'var(--text)') +
+      _bulkStat(result.block_count, 'Blocks', 'var(--text)') +
+      _bulkStat(result.rblock_count, 'Recurring', 'var(--text)') +
+      _bulkStat(result.error_count, 'Errors', '#c62828');
+  }
+  var errSec = document.getElementById('bulk-error-section');
+  var body = document.getElementById('bulk-error-body');
+  if (body) body.innerHTML = '';
+  if (body && result.errors && result.errors.length > 0) {
+    if (errSec) errSec.style.display = 'block';
+    result.errors.forEach(function(row) {
+      var tr = document.createElement('tr');
+      var td1 = document.createElement('td');
+      td1.style.padding = '8px 12px';
+      td1.style.borderBottom = '1px solid var(--border)';
+      td1.textContent = row.row_number;
+      var td2 = document.createElement('td');
+      td2.style.padding = '8px 12px';
+      td2.style.borderBottom = '1px solid var(--border)';
+      td2.style.color = '#c62828';
+      td2.textContent = (row.errors || []).join('; ');
+      tr.appendChild(td1);
+      tr.appendChild(td2);
+      body.appendChild(tr);
+    });
+  } else if (errSec) {
+    errSec.style.display = 'none';
+  }
+  var commitBtn = document.getElementById('bulk-commit-btn');
+  if (commitBtn) commitBtn.disabled = result.record_count === 0;
+}
+
+async function bulkConfirmCommit() {
+  if (!_bulkRecords || _bulkRecords.length === 0) return;
+  var btn = document.getElementById('bulk-commit-btn');
+  if (btn) btn.disabled = true;
+  try {
+    var resp = await fetch(CSV_BASE + '/commit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ records: _bulkRecords }),
+      credentials: 'same-origin',
+    });
+    if (!resp.ok) {
+      var e = await resp.json().catch(function() { return { error: 'Load failed' }; });
+      showMsg(e.error || 'Load failed', 'error');
+      if (btn) btn.disabled = false;
+      return;
+    }
+    var result = await resp.json();
+    var rules = result.created_rules || 0;
+    var blocks = result.created_blocks || 0;
+    var rblocks = result.created_recurring_blocks || 0;
+    var total = rules + blocks + rblocks;
+    var msg = document.getElementById('bulk-results-msg');
+    if (msg) {
+      msg.textContent = total + ' record(s) loaded: ' + rules + ' rule(s), ' + blocks +
+        ' block(s), ' + rblocks + ' recurring block(s). Calendar events are syncing.';
+    }
+    bulkShowStep('results');
+    showMsg('Imported ' + total + ' record(s)', 'success');
+  } catch (err) {
+    showMsg('Load failed: ' + err.message, 'error');
+    if (btn) btn.disabled = false;
+  }
 }
 
 
@@ -3125,6 +3281,8 @@ if (_mainTabsEl) {
       if (!_skipDirtyCheck) resetForm();
     } else if (name === 'settings') {
       renderSettingsPanel();
+    } else if (name === 'bulk-import') {
+      bulkReset();
     } else {
       if (!_skipDirtyCheck) loadOverview();
     }
@@ -3138,7 +3296,7 @@ if (_mainTabsEl) {
 
 // Restore active tab from URL hash
 var _initHash = location.hash.replace('#', '');
-if (_initHash === 'settings' || _initHash === 'editor') {
+if (_initHash === 'settings' || _initHash === 'editor' || _initHash === 'bulk-import') {
   showTab(_initHash);
 }
 

--- a/extensions/provider_availability/provider_availability/templates/admin_ui.py
+++ b/extensions/provider_availability/provider_availability/templates/admin_ui.py
@@ -35,6 +35,7 @@ ADMIN_HTML_TEMPLATE = """<!DOCTYPE html>
     <canvas-tab for="panel-availability" active><canvas-tab-label>Availability</canvas-tab-label></canvas-tab>
     <canvas-tab for="panel-editor"><canvas-tab-label>Add / Edit</canvas-tab-label></canvas-tab>
     <canvas-tab for="panel-settings"><canvas-tab-label>Settings</canvas-tab-label></canvas-tab>
+    <canvas-tab for="panel-bulk-import"><canvas-tab-label>Bulk Import</canvas-tab-label></canvas-tab>
 
   <!-- Availability Panel -->
   <canvas-tab-panel id="panel-availability">
@@ -528,6 +529,69 @@ ADMIN_HTML_TEMPLATE = """<!DOCTYPE html>
           </div>
         </div>
 
+
+      </div>
+    </div>
+  </canvas-tab-panel>
+
+  <!-- Bulk Import Panel -->
+  <canvas-tab-panel id="panel-bulk-import">
+    <div class="panel">
+      <div class="panel-header">
+        <div class="panel-header-left">
+          <div class="panel-title">Bulk Import</div>
+          <div class="panel-subtitle">Upload a CSV to load availability, blocks, and holds for many staff at once.</div>
+        </div>
+      </div>
+      <div class="panel-body">
+
+        <!-- Step 1: upload -->
+        <div id="bulk-step-upload">
+          <div class="section-label">CSV File</div>
+          <p style="font-size:13px;color:var(--text-muted);margin-bottom:10px;">
+            One row per time window; rows for the same staff key and settings merge into one rule.
+            Staff are keyed by <strong>staff_key</strong> (Canvas Staff UUID).
+            <a href="#" onclick="bulkDownloadTemplate();return false;">Download template</a>
+          </p>
+          <input type="file" id="bulk-file" accept=".csv" onchange="bulkFileSelect(event)">
+          <div id="bulk-upload-error" class="alert alert-error" style="display:none;margin-top:12px;"></div>
+          <div style="margin-top:16px;">
+            <button type="button" id="bulk-validate-btn" class="btn" disabled onclick="bulkUploadValidate()"
+              style="background:var(--cyan);color:#fff;padding:10px 20px;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;">Upload &amp; Validate</button>
+          </div>
+        </div>
+
+        <!-- Step 2: preview -->
+        <div id="bulk-step-preview" style="display:none;">
+          <div id="bulk-summary" style="display:flex;gap:24px;flex-wrap:wrap;margin-bottom:16px;"></div>
+          <div id="bulk-error-section" style="display:none;">
+            <div class="section-label">Rows with errors</div>
+            <div style="max-height:280px;overflow:auto;border:1px solid var(--border);border-radius:8px;">
+              <table style="width:100%;border-collapse:collapse;font-size:13px;">
+                <thead><tr>
+                  <th style="text-align:left;padding:8px 12px;border-bottom:1px solid var(--border);">Row</th>
+                  <th style="text-align:left;padding:8px 12px;border-bottom:1px solid var(--border);">Errors</th>
+                </tr></thead>
+                <tbody id="bulk-error-body"></tbody>
+              </table>
+            </div>
+          </div>
+          <p style="font-size:13px;color:var(--text-muted);margin-top:16px;">Only valid records will be loaded. Rows with errors are skipped.</p>
+          <div style="display:flex;gap:12px;margin-top:16px;">
+            <button type="button" class="btn" onclick="bulkReset()"
+              style="background:var(--surface-2,#e8e8e8);color:var(--text);padding:10px 20px;border:none;border-radius:6px;font-size:14px;cursor:pointer;">Back</button>
+            <button type="button" id="bulk-commit-btn" class="btn" onclick="bulkConfirmCommit()"
+              style="background:var(--cyan);color:#fff;padding:10px 20px;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;">Confirm &amp; Load</button>
+          </div>
+        </div>
+
+        <!-- Step 3: results -->
+        <div id="bulk-step-results" style="display:none;">
+          <div class="section-label">Import complete</div>
+          <div id="bulk-results-msg" style="font-size:14px;margin:8px 0 16px;"></div>
+          <button type="button" class="btn" onclick="bulkReset()"
+            style="background:var(--cyan);color:#fff;padding:10px 20px;border:none;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;">Upload another file</button>
+        </div>
 
       </div>
     </div>

--- a/extensions/provider_availability/tests/api/test_availability_api_coverage.py
+++ b/extensions/provider_availability/tests/api/test_availability_api_coverage.py
@@ -1,0 +1,1358 @@
+"""Additional coverage tests for provider_availability.api.availability_api.
+
+Targets the branches left uncovered by test_availability_api.py and
+test_form_handlers.py: the per-provider timezone endpoints, the lead-time
+refresh / orphan-cleanup branches on rule delete + override edits, the
+per-date timed block path, the recurring-block replace/apply-to-group
+branches, and the remaining form-* helper branches.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from datetime import date, datetime, time
+from http import HTTPStatus
+from unittest.mock import MagicMock, call, patch
+
+from provider_availability.api.availability_api import (
+    AvailabilityAPI,
+    _check_write_access,
+)
+from provider_availability.engine.models import (
+    AdminBlock,
+    BookingInterval,
+    DateOverride,
+    ProviderAvailabilityRule,
+    RecurringBlock,
+    TimeWindow,
+)
+
+
+# ── Helpers (mirrors test_availability_api.py) ─────────────────────────────
+
+PROVIDER_ID = "provider-uuid-123"
+PROVIDER_ID_2 = "provider-uuid-456"
+LOCATION_ID = "location-uuid-456"
+VISIT_TYPE_ID = "visit-type-uuid-789"
+
+MODULE = "provider_availability.api.availability_api"
+
+
+def _parse(response) -> tuple[dict, int]:
+    """Extract (body_dict, status_code) from a JSONResponse."""
+    body = json.loads(getattr(response, "content"))
+    return body, response.status_code
+
+
+def _make_handler(
+    query_params: dict | None = None,
+    path_params: dict | None = None,
+    json_body: dict | None = None,
+    staff_id: str = "staff-1",
+) -> AvailabilityAPI:
+    """Create an AvailabilityAPI handler with a mocked request."""
+    handler = AvailabilityAPI(MagicMock())
+    handler.request = MagicMock()
+    handler.request.query_params = query_params or {}
+    handler.request.path_params = path_params or {}
+    handler.request.json.return_value = json_body or {}
+    handler.request.staff_id = staff_id
+    handler.secrets = {}
+    return handler
+
+
+def _make_form_handler(method: str, path: str, body: dict) -> AvailabilityAPI:
+    """Create a handler with a form_data() payload for handle_form_action."""
+    handler = _make_handler()
+    field_method = MagicMock()
+    field_method.value = method
+    field_path = MagicMock()
+    field_path.value = path
+    field_body = MagicMock()
+    field_body.value = json.dumps(body)
+    handler.request.form_data.return_value = {
+        "_method": field_method,
+        "_path": field_path,
+        "_body": field_body,
+    }
+    return handler
+
+
+def _lead_time_rule(rule_id: str = "r-lead") -> ProviderAvailabilityRule:
+    """An active rule with a positive min_lead_hours (triggers lead-time blocks)."""
+    return ProviderAvailabilityRule(
+        id=rule_id,
+        provider_id=PROVIDER_ID,
+        weekly_schedule={"thursday": [TimeWindow(start=time(9, 0), end=time(15, 0))]},
+        booking_interval=BookingInterval(min_lead_hours=24),
+        is_active=True,
+    )
+
+
+# ── update_rule_group: preserve-existing + lead-time / orphan branches ─────
+
+
+class TestUpdateRuleGroupBranches:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects", return_value=["lead-fx"])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.check_rule_overlap", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id")
+    @patch(f"{MODULE}.get_rules_for_provider")
+    def test_preserves_existing_overrides_and_timezone_and_syncs_lead_time(
+        self,
+        mock_get_rules,
+        mock_get_rule,
+        mock_overlap,
+        mock_save,
+        mock_sync,
+        mock_lead,
+        mock_access,
+    ):
+        """When payload omits date_overrides/timezone, they come from the existing
+        rule; an active lead-time rule produces lead-time block effects."""
+        existing = ProviderAvailabilityRule(
+            id="r1",
+            provider_id=PROVIDER_ID,
+            timezone="US/Eastern",
+            date_overrides=[
+                DateOverride(
+                    date=date(2026, 4, 9),
+                    time_windows=[TimeWindow(start=time(9, 0), end=time(10, 0))],
+                )
+            ],
+        )
+        mock_get_rule.return_value = existing
+        mock_get_rules.return_value = [_lead_time_rule()]
+
+        body = {
+            "id": "r1",
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {"monday": [{"start": "09:00", "end": "12:00"}]},
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.update_rule_group()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Updated 1 rule(s)" in data["message"]
+        # Preserved timezone from existing rule is echoed back on the saved rule
+        assert data["rule"]["timezone"] == "US/Eastern"
+        assert len(data["rule"]["date_overrides"]) == 1
+        # Lead-time effects were appended ahead of the JSONResponse
+        assert "lead-fx" in result
+        assert mock_lead.mock_calls == [call(mock_lead.call_args[0][0])]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.check_rule_overlap", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id", return_value=None)
+    @patch(f"{MODULE}.get_rules_for_provider", return_value=[])
+    def test_no_lead_time_cleans_orphan_events(
+        self,
+        mock_get_rules,
+        mock_get_rule,
+        mock_overlap,
+        mock_save,
+        mock_sync,
+        mock_lead,
+        mock_access,
+    ):
+        """No remaining lead-time rule -> orphaned Lead Time events are deleted."""
+        cal = MagicMock()
+        cal.id = "cal-1"
+        evt = MagicMock()
+        evt.id = "evt-1"
+        del_effect = MagicMock()
+        event_effect = MagicMock()
+        event_effect.delete.return_value = del_effect
+
+        body = {
+            "id": "r1",
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {},
+        }
+        handler = _make_handler(json_body=body)
+        with patch(
+            "provider_availability.engine.admin_calendar.get_admin_calendars",
+            return_value=[cal],
+        ) as mock_cals, patch(
+            "canvas_sdk.v1.data.calendar.Event"
+        ) as mock_event_model, patch(
+            "canvas_sdk.effects.calendar.Event", return_value=event_effect
+        ) as mock_event_effect:
+            mock_event_model.objects.filter.return_value = [evt]
+            result = handler.update_rule_group()
+
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert del_effect in result
+        assert mock_lead.mock_calls == []
+        assert mock_cals.mock_calls == [call(PROVIDER_ID)]
+        mock_event_effect.assert_called_once_with(event_id="evt-1")
+
+
+# ── delete_rule: lead-time refresh + orphan cleanup ────────────────────────
+
+
+class TestDeleteRuleBranches:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects", return_value=["lead-fx"])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.get_rules_for_provider")
+    @patch(f"{MODULE}.delete_rule_by_id")
+    def test_refreshes_lead_time_for_remaining_rule(
+        self, mock_delete, mock_get_rules, mock_sync, mock_lead, mock_access
+    ):
+        mock_get_rules.return_value = [_lead_time_rule()]
+        handler = _make_handler(
+            path_params={"provider_id": PROVIDER_ID, "rule_id": "r1"}
+        )
+        result = handler.delete_rule()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Rule deleted"
+        assert "lead-fx" in result
+        assert mock_delete.mock_calls == [call(PROVIDER_ID, "r1")]
+        assert mock_lead.mock_calls == [call(mock_lead.call_args[0][0])]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.get_rules_for_provider", return_value=[])
+    @patch(f"{MODULE}.delete_rule_by_id")
+    def test_orphan_cleanup_when_no_remaining_lead_time(
+        self, mock_delete, mock_get_rules, mock_sync, mock_lead, mock_access
+    ):
+        cal = MagicMock()
+        cal.id = "cal-9"
+        evt = MagicMock()
+        evt.id = "evt-9"
+        del_effect = MagicMock()
+        event_effect = MagicMock()
+        event_effect.delete.return_value = del_effect
+
+        handler = _make_handler(
+            path_params={"provider_id": PROVIDER_ID, "rule_id": "r1"}
+        )
+        with patch(
+            "provider_availability.engine.admin_calendar.get_admin_calendars",
+            return_value=[cal],
+        ) as mock_cals, patch(
+            "canvas_sdk.v1.data.calendar.Event"
+        ) as mock_event_model, patch(
+            "canvas_sdk.effects.calendar.Event", return_value=event_effect
+        ) as mock_event_effect:
+            mock_event_model.objects.filter.return_value = [evt]
+            result = handler.delete_rule()
+
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert del_effect in result
+        assert mock_lead.mock_calls == []
+        assert mock_cals.mock_calls == [call(PROVIDER_ID)]
+        mock_event_effect.assert_called_once_with(event_id="evt-9")
+
+
+# ── add_override / remove_override: lead-time + recurring re-sync ──────────
+
+
+class TestOverrideResyncBranches:
+    def _rule(self) -> ProviderAvailabilityRule:
+        return ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={"thursday": [TimeWindow(start=time(9, 0), end=time(15, 0))]},
+            is_active=True,
+        )
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=["rb-fx"])
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.build_lead_time_block_effects", return_value=["lead-fx"])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.get_rules_for_provider")
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_add_override_resyncs_lead_time_and_recurring(
+        self,
+        mock_get,
+        mock_save,
+        mock_get_rules,
+        mock_sync,
+        mock_lead,
+        mock_get_rb,
+        mock_rb_sync,
+        mock_access,
+    ):
+        mock_get.return_value = self._rule()
+        mock_get_rules.return_value = [_lead_time_rule()]
+        active_rb = RecurringBlock(id="rb1", provider_id=PROVIDER_ID, is_active=True)
+        other_rb = RecurringBlock(
+            id="rb2", provider_id=PROVIDER_ID_2, is_active=True
+        )
+        mock_get_rb.return_value = [active_rb, other_rb]
+
+        handler = _make_handler(
+            path_params={"provider_id": PROVIDER_ID, "rule_id": "rule-1"},
+            # 2026-04-09 is a Thursday, which the rule schedules
+            json_body={"date": "2026-04-09", "time_windows": [{"start": "12:00", "end": "17:00"}]},
+        )
+        result = handler.add_override()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Override saved"
+        assert "lead-fx" in result
+        assert "rb-fx" in result
+        # Only the provider's own active recurring block is re-synced
+        assert mock_rb_sync.mock_calls == [call(active_rb)]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=["rb-fx"])
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.build_lead_time_block_effects", return_value=["lead-fx"])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.get_rules_for_provider")
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_remove_override_resyncs_lead_time_and_recurring(
+        self,
+        mock_get,
+        mock_save,
+        mock_get_rules,
+        mock_sync,
+        mock_lead,
+        mock_get_rb,
+        mock_rb_sync,
+        mock_access,
+    ):
+        existing = DateOverride(
+            date=date(2026, 4, 9),
+            time_windows=[TimeWindow(start=time(9, 0), end=time(12, 0))],
+        )
+        rule = self._rule()
+        rule.date_overrides = [existing]
+        mock_get.return_value = rule
+        mock_get_rules.return_value = [_lead_time_rule()]
+        active_rb = RecurringBlock(id="rb1", provider_id=PROVIDER_ID, is_active=True)
+        mock_get_rb.return_value = [active_rb]
+
+        handler = _make_handler(
+            path_params={
+                "provider_id": PROVIDER_ID,
+                "rule_id": "rule-1",
+                "override_date": "2026-04-09",
+            },
+        )
+        result = handler.remove_override()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Override removed"
+        assert len(rule.date_overrides) == 0
+        assert "lead-fx" in result
+        assert "rb-fx" in result
+        assert mock_rb_sync.mock_calls == [call(active_rb)]
+
+
+# ── create_block: per-date timed path + replace_recurring_block ────────────
+
+
+class TestCreateBlockBranches:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_block_event_effects", return_value=[])
+    @patch(f"{MODULE}.save_block")
+    def test_multi_date_timed_applies_time_of_day(
+        self, mock_save, mock_effects, mock_access
+    ):
+        """all_day=false with dates fans out timed blocks per date."""
+        body = {
+            "provider_id": PROVIDER_ID,
+            "dates": ["2026-07-06", "2026-07-07"],
+            "all_day": False,
+            "start": "09:00:00",
+            "end": "11:00:00",
+            "reason": "Timed batch",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_block()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.CREATED
+        assert data["message"] == "Created 2 block(s)"
+        assert data["blocks"][0]["start"] == "2026-07-06T09:00:00"
+        assert data["blocks"][0]["end"] == "2026-07-06T11:00:00"
+        assert data["blocks"][1]["start"] == "2026-07-07T09:00:00"
+        assert len(mock_save.mock_calls) == 2
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    def test_multi_date_timed_missing_start_end_errors(self, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "dates": ["2026-07-06"],
+            "all_day": False,
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_block()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "start and end are required when all_day=false" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    def test_multi_date_timed_start_after_end_errors(self, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "dates": ["2026-07-06"],
+            "all_day": False,
+            "start": "14:00:00",
+            "end": "09:00:00",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_block()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "Start must be before end for date 2026-07-06" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_block_event_effects", return_value=[])
+    @patch(f"{MODULE}.build_delete_recurring_block_effects", return_value=["del-rb"])
+    @patch(f"{MODULE}.delete_recurring_block")
+    @patch(f"{MODULE}.get_recurring_block_by_id")
+    @patch(f"{MODULE}.save_block")
+    def test_single_block_replaces_recurring_block(
+        self,
+        mock_save,
+        mock_get_rb,
+        mock_del_rb,
+        mock_del_effects,
+        mock_effects,
+        mock_access,
+    ):
+        old_rb = RecurringBlock(id="rb-old", provider_id=PROVIDER_ID)
+        mock_get_rb.return_value = old_rb
+        body = {
+            "provider_id": PROVIDER_ID,
+            "start": "2026-03-10T09:00:00",
+            "end": "2026-03-10T12:00:00",
+            "replace_recurring_block_id": "rb-old",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_block()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.CREATED
+        assert data["message"] == "Block created"
+        assert "del-rb" in result
+        assert mock_get_rb.mock_calls == [call(PROVIDER_ID, "rb-old")]
+        assert mock_del_rb.mock_calls == [call(PROVIDER_ID, "rb-old")]
+        assert mock_del_effects.mock_calls == [call(PROVIDER_ID, old_rb)]
+
+
+# ── update_block: apply_to_group skip-self ─────────────────────────────────
+
+
+class TestUpdateBlockGroupSkipsSelf:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_block_event_effects", return_value=[])
+    @patch(f"{MODULE}.save_block")
+    @patch(f"{MODULE}.build_delete_block_effects", return_value=[])
+    @patch(f"{MODULE}.get_block_by_id", return_value=None)
+    @patch(f"{MODULE}.get_blocks_by_group")
+    def test_group_update_skips_same_id(
+        self,
+        mock_group,
+        mock_get,
+        mock_del_effects,
+        mock_save,
+        mock_create_effects,
+        mock_access,
+    ):
+        same = AdminBlock(
+            id="b1",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 8, 0),
+            end=datetime(2026, 3, 10, 11, 0),
+            group_id="g1",
+        )
+        mock_group.return_value = [same]
+        body = {
+            "id": "b1",
+            "provider_id": PROVIDER_ID,
+            "start": "2026-03-10T09:00:00",
+            "end": "2026-03-10T12:00:00",
+            "group_id": "g1",
+            "apply_to_group": True,
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.update_block()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Updated 1 block(s)" in data["message"]
+        # Only the primary block is saved (group member shares id and is skipped)
+        assert len(mock_save.mock_calls) == 1
+
+
+# ── delete_block_endpoint: apply_to_group ──────────────────────────────────
+
+
+class TestDeleteBlockApplyToGroup:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.delete_block")
+    @patch(f"{MODULE}.build_delete_block_effects", return_value=[])
+    @patch(f"{MODULE}.get_blocks_by_group")
+    @patch(f"{MODULE}.get_blocks_for_provider")
+    def test_deletes_all_group_members(
+        self, mock_get_blocks, mock_group, mock_effects, mock_delete, mock_access
+    ):
+        target = AdminBlock(
+            id="b1",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 7, 4, 0, 0),
+            end=datetime(2026, 7, 5, 0, 0),
+            group_id="g1",
+        )
+        member = AdminBlock(
+            id="b2",
+            provider_id=PROVIDER_ID_2,
+            start=datetime(2026, 12, 25, 0, 0),
+            end=datetime(2026, 12, 26, 0, 0),
+            group_id="g1",
+        )
+        mock_get_blocks.return_value = [target]
+        mock_group.return_value = [target, member]
+
+        handler = _make_handler(
+            path_params={"provider_id": PROVIDER_ID, "block_id": "b1"},
+            query_params={"apply_to_group": "true"},
+        )
+        result = handler.delete_block_endpoint()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["deleted_count"] == 2
+        assert data["message"] == "Deleted 2 block(s)"
+        assert mock_group.mock_calls == [call("g1")]
+        # Deleted both the target and the group member (target skipped in loop)
+        assert mock_delete.mock_calls == [
+            call(PROVIDER_ID, "b1"),
+            call(PROVIDER_ID_2, "b2"),
+        ]
+
+
+# ── create_recurring_block: replace_block branch ───────────────────────────
+
+
+class TestCreateRecurringBlockReplace:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=[])
+    @patch(f"{MODULE}.build_delete_block_effects", return_value=["del-blk"])
+    @patch(f"{MODULE}.delete_block")
+    @patch(f"{MODULE}.get_block_by_id")
+    @patch(f"{MODULE}.save_recurring_block")
+    def test_replaces_single_block(
+        self,
+        mock_save,
+        mock_get_block,
+        mock_del_block,
+        mock_del_effects,
+        mock_sync_effects,
+        mock_access,
+    ):
+        old_block = AdminBlock(
+            id="b-old",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 9, 0),
+            end=datetime(2026, 3, 10, 12, 0),
+        )
+        mock_get_block.return_value = old_block
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {"friday": [{"start": "12:00", "end": "13:00"}]},
+            "replace_block_id": "b-old",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_recurring_block()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.CREATED
+        assert data["message"] == "Recurring block created"
+        assert "del-blk" in result
+        assert mock_get_block.mock_calls == [call(PROVIDER_ID, "b-old")]
+        assert mock_del_block.mock_calls == [call(PROVIDER_ID, "b-old")]
+        assert mock_del_effects.mock_calls == [call(PROVIDER_ID, old_block)]
+
+
+# ── Per-provider timezone: get_provider_tz / get_all_provider_tzs ──────────
+
+
+class TestGetProviderTz:
+    def test_missing_provider_id(self):
+        handler = _make_handler(query_params={})
+        result = handler.get_provider_tz()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "provider_id is required" in data["error"]
+
+    @patch(f"{MODULE}.get_provider_timezone", return_value="US/Pacific")
+    def test_explicit_timezone(self, mock_get):
+        handler = _make_handler(query_params={"provider_id": PROVIDER_ID})
+        result = handler.get_provider_tz()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.OK
+        assert data["provider_id"] == PROVIDER_ID
+        assert data["timezone"] == "US/Pacific"
+        assert data["explicit"] is True
+        assert mock_get.mock_calls == [call(PROVIDER_ID)]
+
+    @patch(f"{MODULE}.get_practice_timezone", return_value="US/Eastern")
+    @patch(f"{MODULE}.get_provider_timezone", return_value=None)
+    def test_falls_back_to_practice_timezone(self, mock_get, mock_practice):
+        handler = _make_handler(query_params={"provider_id": PROVIDER_ID})
+        result = handler.get_provider_tz()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.OK
+        assert data["timezone"] == "US/Eastern"
+        assert data["explicit"] is False
+        assert mock_practice.mock_calls == [call()]
+
+
+class TestGetAllProviderTzs:
+    @patch(
+        f"{MODULE}.get_all_provider_timezones",
+        return_value={PROVIDER_ID: "US/Pacific"},
+    )
+    def test_returns_all(self, mock_all):
+        handler = _make_handler()
+        result = handler.get_all_provider_tzs()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.OK
+        assert data["timezones"] == {PROVIDER_ID: "US/Pacific"}
+        assert mock_all.mock_calls == [call()]
+
+
+# ── set_provider_tz ────────────────────────────────────────────────────────
+
+
+class TestSetProviderTz:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    def test_missing_provider_id(self, mock_access):
+        handler = _make_handler(json_body={"timezone": "US/Eastern"})
+        result = handler.set_provider_tz()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "provider_id is required" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    def test_invalid_timezone(self, mock_access):
+        handler = _make_handler(
+            json_body={"provider_id": PROVIDER_ID, "timezone": "Mars/Base"}
+        )
+        result = handler.set_provider_tz()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "Invalid timezone" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=["rb-fx"])
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=["sync-fx"])
+    @patch(f"{MODULE}.set_provider_timezone")
+    def test_success_resyncs_matching_recurring_blocks(
+        self, mock_set, mock_sync, mock_get_rb, mock_rb_sync, mock_access
+    ):
+        matching = RecurringBlock(id="rb1", provider_id=PROVIDER_ID)
+        other = RecurringBlock(id="rb2", provider_id=PROVIDER_ID_2)
+        mock_get_rb.return_value = [matching, other]
+
+        handler = _make_handler(
+            json_body={"provider_id": PROVIDER_ID, "timezone": "US/Pacific"}
+        )
+        result = handler.set_provider_tz()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["timezone"] == "US/Pacific"
+        assert data["provider_id"] == PROVIDER_ID
+        assert "sync-fx" in result
+        assert "rb-fx" in result
+        assert mock_set.mock_calls == [call(PROVIDER_ID, "US/Pacific")]
+        assert mock_sync.mock_calls == [call(PROVIDER_ID)]
+        # Only the matching provider's recurring block is re-synced
+        assert mock_rb_sync.mock_calls == [call(matching)]
+
+    @patch(f"{MODULE}._check_write_access")
+    def test_write_access_denied(self, mock_access):
+        from canvas_sdk.effects.simple_api import JSONResponse
+
+        mock_access.return_value = [
+            JSONResponse({"error": "Access denied"}, status_code=HTTPStatus.FORBIDDEN)
+        ]
+        handler = _make_handler(
+            json_body={"provider_id": PROVIDER_ID, "timezone": "US/Pacific"}
+        )
+        result = handler.set_provider_tz()
+        _, code = _parse(result[0])
+        assert code == HTTPStatus.FORBIDDEN
+
+
+# ── set_provider_tz_bulk ───────────────────────────────────────────────────
+
+
+class TestSetProviderTzBulk:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    def test_missing_provider_ids(self, mock_access):
+        handler = _make_handler(json_body={"timezone": "US/Eastern"})
+        result = handler.set_provider_tz_bulk()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "provider_ids is required" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    def test_invalid_timezone(self, mock_access):
+        handler = _make_handler(
+            json_body={"provider_ids": [PROVIDER_ID], "timezone": "Nowhere"}
+        )
+        result = handler.set_provider_tz_bulk()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "Invalid timezone" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=["rb-fx"])
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=["sync-fx"])
+    @patch(f"{MODULE}.set_provider_timezone")
+    def test_success_sets_all_and_resyncs(
+        self, mock_set, mock_sync, mock_get_rb, mock_rb_sync, mock_access
+    ):
+        matching = RecurringBlock(id="rb1", provider_id=PROVIDER_ID)
+        other = RecurringBlock(id="rb2", provider_id="not-in-list")
+        mock_get_rb.return_value = [matching, other]
+
+        handler = _make_handler(
+            json_body={
+                "provider_ids": [PROVIDER_ID, PROVIDER_ID_2],
+                "timezone": "US/Eastern",
+            }
+        )
+        result = handler.set_provider_tz_bulk()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["count"] == 2
+        assert data["timezone"] == "US/Eastern"
+        assert "sync-fx" in result
+        assert "rb-fx" in result
+        assert mock_set.mock_calls == [
+            call(PROVIDER_ID, "US/Eastern"),
+            call(PROVIDER_ID_2, "US/Eastern"),
+        ]
+        assert mock_sync.mock_calls == [call(PROVIDER_ID), call(PROVIDER_ID_2)]
+        assert mock_rb_sync.mock_calls == [call(matching)]
+
+
+# ── recurrence validation (daily) ──────────────────────────────────────────
+
+
+class TestRecurrenceValidation:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.resolve_provider_id", return_value=PROVIDER_ID)
+    def test_invalid_frequency_rejected(self, mock_resolve, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {},
+            "recurrence_frequency": "hourly",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_or_update_rule()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "recurrence_frequency must be one of" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.resolve_provider_id", return_value=PROVIDER_ID)
+    def test_non_integer_interval_rejected(self, mock_resolve, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {},
+            "recurrence_interval": "abc",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_or_update_rule()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "recurrence_interval must be an integer" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.resolve_provider_id", return_value=PROVIDER_ID)
+    def test_interval_below_one_rejected(self, mock_resolve, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {},
+            "recurrence_interval": 0,
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_or_update_rule()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "recurrence_interval must be >= 1" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.resolve_provider_id", return_value=PROVIDER_ID)
+    def test_daily_requires_time_windows(self, mock_resolve, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {},
+            "recurrence_frequency": "daily",
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_or_update_rule()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "time_windows is required when recurrence_frequency is 'daily'" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.resolve_provider_id", return_value=PROVIDER_ID)
+    def test_daily_time_window_start_after_end_rejected(self, mock_resolve, mock_access):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {},
+            "recurrence_frequency": "daily",
+            "time_windows": [{"start": "17:00", "end": "09:00"}],
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_or_update_rule()
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "Start time must be before end time" in data["error"]
+
+
+# ── create_or_update_rule: lead-time effect path ───────────────────────────
+
+
+class TestCreateRuleLeadTime:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects", return_value=["lead-fx"])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.check_rule_overlap", return_value=None)
+    @patch(f"{MODULE}.resolve_provider_id", return_value=PROVIDER_ID)
+    def test_active_lead_time_rule_appends_effects(
+        self, mock_resolve, mock_overlap, mock_save, mock_sync, mock_lead, mock_access
+    ):
+        body = {
+            "provider_id": PROVIDER_ID,
+            "weekly_schedule": {"monday": [{"start": "09:00", "end": "12:00"}]},
+            "is_active": True,
+            "booking_interval": {"min_lead_hours": 48},
+        }
+        handler = _make_handler(json_body=body)
+        result = handler.create_or_update_rule()
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.CREATED
+        assert "lead-fx" in result
+        assert mock_lead.mock_calls == [call(mock_lead.call_args[0][0])]
+
+
+# ── _form_set_provider_timezone / _form_set_provider_tz_bulk ───────────────
+
+
+class TestFormSetProviderTimezone:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    def test_missing_provider_id(self, mock_access):
+        handler = _make_handler()
+        result = handler._form_set_provider_timezone({"timezone": "US/Eastern"})
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "provider_id required" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    def test_invalid_timezone(self, mock_access):
+        handler = _make_handler()
+        result = handler._form_set_provider_timezone(
+            {"provider_id": PROVIDER_ID, "timezone": "Bad/Zone"}
+        )
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "Invalid timezone" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=["rb-fx"])
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=["sync-fx"])
+    @patch(f"{MODULE}.set_provider_timezone")
+    def test_success_resyncs(
+        self, mock_set, mock_sync, mock_get_rb, mock_rb_sync, mock_access
+    ):
+        matching = RecurringBlock(id="rb1", provider_id=PROVIDER_ID)
+        other = RecurringBlock(id="rb2", provider_id=PROVIDER_ID_2)
+        mock_get_rb.return_value = [matching, other]
+        handler = _make_handler()
+        result = handler._form_set_provider_timezone(
+            {"provider_id": PROVIDER_ID, "timezone": "US/Pacific"}
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Provider timezone set to US/Pacific" in data["message"]
+        assert "sync-fx" in result
+        assert "rb-fx" in result
+        assert mock_set.mock_calls == [call(PROVIDER_ID, "US/Pacific")]
+        assert mock_rb_sync.mock_calls == [call(matching)]
+
+
+class TestFormSetProviderTzBulk:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    def test_missing_provider_ids(self, mock_access):
+        handler = _make_handler()
+        result = handler._form_set_provider_tz_bulk({"timezone": "US/Eastern"})
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "provider_ids required" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    def test_invalid_timezone(self, mock_access):
+        handler = _make_handler()
+        result = handler._form_set_provider_tz_bulk(
+            {"provider_ids": [PROVIDER_ID], "timezone": "Bad"}
+        )
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "Invalid timezone" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=["rb-fx"])
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=["sync-fx"])
+    @patch(f"{MODULE}.set_provider_timezone")
+    def test_success(
+        self, mock_set, mock_sync, mock_get_rb, mock_rb_sync, mock_access
+    ):
+        matching = RecurringBlock(id="rb1", provider_id=PROVIDER_ID)
+        other = RecurringBlock(id="rb2", provider_id="unrelated")
+        mock_get_rb.return_value = [matching, other]
+        handler = _make_handler()
+        result = handler._form_set_provider_tz_bulk(
+            {"provider_ids": [PROVIDER_ID, PROVIDER_ID_2], "timezone": "US/Eastern"}
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Timezone set to US/Eastern for 2 providers" in data["message"]
+        assert mock_set.mock_calls == [
+            call(PROVIDER_ID, "US/Eastern"),
+            call(PROVIDER_ID_2, "US/Eastern"),
+        ]
+        assert mock_rb_sync.mock_calls == [call(matching)]
+
+
+# ── _dispatch_write routing for provider-timezone form paths ───────────────
+
+
+class TestDispatchWriteProviderTimezone:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=[])
+    @patch(f"{MODULE}.get_all_recurring_blocks", return_value=[])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.set_provider_timezone")
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    def test_put_provider_timezone(
+        self, mock_set, mock_sync, mock_get_rb, mock_rb_sync, mock_access
+    ):
+        handler = _make_handler()
+        result = handler._dispatch_write(
+            "PUT", "/provider-timezone", {"provider_id": PROVIDER_ID, "timezone": "US/Pacific"}
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Provider timezone set" in data["message"]
+        assert mock_set.mock_calls == [call(PROVIDER_ID, "US/Pacific")]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=[])
+    @patch(f"{MODULE}.get_all_recurring_blocks", return_value=[])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.set_provider_timezone")
+    @patch(f"{MODULE}.COMMON_TIMEZONES", ["US/Eastern", "US/Pacific", "UTC"])
+    def test_put_provider_timezones_bulk(
+        self, mock_set, mock_sync, mock_get_rb, mock_rb_sync, mock_access
+    ):
+        handler = _make_handler()
+        result = handler._dispatch_write(
+            "PUT",
+            "/provider-timezones/bulk",
+            {"provider_ids": [PROVIDER_ID], "timezone": "US/Eastern"},
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Timezone set to US/Eastern for 1 providers" in data["message"]
+        assert mock_set.mock_calls == [call(PROVIDER_ID, "US/Eastern")]
+
+
+# ── _check_write_access: secret-based path ─────────────────────────────────
+
+
+class TestCheckWriteAccessSecret:
+    def test_secret_allows_matching_staff(self):
+        request = MagicMock()
+        request.staff_id = "staff-42"
+        result = _check_write_access(
+            request, {"allowed-staff-keys": "staff-1, staff-42 , staff-9"}
+        )
+        assert result is None
+
+    def test_secret_denies_unlisted_staff(self):
+        request = MagicMock()
+        request.staff_id = "intruder"
+        result = _check_write_access(request, {"allowed-staff-keys": "staff-1,staff-2"})
+        assert result is not None
+        body, code = _parse(result[0])
+        assert code == HTTPStatus.FORBIDDEN
+        assert "Access denied" in body["error"]
+
+
+# ── _form_delete_rule: lead-time + orphan cleanup ──────────────────────────
+
+
+class TestFormDeleteRule:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects", return_value=["lead-fx"])
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.get_rules_for_provider")
+    @patch(f"{MODULE}.delete_rule_by_id")
+    def test_refreshes_lead_time(
+        self, mock_delete, mock_get_rules, mock_sync, mock_lead, mock_access
+    ):
+        mock_get_rules.return_value = [_lead_time_rule()]
+        handler = _make_handler()
+        result = handler._form_delete_rule(PROVIDER_ID, "r1")
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Rule deleted"
+        assert "lead-fx" in result
+        assert mock_delete.mock_calls == [call(PROVIDER_ID, "r1")]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_lead_time_block_effects")
+    @patch(f"{MODULE}.sync_provider_availability", return_value=[])
+    @patch(f"{MODULE}.get_rules_for_provider", return_value=[])
+    @patch(f"{MODULE}.delete_rule_by_id")
+    def test_orphan_cleanup(
+        self, mock_delete, mock_get_rules, mock_sync, mock_lead, mock_access
+    ):
+        cal = MagicMock()
+        cal.id = "cal-form"
+        evt = MagicMock()
+        evt.id = "evt-form"
+        del_effect = MagicMock()
+        event_effect = MagicMock()
+        event_effect.delete.return_value = del_effect
+
+        handler = _make_handler()
+        with patch(
+            "provider_availability.engine.admin_calendar.get_admin_calendars",
+            return_value=[cal],
+        ), patch("canvas_sdk.v1.data.calendar.Event") as mock_event_model, patch(
+            "canvas_sdk.effects.calendar.Event", return_value=event_effect
+        ) as mock_event_effect:
+            mock_event_model.objects.filter.return_value = [evt]
+            result = handler._form_delete_rule(PROVIDER_ID, "r1")
+
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert del_effect in result
+        assert mock_lead.mock_calls == []
+        mock_event_effect.assert_called_once_with(event_id="evt-form")
+
+
+# ── _form_add_override / _form_remove_override ─────────────────────────────
+
+
+class TestFormOverrideHelpers:
+    def _rule(self) -> ProviderAvailabilityRule:
+        return ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={"thursday": [TimeWindow(start=time(9, 0), end=time(15, 0))]},
+            is_active=True,
+        )
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id", return_value=None)
+    def test_add_override_rule_not_found(self, mock_get, mock_access):
+        handler = _make_handler()
+        result = handler._form_add_override(
+            PROVIDER_ID, "missing", {"date": "2026-04-09", "time_windows": [{"start": "12:00", "end": "17:00"}]}
+        )
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.NOT_FOUND
+        assert "Rule not found" in data["error"]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_add_override_missing_windows(self, mock_get, mock_access):
+        mock_get.return_value = self._rule()
+        handler = _make_handler()
+        result = handler._form_add_override(PROVIDER_ID, "rule-1", {"date": "2026-04-09"})
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "time window" in data["error"].lower()
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_add_override_bad_window(self, mock_get, mock_access):
+        mock_get.return_value = self._rule()
+        handler = _make_handler()
+        result = handler._form_add_override(
+            PROVIDER_ID, "rule-1", {"date": "2026-04-09", "time_windows": [{"start": "17:00", "end": "12:00"}]}
+        )
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "start must be before end" in data["error"].lower()
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_add_override_wrong_weekday(self, mock_get, mock_access):
+        mock_get.return_value = self._rule()
+        handler = _make_handler()
+        # 2026-04-06 is a Monday; rule only schedules Thursday
+        result = handler._form_add_override(
+            PROVIDER_ID, "rule-1", {"date": "2026-04-06", "time_windows": [{"start": "09:00", "end": "12:00"}]}
+        )
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.BAD_REQUEST
+        assert "monday" in data["error"].lower()
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.sync_provider_availability", return_value=["sync-fx"])
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_add_override_success(self, mock_get, mock_save, mock_sync, mock_access):
+        rule = self._rule()
+        mock_get.return_value = rule
+        handler = _make_handler()
+        result = handler._form_add_override(
+            PROVIDER_ID, "rule-1", {"date": "2026-04-09", "time_windows": [{"start": "12:00", "end": "17:00"}]}
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Override saved"
+        assert len(rule.date_overrides) == 1
+        assert "sync-fx" in result
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.get_rule_by_id", return_value=None)
+    def test_remove_override_rule_not_found(self, mock_get, mock_access):
+        handler = _make_handler()
+        result = handler._form_remove_override(PROVIDER_ID, "missing", "2026-04-09")
+        data, code = _parse(result[0])
+        assert code == HTTPStatus.NOT_FOUND
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.sync_provider_availability", return_value=["sync-fx"])
+    @patch(f"{MODULE}.save_rule")
+    @patch(f"{MODULE}.get_rule_by_id")
+    def test_remove_override_success(self, mock_get, mock_save, mock_sync, mock_access):
+        rule = self._rule()
+        rule.date_overrides = [
+            DateOverride(
+                date=date(2026, 4, 9),
+                time_windows=[TimeWindow(start=time(9, 0), end=time(12, 0))],
+            )
+        ]
+        mock_get.return_value = rule
+        handler = _make_handler()
+        result = handler._form_remove_override(PROVIDER_ID, "rule-1", "2026-04-09")
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Override removed"
+        assert len(rule.date_overrides) == 0
+        assert "sync-fx" in result
+
+
+# ── _form_create_block / _form_update_block / _form_create_recurring_block ─
+
+
+class TestFormBlockHelpers:
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_block_event_effects", return_value=[])
+    @patch(f"{MODULE}.build_delete_recurring_block_effects", return_value=["del-rb"])
+    @patch(f"{MODULE}.delete_recurring_block")
+    @patch(f"{MODULE}.get_recurring_block_by_id")
+    @patch(f"{MODULE}.save_block")
+    def test_create_block_replaces_recurring(
+        self, mock_save, mock_get_rb, mock_del_rb, mock_del_effects, mock_effects, mock_access
+    ):
+        old_rb = RecurringBlock(id="rb-old", provider_id=PROVIDER_ID)
+        mock_get_rb.return_value = old_rb
+        handler = _make_handler()
+        result = handler._form_create_block(
+            {
+                "provider_id": PROVIDER_ID,
+                "start": "2026-03-10T09:00:00",
+                "end": "2026-03-10T12:00:00",
+                "replace_recurring_block_id": "rb-old",
+            }
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Block created"
+        assert "del-rb" in result
+        assert mock_del_rb.mock_calls == [call(PROVIDER_ID, "rb-old")]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_block_event_effects", return_value=[])
+    @patch(f"{MODULE}.save_block")
+    @patch(f"{MODULE}.build_delete_block_effects", return_value=["del-blk"])
+    @patch(f"{MODULE}.get_block_by_id")
+    def test_update_block_with_existing_old_block(
+        self, mock_get, mock_del_effects, mock_save, mock_effects, mock_access
+    ):
+        old = AdminBlock(
+            id="b1",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 8, 0),
+            end=datetime(2026, 3, 10, 11, 0),
+        )
+        mock_get.return_value = old
+        handler = _make_handler()
+        result = handler._form_update_block(
+            {
+                "id": "b1",
+                "provider_id": PROVIDER_ID,
+                "start": "2026-03-10T09:00:00",
+                "end": "2026-03-10T12:00:00",
+            }
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Updated 1 block(s)" in data["message"]
+        assert "del-blk" in result
+        assert mock_del_effects.mock_calls == [call(PROVIDER_ID, old)]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=[])
+    @patch(f"{MODULE}.build_delete_block_effects", return_value=["del-blk"])
+    @patch(f"{MODULE}.delete_block")
+    @patch(f"{MODULE}.get_block_by_id")
+    @patch(f"{MODULE}.save_recurring_block")
+    def test_create_recurring_block_replaces_block(
+        self, mock_save, mock_get_block, mock_del_block, mock_del_effects, mock_sync, mock_access
+    ):
+        old_block = AdminBlock(
+            id="b-old",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 9, 0),
+            end=datetime(2026, 3, 10, 12, 0),
+        )
+        mock_get_block.return_value = old_block
+        handler = _make_handler()
+        result = handler._form_create_recurring_block(
+            {
+                "provider_id": PROVIDER_ID,
+                "weekly_schedule": {"friday": [{"start": "12:00", "end": "13:00"}]},
+                "replace_block_id": "b-old",
+            }
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert data["message"] == "Recurring block created"
+        assert "del-blk" in result
+        assert mock_del_block.mock_calls == [call(PROVIDER_ID, "b-old")]
+
+    @patch(f"{MODULE}._check_write_access", return_value=None)
+    @patch(f"{MODULE}.build_recurring_block_sync_effects", return_value=[])
+    @patch(f"{MODULE}.save_recurring_block")
+    @patch(f"{MODULE}.get_recurring_blocks_by_group")
+    def test_update_recurring_block_apply_to_group(
+        self, mock_group, mock_save, mock_effects, mock_access
+    ):
+        member = RecurringBlock(
+            id="rb2",
+            provider_id=PROVIDER_ID_2,
+            group_id="g1",
+            weekly_schedule={"tuesday": [TimeWindow(start=time(8, 0), end=time(9, 0))]},
+        )
+        mock_group.return_value = [member]
+        handler = _make_handler()
+        result = handler._form_update_recurring_block(
+            {
+                "id": "rb1",
+                "provider_id": PROVIDER_ID,
+                "group_id": "g1",
+                "apply_to_group": True,
+                "weekly_schedule": {"monday": [{"start": "09:00", "end": "12:00"}]},
+            }
+        )
+        data, code = _parse(result[-1])
+        assert code == HTTPStatus.OK
+        assert "Updated 2 recurring block(s)" in data["message"]
+        assert len(mock_save.mock_calls) == 2
+
+
+# ── _build_preloaded_data with data ────────────────────────────────────────
+
+
+class TestBuildPreloadedDataWithData:
+    @patch(f"{MODULE}.generate_template_csv", return_value="csv")
+    @patch(f"{MODULE}.get_all_provider_timezones", return_value={PROVIDER_ID: "US/Pacific"})
+    @patch(f"{MODULE}.get_provider_displays", return_value={PROVIDER_ID: {"name": "Dr. Smith"}})
+    @patch(f"{MODULE}.get_all_recurring_blocks")
+    @patch(f"{MODULE}.get_all_blocks")
+    @patch(f"{MODULE}.get_all_rules")
+    @patch(f"{MODULE}.get_practice_timezone", return_value="UTC")
+    @patch(f"{MODULE}.get_scheduleable_visit_types", return_value=[{"id": VISIT_TYPE_ID, "name": "Follow-up"}])
+    @patch(f"{MODULE}.get_active_locations", return_value=[{"id": LOCATION_ID, "name": "Main"}])
+    @patch(f"{MODULE}.get_active_providers", return_value=[{"id": PROVIDER_ID, "name": "Dr. Smith"}])
+    def test_assembles_overview_with_rules_blocks_recurring(
+        self,
+        mock_providers,
+        mock_locs,
+        mock_vts,
+        mock_practice,
+        mock_rules,
+        mock_blocks,
+        mock_rb,
+        mock_displays,
+        mock_ptzs,
+        mock_csv,
+    ):
+        rule = ProviderAvailabilityRule(
+            id="r1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            visit_types=[VISIT_TYPE_ID],
+        )
+        block = AdminBlock(
+            id="b1",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 9, 0),
+            end=datetime(2026, 3, 10, 12, 0),
+        )
+        recurring = RecurringBlock(
+            id="rb1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={"monday": [TimeWindow(start=time(9, 0), end=time(10, 0))]},
+        )
+        mock_rules.return_value = [rule]
+        mock_blocks.return_value = [block]
+        mock_rb.return_value = [recurring]
+
+        handler = _make_handler()
+        preloaded = handler._build_preloaded_data()
+
+        assert preloaded["csv_template"] == "csv"
+        assert preloaded["timezone"]["timezone"] == "UTC"
+        overview = preloaded["overview"]["providers"]
+        assert len(overview) == 1
+        prov = overview[0]
+        assert prov["provider_name"] == "Dr. Smith"
+        # Explicit provider timezone from get_all_provider_timezones wins over practice tz
+        assert prov["provider_timezone"] == "US/Pacific"
+        assert prov["provider_timezone_explicit"] is True
+        assert prov["rules"][0]["location_names"] == ["Main"]
+        assert prov["rules"][0]["visit_type_names"] == ["Follow-up"]
+        assert len(prov["blocks"]) == 1
+        assert len(prov["recurring_blocks"]) == 1

--- a/extensions/provider_availability/tests/api/test_csv_import_api.py
+++ b/extensions/provider_availability/tests/api/test_csv_import_api.py
@@ -1,0 +1,260 @@
+"""Tests for provider_availability.api.csv_import_api."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from unittest.mock import DEFAULT, MagicMock, patch
+
+from provider_availability.api.csv_import_api import CSVImportAPI
+
+CSV_MODULE = "provider_availability.api.csv_import_api"
+
+HEADER = (
+    "type,staff_key,location,visit_type,day,start,end,all_day,date,reason,"
+    "hold_type,buffer_pre,buffer_post,min_lead_hours,slot_minutes,"
+    "recurrence_frequency,recurrence_interval,effective_start,effective_end,group_key"
+)
+
+STAFF_IDS = {"1234567890"}
+LOCATIONS = [{"id": "loc-1", "name": "Main Clinic"}]
+VISIT_TYPES = [{"id": "vt-1", "name": "New Patient"}]
+
+
+def _parse(response) -> tuple[dict, int]:
+    body = json.loads(getattr(response, "content"))
+    return body, response.status_code
+
+
+def _handler(json_body: dict | None = None, secrets: dict | None = None) -> CSVImportAPI:
+    handler = CSVImportAPI(MagicMock())
+    handler.request = MagicMock()
+    handler.request.json.return_value = json_body or {}
+    handler.secrets = secrets or {}
+    return handler
+
+
+def _file_part(content: str) -> MagicMock:
+    fp = MagicMock()
+    fp.is_file.return_value = True
+    fp.content = content.encode("utf-8")
+    return fp
+
+
+def _set_upload(handler: CSVImportAPI, content: str | None) -> None:
+    form = {"file": _file_part(content)} if content is not None else {}
+    handler.request.form_data.return_value = form
+
+
+def _patch_lookups():
+    return patch.multiple(
+        CSV_MODULE,
+        get_active_staff_ids=MagicMock(return_value=STAFF_IDS),
+        get_active_locations=MagicMock(return_value=LOCATIONS),
+        get_scheduleable_visit_types=MagicMock(return_value=VISIT_TYPES),
+    )
+
+
+# -- template ----------------------------------------------------------------
+
+
+def test_download_template_returns_csv():
+    handler = _handler()
+    result = handler.download_template()
+    resp = result[0]
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.headers["Content-Type"] == "text/csv"
+    assert b"staff_key" in resp.content
+
+
+# -- validate ----------------------------------------------------------------
+
+
+def test_validate_missing_file_returns_400():
+    handler = _handler()
+    _set_upload(handler, None)
+    body, status = _parse(handler.validate_upload()[0])
+    assert status == HTTPStatus.BAD_REQUEST
+    assert "No CSV file" in body["error"]
+
+
+def test_validate_not_a_file_returns_400():
+    handler = _handler()
+    fp = MagicMock()
+    fp.is_file.return_value = False
+    handler.request.form_data.return_value = {"file": fp}
+    _, status = _parse(handler.validate_upload()[0])
+    assert status == HTTPStatus.BAD_REQUEST
+
+
+def test_validate_groups_rows_into_one_rule():
+    handler = _handler()
+    csv = (
+        HEADER + "\n"
+        + "rule,1234567890,Main Clinic,,monday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+        + "rule,1234567890,Main Clinic,,monday,13:00,17:00,,,,,,,,,weekly,1,,,\n"
+    )
+    _set_upload(handler, csv)
+    with _patch_lookups(), patch(CSV_MODULE + ".check_rule_overlap", return_value=None):
+        body, _ = _parse(handler.validate_upload()[0])
+    assert body["total_rows"] == 2
+    assert body["record_count"] == 1
+    assert body["rule_count"] == 1
+    assert body["error_count"] == 0
+    assert body["records"][0]["provider_id"] == "1234567890"
+
+
+def test_validate_surfaces_structural_error():
+    handler = _handler()
+    csv = HEADER + "\n" + "rule,1234567890,Main Clinic,,funday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+    _set_upload(handler, csv)
+    with _patch_lookups(), patch(CSV_MODULE + ".check_rule_overlap", return_value=None):
+        body, _ = _parse(handler.validate_upload()[0])
+    assert body["error_count"] == 1
+    assert body["errors"][0]["row_number"] == 2
+    assert any("day must be one of" in e for e in body["errors"][0]["errors"])
+
+
+def test_validate_surfaces_unknown_provider():
+    handler = _handler()
+    csv = HEADER + "\n" + "rule,0000000000,Main Clinic,,monday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+    _set_upload(handler, csv)
+    with _patch_lookups(), patch(CSV_MODULE + ".check_rule_overlap", return_value=None):
+        body, _ = _parse(handler.validate_upload()[0])
+    assert body["record_count"] == 0
+    assert "not found" in body["errors"][0]["errors"][0]
+
+
+def test_validate_flags_overlap_and_excludes_record():
+    handler = _handler()
+    csv = HEADER + "\n" + "rule,1234567890,Main Clinic,,monday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+    _set_upload(handler, csv)
+    with _patch_lookups(), patch(
+        CSV_MODULE + ".check_rule_overlap", return_value="Overlapping availability on Monday"
+    ):
+        body, _ = _parse(handler.validate_upload()[0])
+    assert body["record_count"] == 0
+    assert body["error_count"] == 1
+    assert "Overlapping" in body["errors"][0]["errors"][0]
+
+
+def test_validate_counts_blocks_and_rblocks():
+    handler = _handler()
+    csv = (
+        HEADER + "\n"
+        + "block,1234567890,,,,,,true,2026-07-04,Holiday,,,,,,,,,,\n"
+        + "rblock,1234567890,,,monday,12:00,13:00,,,Lunch,none,,,,,weekly,1,,,\n"
+    )
+    _set_upload(handler, csv)
+    with _patch_lookups(), patch(CSV_MODULE + ".check_rule_overlap", return_value=None):
+        body, _ = _parse(handler.validate_upload()[0])
+    assert body["block_count"] == 1
+    assert body["rblock_count"] == 1
+    assert body["record_count"] == 2
+
+
+# -- commit ------------------------------------------------------------------
+
+
+def test_commit_denied_when_not_authorized():
+    handler = _handler(json_body={"records": [{"kind": "rule"}]})
+    denied = [MagicMock()]
+    with patch(CSV_MODULE + "._check_write_access", return_value=denied):
+        result = handler.commit_records()
+    assert result is denied
+
+
+def test_commit_no_records_returns_400():
+    handler = _handler(json_body={"records": []})
+    with patch(CSV_MODULE + "._check_write_access", return_value=None):
+        body, status = _parse(handler.commit_records()[0])
+    assert status == HTTPStatus.BAD_REQUEST
+
+
+def test_commit_saves_rule_block_rblock_and_syncs():
+    rule_rec = {
+        "kind": "rule", "provider_id": "prov-1", "location_ids": ["loc-1"],
+        "visit_types": [], "weekly_schedule": {"monday": [{"start": "09:00", "end": "12:00"}]},
+        "time_windows": [], "buffer_minutes": {"pre": 0, "post": 15},
+        "booking_interval": {"min_lead_hours": 24, "slot_granularity_minutes": 15},
+        "recurrence_frequency": "weekly", "recurrence_interval": 1,
+        "effective_start": None, "effective_end": None, "reason": "", "is_active": True,
+    }
+    block_rec = {
+        "kind": "block", "provider_id": "prov-1", "location_ids": [],
+        "start": "2026-07-04T00:00:00", "end": "2026-07-04T23:59:59",
+        "all_day": True, "reason": "Holiday",
+    }
+    rblock_rec = {
+        "kind": "rblock", "provider_id": "prov-1", "location_ids": [],
+        "weekly_schedule": {"monday": [{"start": "12:00", "end": "13:00"}]},
+        "time_windows": [], "recurrence_frequency": "weekly", "recurrence_interval": 1,
+        "reason": "Lunch", "hold_type": "none", "effective_start": None,
+        "effective_end": None, "is_active": True,
+    }
+    handler = _handler(json_body={"records": [rule_rec, block_rec, rblock_rec]})
+
+    with patch(CSV_MODULE + "._check_write_access", return_value=None), patch.multiple(
+        CSV_MODULE,
+        save_rule=DEFAULT,
+        save_block=DEFAULT,
+        save_recurring_block=DEFAULT,
+        build_block_event_effects=DEFAULT,
+        build_recurring_block_sync_effects=DEFAULT,
+        sync_provider_availability=DEFAULT,
+        build_lead_time_block_effects=DEFAULT,
+        get_rules_for_provider=DEFAULT,
+    ) as mocks:
+        mocks["build_block_event_effects"].return_value = ["blk-eff"]
+        mocks["build_recurring_block_sync_effects"].return_value = ["rb-eff"]
+        mocks["sync_provider_availability"].return_value = ["sync-eff"]
+        mocks["build_lead_time_block_effects"].return_value = ["lead-eff"]
+        mocks["get_rules_for_provider"].return_value = []
+        result = handler.commit_records()
+
+    body, _ = _parse(result[-1])
+    assert body["created_rules"] == 1
+    assert body["created_blocks"] == 1
+    assert body["created_recurring_blocks"] == 1
+
+    mocks["save_rule"].assert_called_once()
+    mocks["save_block"].assert_called_once()
+    mocks["save_recurring_block"].assert_called_once()
+    # One provider touched -> synced exactly once
+    mocks["sync_provider_availability"].assert_called_once_with("prov-1")
+
+    # Effects from block, rblock, and provider sync are all forwarded
+    assert "blk-eff" in result
+    assert "rb-eff" in result
+    assert "sync-eff" in result
+
+
+def test_commit_refreshes_lead_time_for_active_rules():
+    rule_rec = {
+        "kind": "rule", "provider_id": "prov-1", "location_ids": [], "visit_types": [],
+        "weekly_schedule": {"monday": [{"start": "09:00", "end": "12:00"}]}, "time_windows": [],
+        "buffer_minutes": {"pre": 0, "post": 15},
+        "booking_interval": {"min_lead_hours": 24, "slot_granularity_minutes": 15},
+        "recurrence_frequency": "weekly", "recurrence_interval": 1,
+        "effective_start": None, "effective_end": None, "reason": "", "is_active": True,
+    }
+    handler = _handler(json_body={"records": [rule_rec]})
+
+    saved_rule = MagicMock()
+    saved_rule.is_active = True
+    saved_rule.booking_interval.min_lead_hours = 24
+
+    with patch(CSV_MODULE + "._check_write_access", return_value=None), patch.multiple(
+        CSV_MODULE,
+        save_rule=DEFAULT,
+        sync_provider_availability=DEFAULT,
+        build_lead_time_block_effects=DEFAULT,
+        get_rules_for_provider=DEFAULT,
+    ) as mocks:
+        mocks["sync_provider_availability"].return_value = []
+        mocks["build_lead_time_block_effects"].return_value = ["lead-eff"]
+        mocks["get_rules_for_provider"].return_value = [saved_rule]
+        result = handler.commit_records()
+
+    mocks["build_lead_time_block_effects"].assert_called_once_with(saved_rule)
+    assert "lead-eff" in result

--- a/extensions/provider_availability/tests/engine/test_csv_import.py
+++ b/extensions/provider_availability/tests/engine/test_csv_import.py
@@ -1,0 +1,425 @@
+"""Tests for the bulk availability CSV import engine."""
+
+from provider_availability.engine.csv_import import (
+    ParseResult,
+    build_records,
+    generate_template_csv,
+    parse_csv,
+    validate_row,
+)
+
+HEADER = (
+    "type,staff_key,location,visit_type,day,start,end,all_day,date,reason,"
+    "hold_type,buffer_pre,buffer_post,min_lead_hours,slot_minutes,"
+    "recurrence_frequency,recurrence_interval,effective_start,effective_end,group_key"
+)
+
+
+def _rule_row(**over):
+    row = {
+        "type": "rule",
+        "staff_key": "1234567890",
+        "location": "Main Clinic",
+        "visit_type": "",
+        "day": "monday",
+        "start": "09:00",
+        "end": "12:00",
+        "recurrence_frequency": "weekly",
+    }
+    row.update(over)
+    return row
+
+
+# -- validate_row ------------------------------------------------------------
+
+
+def test_validate_row_rejects_unknown_type():
+    assert validate_row({"type": "widget", "staff_key": "1"}) == [
+        "type must be one of: rule, block, rblock"
+    ]
+
+
+def test_validate_row_requires_staff_key():
+    assert validate_row({"type": "rule", "staff_key": ""}) == ["staff_key is required"]
+
+
+def test_validate_rule_row_valid_has_no_errors():
+    assert validate_row(_rule_row()) == []
+
+
+def test_validate_rule_row_bad_day():
+    errors = validate_row(_rule_row(day="funday"))
+    assert any("day must be one of" in e for e in errors)
+
+
+def test_validate_rule_row_daily_ignores_day():
+    row = _rule_row(recurrence_frequency="daily", day="")
+    assert validate_row(row) == []
+
+
+def test_validate_rule_row_bad_time_format():
+    errors = validate_row(_rule_row(start="9am"))
+    assert "start must be HH:MM (24-hour)" in errors
+
+
+def test_validate_rule_row_start_after_end():
+    errors = validate_row(_rule_row(start="17:00", end="09:00"))
+    assert any("start must be before end" in e for e in errors)
+
+
+def test_validate_rule_row_bad_integer_field():
+    errors = validate_row(_rule_row(buffer_post="lots"))
+    assert "buffer_post must be a whole number" in errors
+
+
+def test_validate_rule_row_negative_lead_hours():
+    errors = validate_row(_rule_row(min_lead_hours="-1"))
+    assert "min_lead_hours must be >= 0" in errors
+
+
+def test_validate_rule_row_slot_minutes_minimum_one():
+    errors = validate_row(_rule_row(slot_minutes="0"))
+    assert "slot_minutes must be >= 1" in errors
+
+
+def test_validate_rule_row_bad_effective_date():
+    errors = validate_row(_rule_row(effective_start="07/01/2026"))
+    assert "effective_start must be YYYY-MM-DD" in errors
+
+
+def test_validate_rule_row_bad_recurrence_frequency():
+    errors = validate_row(_rule_row(recurrence_frequency="monthly"))
+    assert any("recurrence_frequency must be one of" in e for e in errors)
+
+
+def test_validate_rule_row_bad_recurrence_interval():
+    errors = validate_row(_rule_row(recurrence_interval="0"))
+    assert "recurrence_interval must be >= 1" in errors
+
+
+def test_validate_block_row_requires_date():
+    row = {"type": "block", "staff_key": "1", "all_day": "true", "date": ""}
+    assert "date is required for a block row" in validate_row(row)
+
+
+def test_validate_block_row_bad_date():
+    row = {"type": "block", "staff_key": "1", "all_day": "true", "date": "nope"}
+    assert "date must be YYYY-MM-DD" in validate_row(row)
+
+
+def test_validate_block_row_all_day_needs_no_window():
+    row = {"type": "block", "staff_key": "1", "all_day": "true", "date": "2026-07-04"}
+    assert validate_row(row) == []
+
+
+def test_validate_block_row_timed_needs_window():
+    row = {"type": "block", "staff_key": "1", "all_day": "false", "date": "2026-07-04",
+           "start": "09:00", "end": "10:00"}
+    assert validate_row(row) == []
+
+
+def test_validate_block_row_timed_missing_window():
+    row = {"type": "block", "staff_key": "1", "all_day": "false", "date": "2026-07-04"}
+    assert "start must be HH:MM (24-hour)" in validate_row(row)
+
+
+def test_validate_rblock_row_valid():
+    row = {"type": "rblock", "staff_key": "1", "day": "monday", "start": "12:00",
+           "end": "13:00", "hold_type": "same_day"}
+    assert validate_row(row) == []
+
+
+def test_validate_rblock_row_bad_hold_type():
+    row = {"type": "rblock", "staff_key": "1", "day": "monday", "start": "12:00",
+           "end": "13:00", "hold_type": "maybe"}
+    assert any("hold_type must be one of" in e for e in validate_row(row))
+
+
+# -- parse_csv ---------------------------------------------------------------
+
+
+def test_parse_csv_empty_returns_empty_result():
+    result = parse_csv("")
+    assert isinstance(result, ParseResult)
+    assert result.total_rows == 0
+    assert result.valid_rows == []
+
+
+def test_parse_csv_header_only():
+    result = parse_csv(HEADER + "\n")
+    assert result.total_rows == 0
+
+
+def test_parse_csv_valid_and_error_rows():
+    body = (
+        HEADER + "\n"
+        + "rule,1234567890,Main Clinic,,monday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+        + "rule,1234567890,Main Clinic,,funday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+    )
+    result = parse_csv(body)
+    assert result.total_rows == 2
+    assert len(result.valid_rows) == 1
+    assert len(result.error_rows) == 1
+    assert result.error_rows[0].row_number == 3
+
+
+def test_parse_csv_skips_blank_lines():
+    body = HEADER + "\n\n" + "rule,1234567890,Main Clinic,,monday,09:00,12:00,,,,,,,,,weekly,1,,,\n\n"
+    result = parse_csv(body)
+    assert result.total_rows == 1
+    assert len(result.valid_rows) == 1
+
+
+def test_parse_csv_strips_bom():
+    body = "﻿" + HEADER + "\nrule,1234567890,Main Clinic,,monday,09:00,12:00,,,,,,,,,weekly,1,,,\n"
+    result = parse_csv(body)
+    assert len(result.valid_rows) == 1
+
+
+def test_parse_csv_handles_quoted_reason_with_comma():
+    body = (
+        HEADER + "\n"
+        + 'block,1234567890,,,,,,true,2026-07-04,"Closed, all day",,,,,,,,,,\n'
+    )
+    result = parse_csv(body)
+    assert len(result.valid_rows) == 1
+    assert result.valid_rows[0].data["reason"] == "Closed, all day"
+
+
+def test_parse_csv_short_row_pads_missing_fields():
+    body = HEADER + "\n" + "rule,1234567890,Main Clinic,,monday,09:00,12:00\n"
+    result = parse_csv(body)
+    assert len(result.valid_rows) == 1
+
+
+# -- build_records -----------------------------------------------------------
+
+VALID_STAFF = {"1234567890", "9999999999"}
+LOCATION_MAP = {"main clinic": "loc-1", "east clinic": "loc-2"}
+VISIT_MAP = {"new patient": "vt-1"}
+
+
+def _valid_rows(rows):
+    """Build a ParseResult's valid_rows from raw dicts, asserting each is valid."""
+    result = parse_csv(HEADER + "\n" + "\n".join(
+        ",".join(_line(r)) for r in rows
+    ))
+    assert result.error_rows == [], [e.errors for e in result.error_rows]
+    return result.valid_rows
+
+
+def _line(row):
+    order = HEADER.split(",")
+    return [row.get(col, "") for col in order]
+
+
+def test_build_records_groups_windows_into_one_rule():
+    rows = [
+        _rule_row(day="monday", start="09:00", end="12:00"),
+        _rule_row(day="monday", start="13:00", end="17:00"),
+        _rule_row(day="wednesday", start="09:00", end="12:00"),
+    ]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert len(records) == 1
+    rule = records[0]
+    assert rule["kind"] == "rule"
+    assert rule["provider_id"] == "1234567890"
+    assert rule["location_ids"] == ["loc-1"]
+    assert rule["weekly_schedule"]["monday"] == [
+        {"start": "09:00", "end": "12:00"},
+        {"start": "13:00", "end": "17:00"},
+    ]
+    assert rule["weekly_schedule"]["wednesday"] == [{"start": "09:00", "end": "12:00"}]
+    assert sorted(rule["source_rows"]) == [2, 3, 4]
+
+
+def test_build_records_separate_rules_for_different_locations():
+    rows = [
+        _rule_row(location="Main Clinic"),
+        _rule_row(location="East Clinic"),
+    ]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert len(records) == 2
+
+
+def test_build_records_group_key_forces_merge():
+    rows = [
+        _rule_row(location="Main Clinic", group_key="k1", day="monday"),
+        _rule_row(location="East Clinic", group_key="k1", day="tuesday"),
+    ]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert len(records) == 1
+
+
+def test_build_records_defaults_buffer_and_booking():
+    records, _ = build_records(_valid_rows([_rule_row()]), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    rule = records[0]
+    assert rule["buffer_minutes"] == {"pre": 0, "post": 15}
+    assert rule["booking_interval"] == {"min_lead_hours": 24, "slot_granularity_minutes": 15}
+
+
+def test_build_records_custom_buffer_and_booking():
+    rows = [_rule_row(buffer_pre="10", buffer_post="20", min_lead_hours="48", slot_minutes="30")]
+    records, _ = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    rule = records[0]
+    assert rule["buffer_minutes"] == {"pre": 10, "post": 20}
+    assert rule["booking_interval"] == {"min_lead_hours": 48, "slot_granularity_minutes": 30}
+
+
+def test_build_records_resolves_visit_type():
+    rows = [_rule_row(visit_type="New Patient")]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert records[0]["visit_types"] == ["vt-1"]
+
+
+def test_build_records_unknown_provider_is_error():
+    rows = [_rule_row(staff_key="0000000000")]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert records == []
+    assert len(errors) == 1
+    assert "not found" in errors[0].errors[0]
+
+
+def test_build_records_unknown_location_is_error():
+    rows = [_rule_row(location="Mian Clinic")]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert records == []
+    assert "location 'Mian Clinic' not found" in errors[0].errors
+
+
+def test_build_records_unknown_visit_type_is_error():
+    rows = [_rule_row(visit_type="Telehealth")]
+    _, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert "visit_type 'Telehealth' not found" in errors[0].errors
+
+
+def test_build_records_empty_location_means_all():
+    rows = [_rule_row(location="")]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert records[0]["location_ids"] == []
+
+
+def test_build_records_multiple_locations_pipe_separated():
+    rows = [_rule_row(location="Main Clinic|East Clinic")]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert sorted(records[0]["location_ids"]) == ["loc-1", "loc-2"]
+
+
+def test_build_records_intra_group_window_overlap_is_error():
+    rows = [
+        _rule_row(day="monday", start="09:00", end="12:00"),
+        _rule_row(day="monday", start="11:00", end="13:00"),
+    ]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert len(errors) == 1
+    assert "overlaps another monday window" in errors[0].errors[0]
+    # First window still recorded on the rule
+    assert records[0]["weekly_schedule"]["monday"] == [{"start": "09:00", "end": "12:00"}]
+
+
+def test_build_records_daily_rule_uses_time_windows():
+    rows = [
+        _rule_row(recurrence_frequency="daily", day="", start="09:00", end="12:00"),
+        _rule_row(recurrence_frequency="daily", day="", start="13:00", end="17:00"),
+    ]
+    records, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    assert records[0]["time_windows"] == [
+        {"start": "09:00", "end": "12:00"},
+        {"start": "13:00", "end": "17:00"},
+    ]
+
+
+def test_build_records_daily_overlap_is_error():
+    rows = [
+        _rule_row(recurrence_frequency="daily", day="", start="09:00", end="12:00"),
+        _rule_row(recurrence_frequency="daily", day="", start="10:00", end="11:00"),
+    ]
+    _, errors = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert "overlaps another window in the same daily group" in errors[0].errors[0]
+
+
+def test_build_records_all_day_block():
+    row = {"type": "block", "staff_key": "1234567890", "all_day": "true",
+           "date": "2026-07-04", "reason": "Holiday"}
+    records, errors = build_records(_valid_rows([row]), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    block = records[0]
+    assert block["kind"] == "block"
+    assert block["start"] == "2026-07-04T00:00:00"
+    assert block["end"] == "2026-07-04T23:59:59"
+    assert block["all_day"] is True
+    assert block["reason"] == "Holiday"
+
+
+def test_build_records_timed_block():
+    row = {"type": "block", "staff_key": "1234567890", "all_day": "false",
+           "date": "2026-07-04", "start": "09:00", "end": "10:30"}
+    records, _ = build_records(_valid_rows([row]), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    block = records[0]
+    assert block["start"] == "2026-07-04T09:00:00"
+    assert block["end"] == "2026-07-04T10:30:00"
+    assert block["all_day"] is False
+
+
+def test_build_records_recurring_block():
+    row = {"type": "rblock", "staff_key": "1234567890", "day": "monday",
+           "start": "12:00", "end": "13:00", "reason": "Lunch", "hold_type": "same_day"}
+    records, errors = build_records(_valid_rows([row]), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert errors == []
+    rb = records[0]
+    assert rb["kind"] == "rblock"
+    assert rb["hold_type"] == "same_day"
+    assert rb["weekly_schedule"]["monday"] == [{"start": "12:00", "end": "13:00"}]
+
+
+def test_build_records_recurring_block_default_hold_none():
+    row = {"type": "rblock", "staff_key": "1234567890", "day": "monday",
+           "start": "12:00", "end": "13:00"}
+    records, _ = build_records(_valid_rows([row]), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert records[0]["hold_type"] == "none"
+
+
+def test_build_records_effective_dates_preserved():
+    rows = [_rule_row(effective_start="2026-07-01", effective_end="2026-12-31")]
+    records, _ = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert records[0]["effective_start"] == "2026-07-01"
+    assert records[0]["effective_end"] == "2026-12-31"
+
+
+def test_build_records_no_effective_dates_are_none():
+    records, _ = build_records(_valid_rows([_rule_row()]), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert records[0]["effective_start"] is None
+    assert records[0]["effective_end"] is None
+
+
+# -- template ----------------------------------------------------------------
+
+
+def test_records_have_no_underscore_keys():
+    # The Canvas RestrictedPython sandbox forbids subscripting dict keys that
+    # start with "_". Every record dict must therefore avoid such keys.
+    rows = [
+        _rule_row(),
+        {"type": "block", "staff_key": "1234567890", "all_day": "true", "date": "2026-07-04"},
+        {"type": "rblock", "staff_key": "1234567890", "day": "monday", "start": "12:00", "end": "13:00"},
+    ]
+    records, _ = build_records(_valid_rows(rows), VALID_STAFF, LOCATION_MAP, VISIT_MAP)
+    assert records
+    for rec in records:
+        assert not any(k.startswith("_") for k in rec), rec
+
+
+def test_generate_template_csv_round_trips():
+    template = generate_template_csv()
+    result = parse_csv(template)
+    assert result.error_rows == []
+    assert result.total_rows == 4
+    kinds = {r.data["type"] for r in result.valid_rows}
+    assert kinds == {"rule", "block", "rblock"}

--- a/extensions/provider_availability/tests/engine/test_event_sync_coverage.py
+++ b/extensions/provider_availability/tests/engine/test_event_sync_coverage.py
@@ -1,0 +1,1187 @@
+"""Coverage tests for provider_availability.engine.event_sync.
+
+Targets previously-uncovered branches: daily recurrence, hold-type blocks,
+effective-date windows, override maps, and hold-cleanup delete paths.
+
+Mirrors the mocking patterns in test_event_sync.py exactly:
+- patch(f"{MODULE}.<name>") for SDK models and helpers
+- to_utc / localize_naive patched with identity-style side_effects
+- date patched so date.today() is deterministic while date(...) construction works
+- EventEffect.create() / delete() mocked; assertions on call kwargs
+"""
+
+import datetime as dt
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, call, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from canvas_sdk.effects.calendar import EventRecurrence
+
+from provider_availability.engine.models import (
+    DateOverride,
+    ProviderAvailabilityRule,
+    RecurringBlock,
+    TimeWindow,
+)
+from provider_availability.engine.event_sync import (
+    AVAILABILITY_TITLE,
+    HOLD_TITLE_PREFIXES,
+    RECURRING_BLOCK_TITLE,
+    _block_outside_override,
+    _build_hold_block_events,
+    _build_rule_events,
+    _compute_recurring_segments,
+    _get_provider_override_map,
+    build_block_event_effects,
+    build_delete_block_effects,
+    build_delete_recurring_block_effects,
+    build_hold_block_refresh_effects,
+    build_lead_time_block_effects,
+    build_recurring_block_sync_effects,
+)
+from provider_availability.engine.models import BookingInterval
+
+MODULE = "provider_availability.engine.event_sync"
+PROVIDER_ID = "provider-uuid-123"
+LOCATION_ID = "location-uuid-456"
+
+
+# ── _build_rule_events: DAILY path (lines 124-125, 172-216) ───────────
+
+
+class TestBuildRuleEventsDaily:
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}._get_calendar_id")
+    def test_daily_no_time_windows_returns_empty(self, mock_get_cal, mock_tz):
+        """Daily rule with no time_windows returns empty (lines 124-125)."""
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            recurrence_frequency="daily",
+            time_windows=[],
+        )
+        result = _build_rule_events(rule)
+
+        assert result == []
+        assert mock_get_cal.mock_calls == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}._get_calendar_id")
+    def test_daily_single_window_creates_daily_recurring_event(
+        self, mock_get_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily rule emits one Daily recurring event per time_window (lines 183-198)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_cal.return_value = ("cal-daily-1", [])
+
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            recurrence_frequency="daily",
+            recurrence_interval=1,
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))],
+            effective_end=date(2026, 3, 31),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_rule_events(rule)
+
+            init_call = mock_event_effect.call_args_list[0]
+            assert init_call.kwargs["title"] == AVAILABILITY_TITLE
+            assert init_call.kwargs["calendar_id"] == "cal-daily-1"
+            assert init_call.kwargs["recurrence_frequency"] == EventRecurrence.Daily
+            assert init_call.kwargs["recurrence_interval"] == 1
+            # anchor is today (2026-03-02), starts_at at 09:00
+            assert init_call.kwargs["starts_at"].month == 3
+            assert init_call.kwargs["starts_at"].day == 2
+            assert init_call.kwargs["starts_at"].hour == 9
+
+        assert len(result) == 1
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}._get_calendar_id")
+    def test_daily_anchor_advances_to_pattern(
+        self, mock_get_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily interval>1 with past effective_start advances anchor (lines 172-179)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_cal.return_value = ("cal-daily-1", [])
+
+        # effective_start 2026-02-27, today 2026-03-02, interval 3.
+        # offset = (03-02 - 02-27).days = 3; 3 % 3 == 0 so anchor = range_start = today.
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            recurrence_frequency="daily",
+            recurrence_interval=3,
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))],
+            effective_start=date(2026, 2, 27),
+            effective_end=date(2026, 3, 31),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_rule_events(rule)
+
+            init_call = mock_event_effect.call_args_list[0]
+            # anchor lands on today (2026-03-02) since offset%interval == 0
+            assert init_call.kwargs["starts_at"].day == 2
+
+        assert len(result) == 1
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}._get_calendar_id")
+    def test_daily_anchor_offset_not_aligned_advances(
+        self, mock_get_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily interval>1 with offset not divisible advances to next in-pattern date (line 177)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_cal.return_value = ("cal-daily-1", [])
+
+        # effective_start 2026-02-28, today 2026-03-02, interval 5.
+        # offset = 2; 2 % 5 != 0 -> anchor = range_start + (5 - 2) = 03-02 + 3 = 03-05
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            recurrence_frequency="daily",
+            recurrence_interval=5,
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))],
+            effective_start=date(2026, 2, 28),
+            effective_end=date(2026, 3, 31),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_rule_events(rule)
+
+            init_call = mock_event_effect.call_args_list[0]
+            assert init_call.kwargs["starts_at"].day == 5
+
+        assert len(result) == 1
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}._get_calendar_id")
+    def test_daily_anchor_beyond_range_end_skips(
+        self, mock_get_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily anchor after range_end skips the location (lines 180-181)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_cal.return_value = ("cal-daily-1", [])
+
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            recurrence_frequency="daily",
+            recurrence_interval=1,
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))],
+            effective_start=date(2026, 4, 1),
+            effective_end=date(2026, 3, 15),  # end before start -> anchor > range_end
+        )
+
+        with patch(f"{MODULE}.date") as mock_date:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+            result = _build_rule_events(rule)
+
+        # anchor (2026-04-01) > range_end (2026-03-15) -> continue, no events
+        assert result == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}._get_calendar_id")
+    def test_daily_with_date_overrides_emits_oneoff(
+        self, mock_get_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily rule honors date_overrides with one-off events (lines 200-215)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_cal.return_value = ("cal-daily-1", [])
+
+        override_open = DateOverride(
+            date=date(2026, 3, 10),
+            time_windows=[TimeWindow(start=dt.time(14, 0), end=dt.time(16, 0))],
+        )
+        override_closed = DateOverride(date=date(2026, 3, 11), is_closed=True)
+        override_empty = DateOverride(date=date(2026, 3, 12), time_windows=[])
+
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            location_ids=[LOCATION_ID],
+            recurrence_frequency="daily",
+            recurrence_interval=1,
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))],
+            effective_end=date(2026, 3, 31),
+            date_overrides=[override_open, override_closed, override_empty],
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_rule_events(rule)
+
+        # 1 daily recurring event + 1 one-off (only the open override) = 2.
+        # closed and empty-window overrides are skipped (line 202).
+        assert len(result) == 2
+        oneoff_call = mock_event_effect.call_args_list[-1]
+        # one-off has no recurrence_frequency kwarg
+        assert "recurrence_frequency" not in oneoff_call.kwargs
+        assert oneoff_call.kwargs["starts_at"].day == 10
+        assert oneoff_call.kwargs["starts_at"].hour == 14
+
+
+# ── _compute_recurring_segments: off-pattern override (line 333) ──────
+
+
+class TestComputeRecurringSegmentsOffPattern:
+    def test_override_before_first_date_ignored(self):
+        """Override before first_date is skipped (line 332-333)."""
+        segments = _compute_recurring_segments(
+            date(2026, 3, 5), date(2026, 4, 30),
+            [date(2026, 2, 26)],  # before first_date
+        )
+        assert segments == [(date(2026, 3, 5), date(2026, 4, 30))]
+
+    def test_override_not_on_step_pattern_ignored(self):
+        """Override that isn't on the step_days pattern is skipped (line 333)."""
+        # first_date 2026-03-05 (Thu), step 7. 2026-03-08 is +3 days, not on pattern.
+        segments = _compute_recurring_segments(
+            date(2026, 3, 5), date(2026, 4, 30),
+            [date(2026, 3, 8)],
+            step_days=7,
+        )
+        # Off-pattern override ignored -> single full-range segment
+        assert segments == [(date(2026, 3, 5), date(2026, 4, 30))]
+
+
+# ── build_block_event_effects: location_ids (line 479) ────────────────
+
+
+class TestBuildBlockEventEffectsLocations:
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_per_location_events(
+        self, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Block with location_ids creates one event per location (line 479)."""
+        from provider_availability.engine.models import AdminBlock
+
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.side_effect = [
+            ("admin-cal-A", []),
+            ("admin-cal-B", []),
+        ]
+
+        block = AdminBlock(
+            id="block-1",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 9, 0),
+            end=datetime(2026, 3, 10, 12, 0),
+            reason="Offsite",
+            location_ids=["loc-A", "loc-B"],
+        )
+
+        with patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_event_effect.return_value.create.return_value = MagicMock()
+            result = build_block_event_effects(block)
+
+            # one event per calendar with matching calendar_id
+            cal_ids = [c.kwargs["calendar_id"] for c in mock_event_effect.call_args_list]
+            assert cal_ids == ["admin-cal-A", "admin-cal-B"]
+            assert all(c.kwargs["title"] == "Offsite" for c in mock_event_effect.call_args_list)
+
+        assert mock_get_admin_cal.mock_calls == [
+            call(PROVIDER_ID, "loc-A"),
+            call(PROVIDER_ID, "loc-B"),
+        ]
+        assert len(result) == 2
+
+
+# ── build_delete_block_effects: title fallback (lines 541-548) ────────
+
+
+class TestBuildDeleteBlockEffectsTitleFallback:
+    @patch(f"{MODULE}.provider_tz", return_value=ZoneInfo("UTC"))
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.get_event_ids")
+    def test_title_fallback_when_time_match_empty(
+        self, mock_get_ids, mock_get_admin_cals, mock_tz, sample_block
+    ):
+        """When no stored IDs and time-range match is empty, fall back to title match (lines 540-548)."""
+        mock_get_ids.return_value = []
+
+        mock_cal = MagicMock()
+        mock_cal.id = "admin-cal-1"
+        mock_get_admin_cals.return_value = [mock_cal]
+
+        mock_evt = MagicMock()
+        mock_evt.id = "evt-by-title"
+
+        with patch(f"{MODULE}.EventModel.objects") as mock_event_objects:
+            # First filter (time-range) returns nothing, second (title) returns the event
+            mock_event_objects.filter.side_effect = [[], [mock_evt]]
+
+            result = build_delete_block_effects(PROVIDER_ID, sample_block)
+
+        # Two filter calls: time-range then title
+        assert mock_event_objects.filter.call_count == 2
+        title_call = mock_event_objects.filter.call_args_list[1]
+        assert title_call.kwargs["calendar__id"] == "admin-cal-1"
+        assert title_call.kwargs["title"] == sample_block.reason
+        assert title_call.kwargs["is_cancelled"] is False
+        assert "starts_at__date" in title_call.kwargs
+        assert len(result) == 1
+
+    @patch(f"{MODULE}.provider_tz", return_value=ZoneInfo("UTC"))
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.get_event_ids")
+    def test_title_fallback_uses_blocked_when_no_reason(
+        self, mock_get_ids, mock_get_admin_cals, mock_tz
+    ):
+        """Empty-reason block uses 'Blocked' as fallback title (line 527 + 541-548)."""
+        from provider_availability.engine.models import AdminBlock
+
+        mock_get_ids.return_value = []
+        mock_cal = MagicMock()
+        mock_cal.id = "admin-cal-1"
+        mock_get_admin_cals.return_value = [mock_cal]
+
+        mock_evt = MagicMock()
+        mock_evt.id = "evt-1"
+
+        block = AdminBlock(
+            id="block-noreason",
+            provider_id=PROVIDER_ID,
+            start=datetime(2026, 3, 10, 9, 0),
+            end=datetime(2026, 3, 10, 12, 0),
+            reason="",
+        )
+
+        with patch(f"{MODULE}.EventModel.objects") as mock_event_objects:
+            mock_event_objects.filter.side_effect = [[], [mock_evt]]
+
+            result = build_delete_block_effects(PROVIDER_ID, block)
+
+        title_call = mock_event_objects.filter.call_args_list[1]
+        assert title_call.kwargs["title"] == "Blocked"
+        assert len(result) == 1
+
+
+# ── build_lead_time_block_effects: override branches (lines 660-663, 671) ──
+
+
+class TestBuildLeadTimeOverrideBranches:
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_closed_override_day_skipped(
+        self, mock_get_admin_cal, mock_tz, mock_get_admin_cals, mock_to_utc
+    ):
+        """A closed date override within the lead window is skipped (lines 660-663)."""
+        tz = ZoneInfo("US/Eastern")
+        mock_tz.return_value = tz
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+        mock_get_admin_cals.return_value = []
+
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            booking_interval=BookingInterval(min_lead_hours=4),
+            weekly_schedule={
+                "monday": [TimeWindow(start=dt.time(9, 0), end=dt.time(17, 0))],
+            },
+            # today (Monday 2026-03-02) is a closed override
+            date_overrides=[DateOverride(date=date(2026, 3, 2), is_closed=True)],
+        )
+
+        mock_now = datetime(2026, 3, 2, 10, 0, tzinfo=tz)
+        with patch(f"{MODULE}.datetime") as mock_datetime:
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.combine = datetime.combine
+            mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            result = build_lead_time_block_effects(rule)
+
+        # Closed override on the only in-window day -> no lead blocks
+        assert result == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_open_override_uses_override_windows(
+        self, mock_get_admin_cal, mock_tz, mock_get_admin_cals, mock_to_utc
+    ):
+        """An open override supplies its own windows for lead-time blocking (line 663)."""
+        tz = ZoneInfo("US/Eastern")
+        mock_tz.return_value = tz
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+        mock_get_admin_cals.return_value = []
+
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            booking_interval=BookingInterval(min_lead_hours=4),
+            weekly_schedule={
+                "monday": [TimeWindow(start=dt.time(9, 0), end=dt.time(11, 0))],
+            },
+            # today override widens availability to 9-17
+            date_overrides=[
+                DateOverride(
+                    date=date(2026, 3, 2),
+                    time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(17, 0))],
+                )
+            ],
+        )
+
+        mock_now = datetime(2026, 3, 2, 10, 0, tzinfo=tz)
+        with patch(f"{MODULE}.datetime") as mock_datetime, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.combine = datetime.combine
+            mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = build_lead_time_block_effects(rule)
+
+            # block is intersection of [10:00, 14:00] with override [9,17] = [10,14]
+            init_call = mock_event_effect.call_args_list[0]
+            assert init_call.kwargs["starts_at"].hour == 10
+            assert init_call.kwargs["ends_at"].hour == 14
+
+        assert len(result) == 1
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_daily_rule_uses_time_windows(
+        self, mock_get_admin_cal, mock_tz, mock_pattern, mock_get_admin_cals, mock_to_utc
+    ):
+        """A daily rule uses rule.time_windows in the lead-time loop (line 671)."""
+        tz = ZoneInfo("US/Eastern")
+        mock_tz.return_value = tz
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+        mock_get_admin_cals.return_value = []
+
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            booking_interval=BookingInterval(min_lead_hours=4),
+            recurrence_frequency="daily",
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(17, 0))],
+        )
+
+        mock_now = datetime(2026, 3, 2, 10, 0, tzinfo=tz)
+        with patch(f"{MODULE}.datetime") as mock_datetime, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.combine = datetime.combine
+            mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = build_lead_time_block_effects(rule)
+
+            init_call = mock_event_effect.call_args_list[0]
+            assert init_call.kwargs["title"] == "Lead Time"
+            assert init_call.kwargs["starts_at"].hour == 10
+            assert init_call.kwargs["ends_at"].hour == 14
+
+        assert len(result) == 1
+
+
+# ── _get_provider_override_map (lines 754-758) ────────────────────────
+
+
+class TestGetProviderOverrideMap:
+    @patch(f"{MODULE}.get_rules_for_provider")
+    def test_maps_open_and_closed_overrides(self, mock_get_rules):
+        """Closed overrides map to [], open overrides map to their windows (lines 753-758)."""
+        windows = [TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))]
+        rule = ProviderAvailabilityRule(
+            id="rule-1",
+            provider_id=PROVIDER_ID,
+            date_overrides=[
+                DateOverride(date=date(2026, 3, 10), time_windows=windows),
+                DateOverride(date=date(2026, 3, 11), is_closed=True),
+            ],
+        )
+        mock_get_rules.return_value = [rule]
+
+        result = _get_provider_override_map(PROVIDER_ID)
+
+        assert mock_get_rules.mock_calls == [call(PROVIDER_ID)]
+        assert result[date(2026, 3, 11)] == []  # closed -> empty
+        assert result[date(2026, 3, 10)] == windows
+
+    @patch(f"{MODULE}.get_rules_for_provider")
+    def test_no_rules_returns_empty_map(self, mock_get_rules):
+        mock_get_rules.return_value = []
+        assert _get_provider_override_map(PROVIDER_ID) == {}
+
+
+# ── _block_outside_override (lines 767-774) ───────────────────────────
+
+
+class TestBlockOutsideOverride:
+    def test_empty_override_windows_is_outside(self):
+        """No override windows (closed day) means all blocks are outside (line 767-768)."""
+        block = [TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))]
+        assert _block_outside_override(block, []) is True
+
+    def test_overlapping_block_is_inside(self):
+        """Block overlapping an override window returns False (line 773)."""
+        block = [TimeWindow(start=dt.time(10, 0), end=dt.time(11, 0))]
+        override = [TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))]
+        assert _block_outside_override(block, override) is False
+
+    def test_non_overlapping_block_is_outside(self):
+        """Block entirely outside override windows returns True (line 774)."""
+        block = [TimeWindow(start=dt.time(13, 0), end=dt.time(14, 0))]
+        override = [TimeWindow(start=dt.time(9, 0), end=dt.time(12, 0))]
+        assert _block_outside_override(block, override) is True
+
+
+# ── build_recurring_block_sync_effects: location_ids, daily, splits ───
+
+
+class TestBuildRecurringBlockSyncDailyAndLocations:
+    @pytest.fixture(autouse=True)
+    def _mock_override_map(self):
+        with patch(f"{MODULE}.get_rules_for_provider", return_value=[]):
+            yield
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.build_delete_recurring_block_effects")
+    def test_per_location_calendars(
+        self, mock_delete, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Recurring block with location_ids creates events per location (line 818)."""
+        mock_delete.return_value = []
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.side_effect = [
+            ("admin-cal-A", []),
+            ("admin-cal-B", []),
+        ]
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={
+                "monday": [TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            },
+            reason="Meeting",
+            is_active=True,
+            location_ids=["loc-A", "loc-B"],
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = build_recurring_block_sync_effects(block)
+
+            cal_ids = [c.kwargs["calendar_id"] for c in mock_event_effect.call_args_list]
+            assert cal_ids == ["admin-cal-A", "admin-cal-B"]
+
+        assert mock_get_admin_cal.mock_calls == [
+            call(PROVIDER_ID, "loc-A"),
+            call(PROVIDER_ID, "loc-B"),
+        ]
+        # 1 weekly event per location = 2
+        assert len(result) == 2
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.build_delete_recurring_block_effects")
+    def test_daily_recurring_block(
+        self, mock_delete, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily recurring block emits a Daily recurring event (lines 834-859)."""
+        mock_delete.return_value = []
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            recurrence_interval=1,
+            time_windows=[TimeWindow(start=dt.time(12, 0), end=dt.time(13, 0))],
+            reason="Lunch",
+            is_active=True,
+            effective_end=date(2026, 3, 31),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = build_recurring_block_sync_effects(block)
+
+            init_call = mock_event_effect.call_args_list[0]
+            assert init_call.kwargs["title"] == "Lunch"
+            assert init_call.kwargs["recurrence_frequency"] == EventRecurrence.Daily
+            assert init_call.kwargs["starts_at"].hour == 12
+
+        assert len(result) == 1
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.build_delete_recurring_block_effects")
+    def test_daily_anchor_beyond_range_end_skips(
+        self, mock_delete, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Daily block anchor past range_end skips (lines 835-843)."""
+        mock_delete.return_value = []
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            recurrence_interval=1,
+            time_windows=[TimeWindow(start=dt.time(12, 0), end=dt.time(13, 0))],
+            reason="Lunch",
+            is_active=True,
+            effective_start=date(2026, 4, 1),
+            effective_end=date(2026, 3, 15),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+            result = build_recurring_block_sync_effects(block)
+
+        assert result == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.build_delete_recurring_block_effects")
+    def test_weekly_first_date_beyond_range_end_skipped(
+        self, mock_delete, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Weekly block whose first weekday is past range_end is skipped (line 871)."""
+        mock_delete.return_value = []
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={
+                "friday": [TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            },
+            reason="Meeting",
+            is_active=True,
+            effective_start=date(2026, 3, 2),  # Monday
+            effective_end=date(2026, 3, 5),     # Thursday, before Friday
+        )
+
+        with patch(f"{MODULE}.date") as mock_date:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+            result = build_recurring_block_sync_effects(block)
+
+        assert result == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.build_delete_recurring_block_effects")
+    def test_weekly_override_splits_into_segments(
+        self, mock_delete, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """An override where the block falls outside its window splits the recurrence (lines 902-921)."""
+        mock_delete.return_value = []
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={
+                # Thursday block 13:00-14:00
+                "thursday": [TimeWindow(start=dt.time(13, 0), end=dt.time(14, 0))],
+            },
+            reason="Meeting",
+            is_active=True,
+            effective_end=date(2026, 5, 28),
+        )
+
+        # Provider override on Thu 2026-04-09 narrows availability to a morning
+        # window (9-11) that does NOT overlap the 13-14 block, so the block is
+        # "outside" and that date becomes a skip_date -> segment split.
+        override_rule = ProviderAvailabilityRule(
+            id="ovr-rule",
+            provider_id=PROVIDER_ID,
+            date_overrides=[
+                DateOverride(
+                    date=date(2026, 4, 9),
+                    time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(11, 0))],
+                )
+            ],
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.get_rules_for_provider", return_value=[override_rule]):
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+            result = build_recurring_block_sync_effects(block)
+
+        # Split into 2 segments (before + after 2026-04-09)
+        assert len(result) == 2
+
+
+# ── _build_hold_block_events (lines 944-1026) ─────────────────────────
+
+
+class TestBuildHoldBlockEvents:
+    @pytest.fixture(autouse=True)
+    def _mock_override_map(self):
+        with patch(f"{MODULE}.get_rules_for_provider", return_value=[]):
+            yield
+
+    @patch(f"{MODULE}.provider_tz")
+    def test_hold_type_none_returns_empty(self, mock_tz):
+        """hold_type 'none' returns empty (lines 947-948)."""
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            weekly_schedule={
+                "monday": [TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            },
+            hold_type="none",
+        )
+        assert _build_hold_block_events(block) == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_same_day_hold_blocks_future_dates(
+        self, mock_get_admin_cal, mock_tz, mock_pattern, mock_localize, mock_to_utc
+    ):
+        """same_day hold blocks dates strictly after today (lines 943-944, 1007-1018)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            reason="Hold",
+            hold_type="same_day",
+            effective_end=date(2026, 3, 5),  # small window: 03-03, 03-04, 03-05
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_hold_block_events(block)
+
+            first_call = mock_event_effect.call_args_list[0]
+            # same_day blocks dates > today; first blocked date is 2026-03-03
+            assert first_call.kwargs["title"] == "Same Day Hold: Hold"
+            assert first_call.kwargs["starts_at"].day == 3
+
+        # Dates 03-03, 03-04, 03-05 each get one event = 3
+        assert len(result) == 3
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_next_day_hold_skips_tomorrow(
+        self, mock_get_admin_cal, mock_tz, mock_pattern, mock_localize, mock_to_utc
+    ):
+        """next_day hold blocks dates after today+1 (lines 945-946)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            reason="",
+            hold_type="next_day",
+            effective_end=date(2026, 3, 5),  # 03-03 skipped, block 03-04, 03-05
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_hold_block_events(block)
+
+            first_call = mock_event_effect.call_args_list[0]
+            # next_day blocks dates > today+1; first blocked date is 2026-03-04
+            assert first_call.kwargs["title"] == "Next Day Hold"
+            assert first_call.kwargs["starts_at"].day == 4
+
+        # 03-04, 03-05 = 2 events
+        assert len(result) == 2
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_no_admin_calendar_skips_location(
+        self, mock_get_admin_cal, mock_tz, mock_pattern, mock_localize, mock_to_utc
+    ):
+        """No admin calendar for the location skips it (lines 971-973)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            hold_type="same_day",
+            effective_end=date(2026, 3, 5),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+            result = _build_hold_block_events(block)
+
+        assert result == []
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_weekly_hold_uses_weekday_windows(
+        self, mock_get_admin_cal, mock_tz, mock_localize, mock_to_utc
+    ):
+        """Weekly hold looks up windows by weekday name (lines 996-998)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="weekly",
+            recurrence_interval=1,
+            weekly_schedule={
+                # Wednesday only
+                "wednesday": [TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            },
+            reason="WedHold",
+            hold_type="same_day",
+            effective_end=date(2026, 3, 12),  # covers Wed 03-04, 03-11
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_hold_block_events(block)
+
+            # Only Wednesdays produce events (in-pattern check + weekday window)
+            for c in mock_event_effect.call_args_list:
+                assert c.kwargs["starts_at"].weekday() == 2  # Wednesday
+
+        # Wednesdays in [2026-03-03 .. 2026-03-12]: 03-04, 03-11 = 2
+        assert len(result) == 2
+
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    def test_override_suppresses_hold_date(
+        self, mock_get_admin_cal, mock_tz, mock_pattern, mock_localize, mock_to_utc
+    ):
+        """A date override where the hold falls outside its window suppresses that date (lines 1000-1005)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            # Hold at 13:00-14:00
+            time_windows=[TimeWindow(start=dt.time(13, 0), end=dt.time(14, 0))],
+            reason="Hold",
+            hold_type="same_day",
+            effective_end=date(2026, 3, 4),  # only 03-03, 03-04 blocked
+        )
+
+        # Override on 2026-03-03 narrows to morning 9-11 (does not overlap 13-14)
+        override_rule = ProviderAvailabilityRule(
+            id="ovr-rule",
+            provider_id=PROVIDER_ID,
+            date_overrides=[
+                DateOverride(
+                    date=date(2026, 3, 3),
+                    time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(11, 0))],
+                )
+            ],
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.get_rules_for_provider", return_value=[override_rule]), \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = _build_hold_block_events(block)
+
+            # 03-03 suppressed by override; only 03-04 remains
+            assert len(mock_event_effect.call_args_list) == 1
+            assert mock_event_effect.call_args_list[0].kwargs["starts_at"].day == 4
+
+        assert len(result) == 1
+
+
+# ── build_recurring_block_sync_effects routes hold to _build_hold_block_events ──
+
+
+class TestRecurringBlockSyncHoldRoute:
+    @patch(f"{MODULE}.get_rules_for_provider", return_value=[])
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.build_delete_recurring_block_effects")
+    def test_hold_type_routes_to_hold_events(
+        self, mock_delete, mock_get_admin_cal, mock_tz, mock_pattern,
+        mock_localize, mock_to_utc, mock_rules
+    ):
+        """A hold_type block routes to _build_hold_block_events (lines 797-798)."""
+        mock_delete.return_value = []
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            reason="Hold",
+            hold_type="same_day",
+            is_active=True,
+            effective_end=date(2026, 3, 4),
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_event_effect.return_value.create.return_value = MagicMock()
+
+            result = build_recurring_block_sync_effects(block)
+
+            assert all(
+                c.kwargs["title"].startswith("Same Day Hold")
+                for c in mock_event_effect.call_args_list
+            )
+
+        # Blocks 03-03, 03-04 = 2 hold events
+        assert len(result) == 2
+
+
+# ── build_hold_block_refresh_effects (lines 1035-1049) ────────────────
+
+
+class TestBuildHoldBlockRefreshEffects:
+    @patch(f"{MODULE}.get_rules_for_provider", return_value=[])
+    @patch(f"{MODULE}.to_utc", side_effect=lambda x: x)
+    @patch(f"{MODULE}.localize_naive", side_effect=lambda x, tz: x.replace(tzinfo=UTC))
+    @patch(f"{MODULE}.date_in_pattern", return_value=True)
+    @patch(f"{MODULE}.provider_tz")
+    @patch(f"{MODULE}.get_admin_calendar_id")
+    @patch(f"{MODULE}.get_admin_calendars")
+    def test_deletes_existing_then_recreates(
+        self, mock_get_admin_cals, mock_get_admin_cal, mock_tz, mock_pattern,
+        mock_localize, mock_to_utc, mock_rules
+    ):
+        """Refresh deletes existing hold events (all prefixes) then recreates (lines 1038-1048)."""
+        mock_tz.return_value = ZoneInfo("US/Eastern")
+        mock_get_admin_cal.return_value = ("admin-cal-1", [])
+
+        mock_cal = MagicMock()
+        mock_cal.id = "admin-cal-1"
+        mock_get_admin_cals.return_value = [mock_cal]
+
+        existing_evt = MagicMock()
+        existing_evt.id = "old-hold-evt"
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            recurrence_frequency="daily",
+            time_windows=[TimeWindow(start=dt.time(9, 0), end=dt.time(10, 0))],
+            reason="Hold",
+            hold_type="same_day",
+            effective_end=date(2026, 3, 3),  # only 03-03 blocked
+        )
+
+        with patch(f"{MODULE}.date") as mock_date, \
+             patch(f"{MODULE}.EventModel.objects") as mock_event_objects, \
+             patch(f"{MODULE}.EventEffect") as mock_event_effect:
+            mock_date.today.return_value = date(2026, 3, 2)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            # First prefix returns one existing event, remaining prefixes empty
+            side = [[existing_evt]] + [[] for _ in HOLD_TITLE_PREFIXES[1:]]
+            mock_event_objects.filter.side_effect = side
+            mock_event_effect.return_value.create.return_value = MagicMock()
+            mock_event_effect.return_value.delete.return_value = MagicMock()
+
+            result = build_hold_block_refresh_effects(block)
+
+        # One prefix query per HOLD_TITLE_PREFIXES entry
+        assert mock_event_objects.filter.call_count == len(HOLD_TITLE_PREFIXES)
+        # 1 delete (existing) + 1 create (03-03) = 2
+        assert len(result) == 2
+
+
+# ── build_delete_recurring_block_effects: hold cleanup (1069-1076, 1093-1099) ──
+
+
+class TestBuildDeleteRecurringBlockHoldCleanup:
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.get_event_ids")
+    def test_stored_ids_plus_hold_cleanup(
+        self, mock_get_ids, mock_get_admin_cals
+    ):
+        """Stored-ID path also cleans up hold events when hold_type != none (lines 1068-1076)."""
+        mock_get_ids.return_value = ["stored-1", "stored-2"]
+
+        mock_cal = MagicMock()
+        mock_cal.id = "admin-cal-1"
+        mock_get_admin_cals.return_value = [mock_cal]
+
+        hold_evt = MagicMock()
+        hold_evt.id = "hold-evt-1"
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            reason="Hold",
+            hold_type="same_day",
+        )
+
+        with patch(f"{MODULE}.EventModel.objects") as mock_event_objects:
+            # One hold event on the first prefix, empty for the rest
+            side = [[hold_evt]] + [[] for _ in HOLD_TITLE_PREFIXES[1:]]
+            mock_event_objects.filter.side_effect = side
+
+            result = build_delete_recurring_block_effects(PROVIDER_ID, block)
+
+        assert mock_get_ids.mock_calls == [call(block.id)]
+        # 2 stored-ID deletes + 1 hold-event delete = 3
+        assert len(result) == 3
+        assert mock_event_objects.filter.call_count == len(HOLD_TITLE_PREFIXES)
+
+    @patch(f"{MODULE}.get_admin_calendars")
+    @patch(f"{MODULE}.get_event_ids")
+    def test_title_fallback_plus_hold_cleanup(
+        self, mock_get_ids, mock_get_admin_cals
+    ):
+        """Title-fallback path also cleans up hold events when hold_type != none (lines 1092-1099)."""
+        mock_get_ids.return_value = []  # no stored IDs -> title fallback
+
+        mock_cal = MagicMock()
+        mock_cal.id = "admin-cal-1"
+        mock_get_admin_cals.return_value = [mock_cal]
+
+        title_evt = MagicMock()
+        title_evt.id = "title-evt-1"
+        hold_evt = MagicMock()
+        hold_evt.id = "hold-evt-1"
+
+        block = RecurringBlock(
+            id="rb-1",
+            provider_id=PROVIDER_ID,
+            reason="Hold",
+            hold_type="next_day",
+        )
+
+        with patch(f"{MODULE}.EventModel.objects") as mock_event_objects:
+            # First filter = title__in match, then one hold event on first prefix,
+            # empty for remaining prefixes.
+            side = [[title_evt], [hold_evt]] + [[] for _ in HOLD_TITLE_PREFIXES[1:]]
+            mock_event_objects.filter.side_effect = side
+
+            result = build_delete_recurring_block_effects(PROVIDER_ID, block)
+
+        # title match uses title__in with reason + legacy
+        title_call = mock_event_objects.filter.call_args_list[0]
+        assert title_call.kwargs["title__in"] == ["Hold", RECURRING_BLOCK_TITLE]
+        # 1 title delete + 1 hold delete = 2
+        assert len(result) == 2
+        # 1 title query + N prefix queries
+        assert mock_event_objects.filter.call_count == 1 + len(HOLD_TITLE_PREFIXES)

--- a/extensions/provider_availability/tests/engine/test_lookups.py
+++ b/extensions/provider_availability/tests/engine/test_lookups.py
@@ -5,11 +5,34 @@ from unittest.mock import MagicMock, call, patch
 from provider_availability.engine.lookups import (
     get_active_locations,
     get_active_providers,
+    get_active_staff_ids,
     get_scheduleable_visit_types,
 )
 
 
 LOOKUPS_MODULE = "provider_availability.engine.lookups"
+
+
+class TestGetActiveStaffIds:
+    def test_returns_all_active_staff_ids(self):
+        s1 = MagicMock()
+        s1.id = "staff-1"
+        s2 = MagicMock()
+        s2.id = "staff-2"
+
+        with patch(f"{LOOKUPS_MODULE}.Staff.objects") as mock_objects:
+            mock_objects.filter.return_value = [s1, s2]
+
+            result = get_active_staff_ids()
+
+            assert mock_objects.mock_calls == [call.filter(active=True)]
+            assert result == {"staff-1", "staff-2"}
+
+    def test_empty(self):
+        with patch(f"{LOOKUPS_MODULE}.Staff.objects") as mock_objects:
+            mock_objects.filter.return_value = []
+
+            assert get_active_staff_ids() == set()
 
 
 class TestGetActiveProviders:

--- a/extensions/provider_availability/tests/templates/test_admin_ui.py
+++ b/extensions/provider_availability/tests/templates/test_admin_ui.py
@@ -27,3 +27,9 @@ class TestRenderAdminPage:
         data = {"key": "value/with/slashes"}
         html = render_admin_page(data)
         assert "value/with/slashes" in html
+
+    def test_includes_bulk_import_tab_and_panel(self):
+        html = render_admin_page(None)
+        assert "panel-bulk-import" in html
+        assert "Bulk Import" in html
+        assert 'onclick="bulkUploadValidate()"' in html


### PR DESCRIPTION
## What this adds

A **Bulk Import** tab in the Provider Availability admin UI, backed by staff-session `/csv` endpoints (`validate`, `commit`, `template`), to upload a CSV and load availability rules, one-off blocks, and recurring blocks (including same-day / next-day holds) for one or many staff at once.

## How it works

- **One row per time window.** Rows for the same staff member and rule-level settings (location, visit type, buffer, booking, recurrence, effective dates) merge into a single rule whose weekly schedule accumulates each window. An optional `group_key` forces rows to merge.
- **Keyed by `staff_key`** (the Canvas Staff UUID), not NPI, so availability can be loaded for providers and non-provider staff alike.
- **Validation + preview before commit:** per-row structural checks, location/visit-type name resolution, staff-key validation against active staff, and overlap detection against existing saved rules. Only clean records are committed.
- **Commit** is gated by the existing `allowed-staff-keys` secret and reuses the same save + calendar-sync path as the manual admin UI.

Three row types via a `type` column: `rule` (bookable window), `block` (one-off unavailable), `rblock` (recurring unavailable, incl. holds). Full column reference is in the plugin README.

## Implementation notes

- CSV parsing is hand-rolled (the plugin sandbox does not allow the `csv` module) and is DB-free, so parsing/validation/grouping are unit-tested without mocking data models. Name resolution and staff validation are batched (3 lookups per upload, no N+1).
- The importer is a tab inside the existing admin page rather than a separate app; it uses `fetch()` like the existing Settings tab.

## Tests

Adds unit tests for the new engine/API/UI code and backfills coverage on `availability_api` and `event_sync`. Full suite: 719 passing; aggregate coverage 96%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)