### PR TITLE
feat(external-calendar-busy-blocks): auto-provision provider Admin calendar

### DIFF
--- a/extensions/external-calendar-busy-blocks/README.md
+++ b/extensions/external-calendar-busy-blocks/README.md
@@ -16,7 +16,7 @@ This plugin declares secrets that must be set before it will function. See the C
 
 ## How it works
 
-Each provider opens the **Calendar Busy Blocks** application from the Canvas global menu, pastes their personal calendar's secret iCal URL, and clicks Save. A scheduled task runs every 15 minutes:
+Each provider opens the **Calendar Busy Blocks** application from the Canvas global menu, pastes their personal calendar's secret iCal URL, and clicks Save. Connecting a feed automatically finds or creates that provider's Canvas Admin calendar — no manual calendar setup is required (the 15-minute sync also creates it if it is ever missing). A scheduled task runs every 15 minutes:
 
 1. Fetches each provider's ICS feed (sending `If-None-Match` / `If-Modified-Since` so unchanged feeds return `304 Not Modified` and skip work).
 2. Parses the feed, filters to confirmed busy events, expands recurring events within a 90-day window, and converts everything to UTC.

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.1.0",
+    "plugin_version": "0.2.0",
     "name": "external_calendar_busy_blocks",
     "description": "Subscribe Canvas to a provider's personal calendar via ICS and mirror busy times as Admin events.",
     "components": {

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -8,7 +8,7 @@
             {
                 "class": "external_calendar_busy_blocks.routes.feeds:FeedsAPI",
                 "description": "POST /feeds to connect; POST /feeds/delete to disconnect.",
-                "data_access": {"event": "", "read": [], "write": ["Event"]}
+                "data_access": {"event": "", "read": [], "write": ["Event", "Calendar"]}
             },
             {
                 "class": "external_calendar_busy_blocks.ui.pages:ConfigPage",
@@ -18,7 +18,7 @@
             {
                 "class": "external_calendar_busy_blocks.sync.cron:SyncCron",
                 "description": "Every 15 minutes: fetch each active feed, parse, diff, and emit Event effects.",
-                "data_access": {"event": "", "read": ["Staff", "Calendar"], "write": ["Event"]}
+                "data_access": {"event": "", "read": ["Staff", "Calendar"], "write": ["Event", "Calendar"]}
             }
         ],
         "applications": [

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/calendars/admin_lookup.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/calendars/admin_lookup.py
@@ -1,20 +1,57 @@
+"""Find or create a provider's Administrative calendar.
+
+Mirrors the provider-availability plugin's ``get_admin_calendar_id``: a
+find-or-create helper returning ``(calendar_id, effects_needed_to_create)``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.calendar import Calendar as CalendarEffect
 from canvas_sdk.effects.calendar import CalendarType
-from canvas_sdk.v1.data.calendar import Calendar
+from canvas_sdk.v1.data.calendar import Calendar as CalendarModel
 from canvas_sdk.v1.data.staff import Staff
+from logger import log
 
 
-def find_admin_calendar_id(staff: Staff) -> str | None:
-    """Return the id of the staff's Administrative calendar, or None."""
-    calendar_id = (
-        Calendar.objects.for_calendar_name(
-            provider_name=staff.full_name,
-            calendar_type=CalendarType.Administrative,
-            location=None,
-        )
-        .values_list("id", flat=True)
-        .last()
+def get_admin_calendar_id(provider_id: str) -> tuple[str, list[Effect]]:
+    """Find or create the provider's Administrative calendar.
+
+    Returns ``(calendar_id, effects_needed_to_create)``. When the provider
+    already has an Admin calendar the effects list is empty. When the staff or
+    their name cannot be resolved, returns ``("", [])``.
+    """
+    try:
+        staff = Staff.objects.get(id=provider_id)
+        provider_name = staff.full_name
+    except Staff.DoesNotExist:
+        return "", []
+
+    if not provider_name:
+        return "", []
+
+    existing = CalendarModel.objects.for_calendar_name(
+        provider_name=provider_name,
+        calendar_type=CalendarType.Administrative,
+        location=None,
+    ).first()
+    if existing:
+        # `id` is a UUID. The Event effect json-serializes calendar_id as-is, so
+        # a UUID object raises "Object of type UUID is not JSON serializable".
+        return str(existing.id), []
+
+    new_id = str(uuid.uuid4())
+    cal_effect = CalendarEffect(
+        id=new_id,
+        provider=provider_id,
+        type=CalendarType.Administrative,
+        location=None,
+    ).create()
+    log.info(
+        "get_admin_calendar_id: creating Admin calendar id=%s for provider %s",
+        new_id,
+        provider_id,
     )
-    # `id` is a UUID. The Event effect json-serializes calendar_id as-is, so a
-    # UUID object raises "Object of type UUID is not JSON serializable". Return
-    # a string so the downstream Event(...).create() payload serializes.
-    return str(calendar_id) if calendar_id is not None else None
+    return new_id, [cal_effect]

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
@@ -7,6 +7,7 @@ from canvas_sdk.effects.simple_api import JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 
 from external_calendar_busy_blocks.auth import canonical_staff_id
+from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
 from external_calendar_busy_blocks.data.models import (
     ImportedEvent,
     StaffCalendarFeed,
@@ -67,7 +68,10 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         else:
             StaffCalendarFeed(staff_id=staff_id, ics_url=url, is_active=True).save()
 
-        return [JSONResponse({"status": "connected"}, status_code=200)]
+        # Provision the provider's Admin calendar so the busy blocks have a
+        # calendar to land on (find-or-create; empty effects if it exists).
+        _, cal_effects = get_admin_calendar_id(staff_id)
+        return [*cal_effects, JSONResponse({"status": "connected"}, status_code=200)]
 
     @api.post("/feeds/delete")
     def delete_feed(self) -> list[Response | Effect]:

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/sync/cron.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/sync/cron.py
@@ -7,9 +7,8 @@ from logger import log
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.calendar import Event
 from canvas_sdk.handlers.cron_task import CronTask
-from canvas_sdk.v1.data.staff import Staff
 
-from external_calendar_busy_blocks.calendars.admin_lookup import find_admin_calendar_id
+from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
 from external_calendar_busy_blocks.data.models import (
     ImportedEvent,
     StaffCalendarFeed,
@@ -67,17 +66,14 @@ class SyncCron(CronTask):
         now: datetime,
         lookahead_days: int,
     ) -> list[Effect]:
-        try:
-            staff = Staff.objects.get(id=feed.staff_id)
-        except Staff.DoesNotExist:
-            log.warning("Skipping feed %s: staff %s not found", feed.dbid, feed.staff_id)
-            feed.last_error = f"staff {feed.staff_id} not found"
-            feed.save()
-            return []
-
-        calendar_id = find_admin_calendar_id(staff)
-        if calendar_id is None:
-            feed.last_error = "no Admin calendar for this provider"
+        calendar_id, cal_effects = get_admin_calendar_id(feed.staff_id)
+        if not calendar_id:
+            log.warning(
+                "Skipping feed %s: could not resolve or provision Admin calendar for staff %s",
+                feed.dbid,
+                feed.staff_id,
+            )
+            feed.last_error = "unable to provision Admin calendar for this provider"
             feed.save()
             return []
 
@@ -93,7 +89,7 @@ class SyncCron(CronTask):
             feed.last_sync_at = now
             feed.last_error = None
             feed.save()
-            return []
+            return cal_effects
         if isinstance(result, (Unauthorized, NotFound)):
             feed.is_active = False
             feed.last_error = result.__class__.__name__
@@ -126,7 +122,7 @@ class SyncCron(CronTask):
         if not parsed and existing:
             feed.last_error = "feed parsed but empty; deletions skipped"
             feed.save()
-            return []
+            return cal_effects
 
         effects = self._diff_and_emit(feed, calendar_id, parsed, existing, now)
 
@@ -135,7 +131,7 @@ class SyncCron(CronTask):
         feed.last_modified = result.last_modified
         feed.last_error = None
         feed.save()
-        return effects
+        return [*cal_effects, *effects]
 
     def _diff_and_emit(
         self,

--- a/extensions/external-calendar-busy-blocks/tests/calendars/test_admin_lookup.py
+++ b/extensions/external-calendar-busy-blocks/tests/calendars/test_admin_lookup.py
@@ -1,51 +1,95 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
-from external_calendar_busy_blocks.calendars.admin_lookup import find_admin_calendar_id
+from canvas_sdk.v1.data.staff import Staff
+
+from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
+
+MODULE = "external_calendar_busy_blocks.calendars.admin_lookup"
 
 
-def test_returns_id_when_calendar_exists() -> None:
-    staff = MagicMock(full_name="Jane Doe")
-    queryset = MagicMock()
-    queryset.values_list.return_value.last.return_value = "calendar-123"
-    with patch(
-        "external_calendar_busy_blocks.calendars.admin_lookup.Calendar"
-    ) as MockCalendar:
-        MockCalendar.objects.for_calendar_name.return_value = queryset
-        result = find_admin_calendar_id(staff)
-    assert result == "calendar-123"
-    MockCalendar.objects.for_calendar_name.assert_called_once()
-    args, kwargs = MockCalendar.objects.for_calendar_name.call_args
+def test_existing_calendar_returns_id_and_no_effects() -> None:
+    mock_staff = MagicMock(full_name="Jane Doe")
+    mock_cal = MagicMock(id="cal-uuid-123")
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarModel.objects") as mock_cal_objects,
+        patch(f"{MODULE}.CalendarEffect") as MockCalEffect,
+    ):
+        mock_staff_objects.get.return_value = mock_staff
+        mock_cal_objects.for_calendar_name.return_value.first.return_value = mock_cal
+        cal_id, effects = get_admin_calendar_id("p1")
+
+    assert cal_id == "cal-uuid-123"
+    assert effects == []
+    MockCalEffect.assert_not_called()
+    assert mock_staff_objects.mock_calls == [call.get(id="p1")]
+    _, kwargs = mock_cal_objects.for_calendar_name.call_args
     assert kwargs["provider_name"] == "Jane Doe"
     assert str(kwargs["calendar_type"]) == "Admin"
     assert kwargs["location"] is None
 
 
-def test_returns_none_when_no_calendar() -> None:
-    staff = MagicMock(full_name="Jane Doe")
-    queryset = MagicMock()
-    queryset.values_list.return_value.last.return_value = None
-    with patch(
-        "external_calendar_busy_blocks.calendars.admin_lookup.Calendar"
-    ) as MockCalendar:
-        MockCalendar.objects.for_calendar_name.return_value = queryset
-        result = find_admin_calendar_id(staff)
-    assert result is None
+def test_creates_calendar_when_missing() -> None:
+    mock_staff = MagicMock(full_name="Jane Doe")
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarModel.objects") as mock_cal_objects,
+        patch(f"{MODULE}.CalendarEffect") as MockCalEffect,
+        patch(f"{MODULE}.uuid.uuid4", return_value="new-cal-id"),
+    ):
+        mock_staff_objects.get.return_value = mock_staff
+        mock_cal_objects.for_calendar_name.return_value.first.return_value = None
+        MockCalEffect.return_value.create.return_value = "CREATE_EFFECT"
+        cal_id, effects = get_admin_calendar_id("p1")
+
+    assert cal_id == "new-cal-id"
+    assert effects == ["CREATE_EFFECT"]
+    _, kwargs = MockCalEffect.call_args
+    assert kwargs["id"] == "new-cal-id"
+    assert kwargs["provider"] == "p1"
+    assert str(kwargs["type"]) == "Admin"
+    assert kwargs["location"] is None
 
 
-def test_returns_stringified_id_for_uuid() -> None:
-    """The Calendar id is a UUID. It must be returned as a str so the
-    downstream Event(...).create() payload is JSON-serializable (a raw UUID
-    raises 'Object of type UUID is not JSON serializable')."""
+def test_stringifies_uuid_id() -> None:
     import uuid
 
     cal_uuid = uuid.uuid4()
-    staff = MagicMock(full_name="Amanda Peterson")
-    queryset = MagicMock()
-    queryset.values_list.return_value.last.return_value = cal_uuid
-    with patch(
-        "external_calendar_busy_blocks.calendars.admin_lookup.Calendar"
-    ) as MockCalendar:
-        MockCalendar.objects.for_calendar_name.return_value = queryset
-        result = find_admin_calendar_id(staff)
-    assert result == str(cal_uuid)
-    assert isinstance(result, str)
+    mock_staff = MagicMock(full_name="Amanda Peterson")
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarModel.objects") as mock_cal_objects,
+        patch(f"{MODULE}.CalendarEffect"),
+    ):
+        mock_staff_objects.get.return_value = mock_staff
+        mock_cal_objects.for_calendar_name.return_value.first.return_value = MagicMock(id=cal_uuid)
+        cal_id, effects = get_admin_calendar_id("p1")
+
+    assert cal_id == str(cal_uuid)
+    assert isinstance(cal_id, str)
+
+
+def test_returns_empty_when_staff_missing() -> None:
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarEffect") as MockCalEffect,
+    ):
+        mock_staff_objects.get.side_effect = Staff.DoesNotExist
+        cal_id, effects = get_admin_calendar_id("nope")
+
+    assert cal_id == ""
+    assert effects == []
+    MockCalEffect.assert_not_called()
+
+
+def test_returns_empty_when_name_blank() -> None:
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarEffect") as MockCalEffect,
+    ):
+        mock_staff_objects.get.return_value = MagicMock(full_name="")
+        cal_id, effects = get_admin_calendar_id("p1")
+
+    assert cal_id == ""
+    assert effects == []
+    MockCalEffect.assert_not_called()

