### PR TITLE
missed-appointment-notifications: configurable reschedule due-days

### DIFF
--- a/extensions/missed-appointment-notifications/missed_appointment_notifications/CANVAS_MANIFEST.json
+++ b/extensions/missed-appointment-notifications/missed_appointment_notifications/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.0.1",
+    "plugin_version": "0.0.2",
     "name": "missed_appointment_notifications",
     "description": "When an appointment is cancelled or no-showed, creates a follow-up task for scheduling/front-desk staff to rebook the patient, routed to a scheduling team (by configured name) or the appointment's provider, with a comment summarising the original appointment.",
     "components": {
@@ -16,7 +16,10 @@
             }
         ]
     },
-    "variables": [{"name": "SCHEDULING_TEAM_NAME", "sensitive": true}],
+    "variables": [
+        {"name": "SCHEDULING_TEAM_NAME", "sensitive": true},
+        {"name": "RESCHEDULE_DUE_DAYS", "sensitive": false}
+    ],
     "tags": {},
     "references": [],
     "license": "MIT",

--- a/extensions/missed-appointment-notifications/missed_appointment_notifications/README.md
+++ b/extensions/missed-appointment-notifications/missed_appointment_notifications/README.md
@@ -29,7 +29,8 @@ events and creates:
 
 - a **task** titled with the provider and the original appointment date/time
   (noting whether the appointment was *cancelled* or *no-showed*), linked to the
-  patient, due **the next day**; and
+  patient, due a configurable number of days later (see `RESCHEDULE_DUE_DAYS`;
+  defaults to the next day); and
 - a **comment** summarising the original appointment: reason for visit,
   provider, date/time, location, and note type.
 
@@ -69,16 +70,20 @@ Configured via plugin **variables** (declared in `CANVAS_MANIFEST.json`):
 | Variable | Required | Description |
 |---|---|---|
 | `SCHEDULING_TEAM_NAME` | optional | Exact name of the Team that reschedule tasks should be assigned to (matched case-insensitively, e.g. `Scheduling`). If unset/blank or no team matches, tasks are assigned to the appointment's provider. |
+| `RESCHEDULE_DUE_DAYS` | optional | Whole number of days after the cancellation/no-show that the reschedule task is due. Defaults to `1` when unset. A blank, non-numeric, zero, or negative value is ignored (with a logged warning) and falls back to the default. |
 
-No code changes are needed to customise routing — leave `SCHEDULING_TEAM_NAME`
-blank to always assign to the provider. The display timezone is taken from the
-instance configuration (`INSTALLATION_TIME_ZONE`), not a setting.
+No code changes are needed to customise routing or timing — leave
+`SCHEDULING_TEAM_NAME` blank to always assign to the provider, and set
+`RESCHEDULE_DUE_DAYS` (e.g. `7`) to change how long staff have before the task
+is due. The display timezone is taken from the instance configuration
+(`INSTALLATION_TIME_ZONE`), not a setting.
 
 ## Screenshots
 
 The reschedule task created in a patient's chart after a cancellation — titled
-with the provider and original appointment time, due the next day, labelled
-`Reschedule`, with a comment summarising the original appointment:
+with the provider and original appointment time, due after the configured
+number of days, labelled `Reschedule`, with a comment summarising the original
+appointment:
 
 ![Reschedule task generated from a cancelled appointment](docs/reschedule-task.png)
 

--- a/extensions/missed-appointment-notifications/missed_appointment_notifications/README.md
+++ b/extensions/missed-appointment-notifications/missed_appointment_notifications/README.md
@@ -70,7 +70,7 @@ Configured via plugin **variables** (declared in `CANVAS_MANIFEST.json`):
 | Variable | Required | Description |
 |---|---|---|
 | `SCHEDULING_TEAM_NAME` | optional | Exact name of the Team that reschedule tasks should be assigned to (matched case-insensitively, e.g. `Scheduling`). If unset/blank or no team matches, tasks are assigned to the appointment's provider. |
-| `RESCHEDULE_DUE_DAYS` | optional | Whole number of days after the cancellation/no-show that the reschedule task is due. Defaults to `1` when unset. A blank, non-numeric, zero, or negative value is ignored (with a logged warning) and falls back to the default. |
+| `RESCHEDULE_DUE_DAYS` | optional | Whole number of days (1–366) after the cancellation/no-show that the reschedule task is due. Defaults to `1` when unset. A blank, non-numeric, or out-of-range value is ignored (with a logged warning) and falls back to the default. |
 
 No code changes are needed to customise routing or timing — leave
 `SCHEDULING_TEAM_NAME` blank to always assign to the provider, and set

--- a/extensions/missed-appointment-notifications/missed_appointment_notifications/handlers/event_handlers.py
+++ b/extensions/missed-appointment-notifications/missed_appointment_notifications/handlers/event_handlers.py
@@ -18,8 +18,14 @@ from logger import log
 #: to the appointment's provider. (Accessed at runtime via ``self.secrets``.)
 SCHEDULING_TEAM_NAME_VARIABLE = "SCHEDULING_TEAM_NAME"
 
