### PR TITLE
fix(gcal_sync): stop duplicate inbound hold imports while a create is in flight (v0.4.5)

### DIFF
--- a/extensions/gcal_sync/gcal_sync/CANVAS_MANIFEST.json
+++ b/extensions/gcal_sync/gcal_sync/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.164.0",
-    "plugin_version": "0.4.4",
+    "plugin_version": "0.4.5",
     "name": "gcal_sync",
     "description": "Two-way Google Calendar sync for Canvas: pushes appointments and admin blocks (lunch/PTO) into providers' Workspace calendars in near-real-time, and imports provider-created Google events back into Canvas as admin holds. Canvas remains the system of record. Service-account + domain-wide delegation; no PHI in event fields.",
     "components": {

--- a/extensions/gcal_sync/gcal_sync/inbound.py
+++ b/extensions/gcal_sync/gcal_sync/inbound.py
@@ -57,6 +57,11 @@ class InboundSync:
     # broken (the 2040 bug was ~37k). Set high enough to comfortably import a dense provider's full
     # 6-month calendar — hundreds of recurring-meeting instances is normal and expected here.
     _MAX_HOLDS_PER_RUN = 5000
+    # The create effect is applied asynchronously, so a mapping written moments ago still has no
+    # visible Canvas hold. Within this window we treat the mapping as a create in flight and skip
+    # re-importing the event; re-issuing the create here is what generated duplicate holds under
+    # load. Past the window, a still-holdless mapping is a genuine orphan and is re-created.
+    _PENDING_CREATE_GRACE_SECONDS = 30 * 60
 
     def __init__(
         self,
@@ -216,8 +221,21 @@ class InboundSync:
             stats["holds_updated"] = stats["holds_updated"] + 1
             return [effect]
 
-        # Brand-new Google event (or an orphaned mapping whose hold never materialised) -> create a
-        # Canvas admin hold, subject to the org's import filters.
+        # Mapping exists but no live hold (the update branch above didn't fire). The create is
+        # applied asynchronously, so a recently-recorded mapping is a create still in flight —
+        # re-issuing it is what produced duplicate holds under load. Skip while pending; only fall
+        # through to re-create once the mapping predates the grace window (a genuine orphan).
+        if existing is not None:
+            created_at = getattr(existing, "created_at", None)
+            if created_at is None or (
+                (arrow.utcnow() - arrow.get(created_at)).total_seconds()
+                < self._PENDING_CREATE_GRACE_SECONDS
+            ):
+                stats["ignored"] = stats["ignored"] + 1
+                return []
+
+        # Brand-new Google event (or a genuine orphan past the grace window) -> create a Canvas
+        # admin hold, subject to the org's import filters.
         if is_all_day(event) and not self._ingest_all_day:
             stats["ignored"] = stats["ignored"] + 1
             return []

--- a/extensions/gcal_sync/tests/test_inbound_decisions.py
+++ b/extensions/gcal_sync/tests/test_inbound_decisions.py
@@ -4,7 +4,7 @@ Models and effect-builders are mocked so no DB or network is needed. We assert w
 what effects come back.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -128,10 +128,12 @@ def test_unmarked_known_event_updates_hold(mocker):
 
 
 def test_unmarked_orphaned_mapping_recreates_hold(mocker):
-    # Mapping row exists but no live Canvas hold (a prior run was interrupted/capped before the
-    # create effect applied). The event must be RE-CREATED, not silently skipped as an update (#4).
+    # Mapping row exists but no live Canvas hold AND it predates the pending-create grace window (a
+    # prior run was interrupted/capped before the create applied). RE-CREATE it, don't skip (#4).
     iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
-    iem.objects.filter.return_value.first.return_value = SimpleNamespace(google_event_id="g-1")
+    iem.objects.filter.return_value.first.return_value = SimpleNamespace(
+        google_event_id="g-1", created_at=datetime.now(timezone.utc) - timedelta(hours=1)
+    )
     mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
     mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
     mocker.patch("gcal_sync.inbound.build_hold_effect", return_value="HOLD_EFFECT")
@@ -144,6 +146,26 @@ def test_unmarked_orphaned_mapping_recreates_hold(mocker):
     assert stats["holds_created"] == 1
     update_spy.assert_not_called()
     iem.objects.update_or_create.assert_called_once()
+
+
+def test_unmarked_pending_create_is_not_duplicated(mocker):
+    # Mapping was written moments ago but the async create hasn't applied yet (no live hold). A
+    # re-delivered webhook must NOT re-issue the create — re-creating in-flight holds is what
+    # produced the duplicate-hold storm under load.
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = SimpleNamespace(
+        google_event_id="g-1", created_at=datetime.now(timezone.utc)
+    )
+    build = mocker.patch("gcal_sync.inbound.build_hold_effect", return_value="HOLD_EFFECT")
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)  # not applied yet
+    stats = _stats()
+    effects = inbound._apply("cal", {"id": "g-1", "status": "confirmed", "summary": "Hold"}, stats)
+    assert effects == []
+    assert stats["holds_created"] == 0
+    assert stats["ignored"] == 1
+    build.assert_not_called()
+    iem.objects.update_or_create.assert_not_called()
 
 
 def test_unmarked_cancelled_known_event_removes_hold(mocker):


### PR DESCRIPTION
## Summary

Fixes duplicate inbound admin-hold imports in `gcal_sync`. Bumps the plugin to **0.4.5**.

## Cause

`_handle_unmarked_event` (`inbound.py`) decides CREATE vs UPDATE by checking whether a live Canvas hold exists for the Google event. But `ScheduleEvent.create()` is applied **asynchronously**, so for a short window after a create is issued the hold isn't yet queryable. A re-delivered `events.watch` webhook — or an overlapping reconciliation pull — in that window finds the `InboundEventMapping` present but no visible hold, falls through to the "orphan self-heal" branch, and **re-issues the create**, producing a duplicate hold. Under load the apply lag widens and the duplicates compound.

## Fix

Add a **pending-create grace window** (`_PENDING_CREATE_GRACE_SECONDS = 30 min`). When a mapping exists but no live hold is visible:

- within the grace window of the mapping's `created_at` → treat the create as still in flight and skip (no duplicate);
- only past the window → treat it as a genuine orphan (an interrupted/capped prior run) and re-create, preserving the existing self-heal intent.

Everything else is unchanged: brand-new events still create, known events with a live hold still update, cancellations still delete.

## Tests

- Added `test_unmarked_pending_create_is_not_duplicated` (mapping written moments ago, hold not yet applied → no re-create).
- Updated `test_unmarked_orphaned_mapping_recreates_hold` to use an old `created_at` so it still exercises true-orphan self-heal past the grace window.
- Full suite: **205 passed** (`uv run pytest`).

## Provenance

Ported verbatim from the internal Canvas fix in `canvas-medical/gtm-extensions` (#393, shipped via #399). The `inbound.py` here was byte-identical to the internal pre-fix version, so the change applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