--- a/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
+++ b/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
@@ -69,6 +69,8 @@ def test_post_creates_feed_when_valid() -> None:
     with (
         patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])),
     ):
         from external_calendar_busy_blocks.http.fetcher import FetchOk
         mock_fetch.return_value = FetchOk(
@@ -97,6 +99,8 @@ def test_post_ignores_staff_id_in_body() -> None:
     with (
         patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])),
     ):
         from external_calendar_busy_blocks.http.fetcher import FetchOk
         mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
@@ -190,6 +194,8 @@ def test_post_accepts_allowlisted_hosts(url) -> None:
     with (
         patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])),
     ):
         from external_calendar_busy_blocks.http.fetcher import FetchOk
         mock_fetch.return_value = FetchOk(
@@ -225,3 +231,55 @@ def test_post_rejects_whitespace_injection(url) -> None:
         responses = api.create_feed()
     assert responses[0].status_code == 400
     mock_fetch.assert_not_called()
+
+
+def test_connect_provisions_calendar_when_missing() -> None:
+    cal_effect = MagicMock()
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-new", [cal_effect])) as mock_get_cal,
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(
+            body=b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", etag=None, last_modified=None
+        )
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+        )
+        responses = api.create_feed()
+
+    # Provisioned with the canonicalized session staff id.
+    assert mock_get_cal.call_args.args[0] == "00000000000000000000000000000001"
+    # The Calendar create effect is returned before the JSONResponse.
+    assert responses[0] is cal_effect
+    assert responses[-1].status_code == 200
+
+
+def test_connect_no_calendar_effect_when_exists() -> None:
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])),
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(
+            body=b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", etag=None, last_modified=None
+        )
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+        )
+        responses = api.create_feed()
+
+    # Only the JSONResponse — no effects emitted.
+    effects_emitted = [r for r in responses if hasattr(r, "type")]
+    assert effects_emitted == []
+    assert responses[0].status_code == 200