-#: Number of days from cancellation until the reschedule task is due.
-RESCHEDULE_DUE_DAYS = 1
+#: Plugin variable holding the number of days from cancellation until the
+#: reschedule task is due. Optional; when unset, blank, or invalid the handler
+#: falls back to ``DEFAULT_RESCHEDULE_DUE_DAYS``. (Accessed at runtime via
+#: ``self.secrets``.) Cylinder sets this to ``7``.
+RESCHEDULE_DUE_DAYS_VARIABLE = "RESCHEDULE_DUE_DAYS"
+
+#: Days until the reschedule task is due when the variable above is not set.
+DEFAULT_RESCHEDULE_DUE_DAYS = 1
 
 #: Label added to the reschedule task — but only when a label of this name
 #: already exists in the instance. We never create a new label.
@@ -87,7 +93,7 @@ class MissedAppointmentNotificationHandler(BaseHandler):
             "id": task_id,
             "patient_id": str(appointment.patient.id) if appointment.patient else None,
             "title": self._task_title(appointment, tz, is_no_show),
-            "due": arrow.utcnow().shift(days=RESCHEDULE_DUE_DAYS).datetime,
+            "due": arrow.utcnow().shift(days=self._due_days()).datetime,
             "status": TaskStatus.OPEN,
             "labels": self._labels(appointment),
         }
@@ -135,6 +141,35 @@ class MissedAppointmentNotificationHandler(BaseHandler):
                 team_name,
             )
         return team
+
+    def _due_days(self) -> int:
+        """Number of days until the reschedule task is due.
+
+        Reads the ``RESCHEDULE_DUE_DAYS`` plugin variable and returns it as a
+        positive integer. When the variable is unset, blank, or not a usable
+        value, logs a warning and falls back to ``DEFAULT_RESCHEDULE_DUE_DAYS``
+        so a misconfiguration never breaks task creation.
+        """
+        raw = (self.secrets.get(RESCHEDULE_DUE_DAYS_VARIABLE) or "").strip()
+        if not raw:
+            return DEFAULT_RESCHEDULE_DUE_DAYS
+
+        try:
+            days = int(raw)
+        except ValueError:
+            days = 0  # not a whole number; falls through to the guard below
+
+        # A due date in the past (negative) or same-day (0) is almost certainly
+        # a misconfiguration — fall back rather than create a nonsensical task.
+        if days < 1:
+            log.warning(
+                "MissedAppointmentNotifications: invalid RESCHEDULE_DUE_DAYS %r; using %d",
+                raw,
+                DEFAULT_RESCHEDULE_DUE_DAYS,
+            )
+            return DEFAULT_RESCHEDULE_DUE_DAYS
+
+        return days
 
     @staticmethod
     def _labels(appointment: Appointment) -> list[str]:

--- a/extensions/missed-appointment-notifications/missed_appointment_notifications/handlers/event_handlers.py
+++ b/extensions/missed-appointment-notifications/missed_appointment_notifications/handlers/event_handlers.py
@@ -27,6 +27,11 @@ RESCHEDULE_DUE_DAYS_VARIABLE = "RESCHEDULE_DUE_DAYS"
 #: Days until the reschedule task is due when the variable above is not set.
 DEFAULT_RESCHEDULE_DUE_DAYS = 1
 
+#: Upper bound on the configured due-days. Anything beyond this is treated as a
+#: misconfiguration — it also keeps the resulting date well within the range a
+#: ``datetime`` can represent (``shift`` overflows for very large values).
+MAX_RESCHEDULE_DUE_DAYS = 366
+
 #: Label added to the reschedule task — but only when a label of this name
 #: already exists in the instance. We never create a new label.
 RESCHEDULE_LABEL = "Reschedule"
@@ -159,9 +164,10 @@ class MissedAppointmentNotificationHandler(BaseHandler):
         except ValueError:
             days = 0  # not a whole number; falls through to the guard below
 