--- a/extensions/external-calendar-busy-blocks/tests/sync/test_cron.py
+++ b/extensions/external-calendar-busy-blocks/tests/sync/test_cron.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +12,22 @@ _CREATE = EffectType.CALENDAR__EVENT__CREATE
 _UPDATE = EffectType.CALENDAR__EVENT__UPDATE
 _DELETE = EffectType.CALENDAR__EVENT__DELETE
 _CALENDAR_TYPES = {_CREATE, _UPDATE, _DELETE}
+_CAL_CREATE = EffectType.CALENDAR__CREATE
+
+
+def _future_dt(days: int, hour: int) -> datetime:
+    """A UTC datetime `days` ahead at `hour`:00, inside the 90-day look-ahead.
+
+    SyncCron.execute() uses the real wall-clock now(), so event dates must be
+    relative to now — hardcoded calendar dates rot into the past and get
+    filtered out by the parser.
+    """
+    base = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    return (base + timedelta(days=days)).replace(hour=hour)
+
+
+def _z(dt: datetime) -> str:
+    return dt.strftime("%Y%m%dT%H%M%SZ")
 
 
 def _new_cron(timestamp: datetime) -> SyncCron:
@@ -64,19 +80,16 @@ def patch_sync_deps():
         patch("external_calendar_busy_blocks.sync.cron.StaffCalendarFeed") as MockFeed,
         patch("external_calendar_busy_blocks.sync.cron.ImportedEvent") as MockImported,
         patch("external_calendar_busy_blocks.sync.cron.fetch_feed") as mock_fetch,
-        patch("external_calendar_busy_blocks.sync.cron.Staff") as MockStaff,
         patch(
-            "external_calendar_busy_blocks.sync.cron.find_admin_calendar_id"
-        ) as mock_find_cal,
+            "external_calendar_busy_blocks.sync.cron.get_admin_calendar_id"
+        ) as mock_get_cal,
     ):
-        MockStaff.objects.get.return_value = MagicMock(full_name="Jane Doe")
-        mock_find_cal.return_value = "cal-1"
+        mock_get_cal.return_value = ("cal-1", [])
         yield {
             "feed_model": MockFeed,
             "imported_model": MockImported,
             "fetch": mock_fetch,
-            "staff": MockStaff,
-            "find_cal": mock_find_cal,
+            "get_cal": mock_get_cal,
         }
 
 
@@ -87,7 +100,7 @@ def test_new_event_emits_create_effect(patch_sync_deps) -> None:
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
     patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = FetchOk(
-        body=_ok_body("ev-1@x", "20260615T140000Z", "20260615T150000Z"),
+        body=_ok_body("ev-1@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
         etag='"abc"',
         last_modified="Mon, 01 Jun 2026",
     )
@@ -104,18 +117,20 @@ def test_unchanged_event_emits_no_effect(patch_sync_deps) -> None:
     from external_calendar_busy_blocks.http.fetcher import FetchOk
 
     feed = _stub_feed()
+    start = _future_dt(10, 14)
+    end = _future_dt(10, 15)
     existing = MagicMock(
         ics_uid="ev-1@x",
         recurrence_id=None,
         canvas_event_id="canvas-1",
         sequence=0,
-        starts_at=datetime(2026, 6, 15, 14, 0, tzinfo=timezone.utc),
-        ends_at=datetime(2026, 6, 15, 15, 0, tzinfo=timezone.utc),
+        starts_at=start,
+        ends_at=end,
     )
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
     patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
     patch_sync_deps["fetch"].return_value = FetchOk(
-        body=_ok_body("ev-1@x", "20260615T140000Z", "20260615T150000Z"),
+        body=_ok_body("ev-1@x", _z(start), _z(end)),
         etag='"abc"',
         last_modified=None,
     )
@@ -140,7 +155,7 @@ def test_time_changed_emits_update_effect(patch_sync_deps) -> None:
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
     patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
     patch_sync_deps["fetch"].return_value = FetchOk(
-        body=_ok_body("ev-1@x", "20260615T160000Z", "20260615T170000Z"),
+        body=_ok_body("ev-1@x", _z(_future_dt(10, 16)), _z(_future_dt(10, 17))),
         etag=None,
         last_modified=None,
     )
@@ -167,7 +182,7 @@ def test_removed_event_emits_delete_effect(patch_sync_deps) -> None:
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
     patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
     patch_sync_deps["fetch"].return_value = FetchOk(
-        body=_ok_body("ev-new@x", "20260615T140000Z", "20260615T150000Z"),
+        body=_ok_body("ev-new@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
         etag=None,
         last_modified=None,
     )
@@ -249,11 +264,11 @@ def test_no_admin_calendar_records_error_and_skips(patch_sync_deps) -> None:
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
     patch_sync_deps["imported_model"].objects.filter.return_value = []
-    patch_sync_deps["find_cal"].return_value = None
+    patch_sync_deps["get_cal"].return_value = ("", [])
 
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
     assert effects == []
-    assert feed.last_error and "no admin calendar" in feed.last_error.lower()
+    assert feed.last_error and "unable to provision" in feed.last_error.lower()
 
 
 def test_existing_query_excludes_past_events(patch_sync_deps) -> None:
@@ -300,7 +315,7 @@ def test_one_feed_failure_does_not_abort_other_feeds(patch_sync_deps) -> None:
         if url == "https://a/x.ics":
             raise RuntimeError("unexpected boom")
         return FetchOk(
-            body=_ok_body("ev-b@x", "20260615T140000Z", "20260615T150000Z"),
+            body=_ok_body("ev-b@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
             etag=None,
             last_modified=None,
         )
@@ -315,3 +330,44 @@ def test_one_feed_failure_does_not_abort_other_feeds(patch_sync_deps) -> None:
     # Feed A recorded an error and was saved.
     assert feed_a.last_error and "unexpected" in feed_a.last_error.lower()
     assert feed_a.save.called
+
+
+def test_new_calendar_effect_is_prepended_before_events(patch_sync_deps) -> None:
+    from external_calendar_busy_blocks.http.fetcher import FetchOk
+
+    cal_effect = MagicMock()
+    cal_effect.type = _CAL_CREATE
+    patch_sync_deps["get_cal"].return_value = ("cal-9", [cal_effect])
+
+    feed = _stub_feed()
+    patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
+    patch_sync_deps["imported_model"].objects.filter.return_value = []
+    patch_sync_deps["fetch"].return_value = FetchOk(
+        body=_ok_body("ev-1@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
+        etag=None,
+        last_modified=None,
+    )
+
+    effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
+    # Calendar create must come first, before the Event.create that references it.
+    assert effects[0] is cal_effect
+    create_effects = [e for e in effects if e.type == _CREATE]
+    assert len(create_effects) == 1
+    payload = json.loads(create_effects[0].payload)["data"]
+    assert payload["calendar_id"] == "cal-9"
+
+
+def test_not_modified_still_provisions_missing_calendar(patch_sync_deps) -> None:
+    from external_calendar_busy_blocks.http.fetcher import NotModified
+
+    cal_effect = MagicMock()
+    cal_effect.type = _CAL_CREATE
+    patch_sync_deps["get_cal"].return_value = ("cal-9", [cal_effect])
+
+    feed = _stub_feed(last_etag='"abc"')
+    patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
+    patch_sync_deps["imported_model"].objects.filter.return_value = []
+    patch_sync_deps["fetch"].return_value = NotModified()
+
+    effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
+    assert effects == [cal_effect]


### PR DESCRIPTION
## What & why

The `external_calendar_busy_blocks` plugin writes a provider's external-calendar
busy times as "Busy" events on that provider's Canvas **Administrative** calendar.
Previously `calendars/admin_lookup.py` only *found* an existing Admin calendar
(returning `None` otherwise), so a connected feed silently did nothing until
someone manually created the provider's Admin calendar.

This change makes connecting a feed **provision the Admin calendar automatically**.

## Changes

- **`calendars/admin_lookup.py`** — replace find-only `find_admin_calendar_id(staff) -> str | None`
  with find-**or-create** `get_admin_calendar_id(provider_id: str) -> tuple[str, list[Effect]]`,
  mirroring the sibling `provider-availability` plugin's helper. Returns a
  `Calendar(...).create()` effect when the provider has no Admin calendar; `("", [])`
  when staff/name can't be resolved. Calendar id returned as `str` for JSON-serializable
  Event payloads.
- **`routes/feeds.py`** — `POST /feeds` provisions the Admin calendar after the feed is
  saved, returning the create effect before the response. Provisioning runs only on the
  success path (never on a validation/SSRF rejection).
- **`sync/cron.py`** — the 15-minute sync uses the find-or-create helper and returns the
  create effect (ordered before the Event effects, and also on the NotModified / empty-feed
  paths) so a missing calendar self-heals — covering feeds connected before this change or
  calendars later deleted. Removed the now-redundant `Staff` lookup/import.
- **Tests** — new coverage for provisioning on connect, effect ordering, and cron self-heal.
  Also fixed 4 pre-existing time-bomb tests in `tests/sync/test_cron.py` that hardcoded
  `2026-06-15` event dates (now in the past; `SyncCron.execute()` uses real wall-clock now,
  so those events were filtered out) — they now use now-relative dates.
- **Manifest/docs** — bump `plugin_version` to `0.2.0`, declare `Calendar` write access for
  the affected handlers, and note auto-provisioning in the README.

## Testing

`pytest` — 140 passed.