-        # A due date in the past (negative) or same-day (0) is almost certainly
-        # a misconfiguration — fall back rather than create a nonsensical task.
-        if days < 1:
+        # Reject values outside a sane range: a past/same-day due date (< 1) or
+        # an implausibly distant one (> MAX). The upper bound also avoids an
+        # OverflowError from shifting a datetime by an enormous number of days.
+        if not 1 <= days <= MAX_RESCHEDULE_DUE_DAYS:
             log.warning(
                 "MissedAppointmentNotifications: invalid RESCHEDULE_DUE_DAYS %r; using %d",
                 raw,

--- a/extensions/missed-appointment-notifications/tests/test_event_handlers.py
+++ b/extensions/missed-appointment-notifications/tests/test_event_handlers.py
@@ -28,6 +28,8 @@ from canvas_sdk.v1.data.staff import Staff
 from canvas_sdk.v1.data.task import TaskLabel
 
 from missed_appointment_notifications.handlers.event_handlers import (
+    DEFAULT_RESCHEDULE_DUE_DAYS,
+    RESCHEDULE_DUE_DAYS_VARIABLE,
     RESCHEDULE_LABEL,
     MissedAppointmentNotificationHandler,
 )
@@ -214,14 +216,46 @@ def test_creates_unassigned_task_when_no_team_and_no_provider() -> None:
     assert data["patient"]["id"] == str(patient.id)
 
 
-def test_due_date_is_next_day() -> None:
-    """The reschedule task is due roughly one day after cancellation."""
+def _due_of(handler: MissedAppointmentNotificationHandler) -> arrow.Arrow:
+    """The due datetime of the reschedule task produced by a handler."""
+    return arrow.get(_task_data(handler.compute()[0])["due"])
+
+
+def _assert_due_in_days(due: arrow.Arrow, days: int) -> None:
+    """Assert the due date is roughly ``days`` out (within a ±1h window)."""
+    now = arrow.utcnow()
+    assert now.shift(days=days, hours=-1) < due < now.shift(days=days, hours=1)
+
+
+def test_due_date_defaults_to_one_day_when_unset() -> None:
+    """With no RESCHEDULE_DUE_DAYS configured, the task is due ~1 day out."""
     patient = PatientFactory.create()
     provider = StaffFactory.create()
     appointment = _create_appointment(patient, provider, start_time=_future())
 
-    due = arrow.get(_task_data(_make_handler(appointment.id, {}).compute()[0])["due"])
-    assert arrow.utcnow().shift(hours=23) < due < arrow.utcnow().shift(hours=25)
+    due = _due_of(_make_handler(appointment.id, {}))
+    _assert_due_in_days(due, DEFAULT_RESCHEDULE_DUE_DAYS)
+
+
+def test_due_date_uses_configured_value() -> None:
+    """RESCHEDULE_DUE_DAYS=7 (Cylinder's setting) makes the task due ~7 days out."""
+    patient = PatientFactory.create()
+    provider = StaffFactory.create()
+    appointment = _create_appointment(patient, provider, start_time=_future())
+
+    due = _due_of(_make_handler(appointment.id, {RESCHEDULE_DUE_DAYS_VARIABLE: "7"}))
+    _assert_due_in_days(due, 7)
+
+
+def test_due_date_falls_back_on_invalid_value() -> None:
+    """A non-numeric, zero, or negative value falls back to the default."""
+    patient = PatientFactory.create()
+    provider = StaffFactory.create()
+    appointment = _create_appointment(patient, provider, start_time=_future())
+
+    for bad in ("abc", "7.5", "0", "-3", "  "):
+        due = _due_of(_make_handler(appointment.id, {RESCHEDULE_DUE_DAYS_VARIABLE: bad}))
+        _assert_due_in_days(due, DEFAULT_RESCHEDULE_DUE_DAYS)
 
 
 # --------------------------------------------------------------------------- #

--- a/extensions/missed-appointment-notifications/tests/test_event_handlers.py
+++ b/extensions/missed-appointment-notifications/tests/test_event_handlers.py
@@ -248,12 +248,16 @@ def test_due_date_uses_configured_value() -> None:
 
 
 def test_due_date_falls_back_on_invalid_value() -> None:
-    """A non-numeric, zero, or negative value falls back to the default."""
+    """Non-numeric, zero, negative, or out-of-range values fall back to the default.
+
+    ``"99999999999"`` is a valid int but would overflow ``datetime`` when shifted,
+    so it must be rejected rather than raised on.
+    """
     patient = PatientFactory.create()
     provider = StaffFactory.create()
     appointment = _create_appointment(patient, provider, start_time=_future())
 
-    for bad in ("abc", "7.5", "0", "-3", "  "):
+    for bad in ("abc", "7.5", "0", "-3", "  ", "367", "99999999999"):
         due = _due_of(_make_handler(appointment.id, {RESCHEDULE_DUE_DAYS_VARIABLE: bad}))
         _assert_due_in_days(due, DEFAULT_RESCHEDULE_DUE_DAYS)
 


### PR DESCRIPTION
## What

Make the reschedule task's due date configurable via a new `RESCHEDULE_DUE_DAYS` plugin variable, instead of the hard-coded 1 day.

- Defaults to **1 day** when the variable is unset — no behavior change for existing adopters.
- A blank, non-numeric, zero, or negative value falls back to the default with a logged warning (fails safe; never raises inside `compute()`).
- Follows the plugin's existing config pattern (mirrors `SCHEDULING_TEAM_NAME`).
- Bumps `plugin_version` `0.0.1` → `0.0.2`; README documents the new variable.

## Why

Cylinder wants the follow-up task due **7 days** after a cancellation/no-show rather than the next day. Making it a per-instance variable keeps the shared reference default unchanged while letting them set `RESCHEDULE_DUE_DAYS=7`.

## Testing

- `uv run pytest` — 36 passed (added coverage for default, configured 7-day, and invalid-value fallback).
- `uv run mypy missed_appointment_notifications` — clean.
- Deployed to the `support-team` instance (`0.0.2`, `RESCHEDULE_DUE_DAYS=7`) and verified the reschedule task lands ~7 days out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)