### PR TITLE
feat(external-calendar-busy-blocks): admin management of provider calendar feeds

### DIFF
--- a/docs/superpowers/plans/2026-07-11-admin-manage-calendar-feeds.md
+++ b/docs/superpowers/plans/2026-07-11-admin-manage-calendar-feeds.md
@@ -1,0 +1,831 @@
+# Admin-Managed Calendar Feeds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an authorized admin connect, view, and disconnect a personal calendar feed on behalf of any active provider, without changing the existing provider self-service flow.
+
+**Architecture:** Add an `is_admin` authorization helper (backed by a new `ADMIN_STAFF_IDS` secret, fail closed). Extend `FeedsAPI` so its connect/disconnect routes accept an optional `staff_id` that is honored only for admins, and add an admin-only `GET /feeds/status` route. `ConfigPage` renders an extra admin section (a server-rendered active-staff dropdown) only for admins. No data-model or cron changes — an admin-created `StaffCalendarFeed` is identical to a self-created one.
+
+**Tech Stack:** Python 3.12, Canvas Plugin SDK (`canvas_sdk`), Django ORM custom-data models, pytest, `unittest.mock`.
+
+## Global Constraints
+
+- Plugin package root: `extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/`.
+- Tests run from `extensions/external-calendar-busy-blocks/` via `.venv/bin/pytest`.
+- Fail closed on missing/empty secrets — a missing `ADMIN_STAFF_IDS` grants access to nobody (never everybody).
+- Staff ids are canonicalized to dashless form; `Staff.id` is stored as `uuid4().hex` (32 lowercase hex chars).
+- A non-admin's body/query `staff_id` must be ignored for writes (act on self) — never a 403 that reveals behavior, never privilege escalation.
+- Never echo a stored ICS URL back to any client (it is a bearer token).
+- No broad `try/except Exception` around handler logic; keep existing specific error handling.
+- Clinical-data `entered_in_error` filtering is N/A here (no clinical models touched).
+
+---
+
+### Task 1: `is_admin` authorization helper
+
+**Files:**
+- Modify: `external_calendar_busy_blocks/auth.py`
+- Test: `tests/test_auth.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `is_admin(staff_id: str | None, secrets: Mapping[str, str] | None) -> bool` in `external_calendar_busy_blocks.auth`. Returns `True` only when `staff_id` (canonicalized dashless, lowercased) is a member of the comma-separated `ADMIN_STAFF_IDS` secret; `False` when `staff_id` is falsy or the secret is unset/empty/whitespace.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_auth.py`:
+
+```python
+from external_calendar_busy_blocks.auth import is_admin
+
+
+def test_is_admin_false_when_secret_unset() -> None:
+    assert is_admin("00000000000000000000000000000001", {}) is False
+
+
+def test_is_admin_false_when_secret_blank() -> None:
+    assert is_admin("00000000000000000000000000000001", {"ADMIN_STAFF_IDS": "   "}) is False
+
+
+def test_is_admin_false_when_staff_id_none() -> None:
+    assert is_admin(None, {"ADMIN_STAFF_IDS": "00000000000000000000000000000001"}) is False
+
+
+def test_is_admin_true_for_member_dashless() -> None:
+    secrets = {"ADMIN_STAFF_IDS": "00000000000000000000000000000001,0000000000000000000000000000ffff"}
+    assert is_admin("0000000000000000000000000000ffff", secrets) is True
+
+
+def test_is_admin_matches_regardless_of_dashes_and_case() -> None:
+    # Secret entered with dashes and uppercase; caller id is dashless lowercase.
+    secrets = {"ADMIN_STAFF_IDS": "00000000-0000-0000-0000-0000000000AB"}
+    assert is_admin("000000000000000000000000000000ab", secrets) is True
+
+
+def test_is_admin_false_for_non_member() -> None:
+    secrets = {"ADMIN_STAFF_IDS": "00000000000000000000000000000001"}
+    assert is_admin("00000000000000000000000000000002", secrets) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_auth.py -v -k is_admin`
+Expected: FAIL with `ImportError: cannot import name 'is_admin'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to the end of `external_calendar_busy_blocks/auth.py`:
+
+```python
+def _canonical(raw: str) -> str:
+    """Dashless, lowercased form for case/format-insensitive UUID comparison."""
+    return raw.replace("-", "").strip().lower()
+
+
+def is_admin(staff_id, secrets) -> bool:
+    """Return True only if ``staff_id`` is listed in the ADMIN_STAFF_IDS secret.
+
+    Fails closed: an unset, empty, or whitespace-only secret means no one is an
+    admin. Both the caller id and each configured id are canonicalized to the
+    dashless, lowercased form so dashed/uppercase entries still match Staff.id
+    (uuid4().hex).
+    """
+    if not staff_id:
+        return False
+    raw = (secrets or {}).get("ADMIN_STAFF_IDS") or ""
+    admins = {_canonical(part) for part in raw.split(",") if part.strip()}
+    if not admins:
+        return False
+    return _canonical(staff_id) in admins
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_auth.py -v`
+Expected: PASS (all `is_admin` tests plus the existing `canonical_staff_id` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add external_calendar_busy_blocks/auth.py tests/test_auth.py
+git commit -m "feat(external-calendar-busy-blocks): add is_admin authorization helper"
+```
+
+---
+
+### Task 2: Admin-targeted connect/disconnect in `FeedsAPI`
+
+**Files:**
+- Modify: `external_calendar_busy_blocks/routes/feeds.py`
+- Test: `tests/routes/test_feeds.py`
+
+**Interfaces:**
+- Consumes: `is_admin` from Task 1.
+- Produces: `FeedsAPI._resolve_target_staff_id(logged_in: str, body: dict) -> str` — returns the canonicalized body `staff_id` when it is present AND the caller is an admin, else `logged_in`. `create_feed`/`delete_feed` operate on this target. `create_feed` now returns `400` when the target's Admin calendar cannot be resolved (empty id from `get_admin_calendar_id`).
+
+- [ ] **Step 1: Update the test helper and rewrite the impersonation test**
+
+In `tests/routes/test_feeds.py`, replace `_api_with_request` so callers can pass secrets and so `query_params` exists:
+
+```python
+def _api_with_request(
+    method: str,
+    body: bytes,
+    logged_in_staff: str | None,
+    secrets: dict | None = None,
+    query_params: dict | None = None,
+) -> FeedsAPI:
+    headers = {}
+    if logged_in_staff:
+        headers["canvas-logged-in-user-id"] = logged_in_staff
+    request = MagicMock(
+        method=method,
+        body=body,
+        headers=headers,
+        path_params={},
+        query_params=query_params or {},
+    )
+    api = FeedsAPI.__new__(FeedsAPI)
+    api.request = request
+    api.secrets = secrets or {}
+    return api
+```
+
+Then replace the existing `test_post_ignores_staff_id_in_body` with the non-admin + admin pair:
+
+```python
+def test_post_non_admin_ignores_staff_id_in_body() -> None:
+    """A non-admin's body staff_id is ignored; the session stays authoritative."""
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])),
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://outlook.office365.com/owa/calendar/x/calendar.ics",'
+            b'"staff_id":"00000000000000000000000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000002",
+            secrets={},  # not an admin
+        )
+        api.create_feed()
+    assert MockFeed.call_args.kwargs["staff_id"] == "00000000000000000000000000000002"
+
+
+def test_post_admin_targets_other_staff() -> None:
+    """An admin's body staff_id is honored: the feed is keyed to the target."""
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])) as mock_get_cal,
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics",'
+            b'"staff_id":"00000000-0000-0000-0000-000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        api.create_feed()
+    assert MockFeed.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert mock_get_cal.call_args.args[0] == "00000000000000000000000000000099"
+
+
+def test_post_admin_returns_400_when_calendar_unresolvable() -> None:
+    """If the target staff can't be resolved, no feed is written and we 400."""
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("", [])),
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics",'
+            b'"staff_id":"00000000000000000000000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        responses = api.create_feed()
+    assert responses[0].status_code == 400
+    MockFeed.assert_not_called()
+
+
+def test_delete_admin_targets_other_staff() -> None:
+    feed = MagicMock(staff_id="00000000000000000000000000000099")
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = feed
+        MockImported.objects.filter.return_value = []
+        api = _api_with_request(
+            "POST",
+            b'{"staff_id":"00000000-0000-0000-0000-000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        responses = api.delete_feed()
+    # Feed and imported-event lookups were scoped to the target staff id.
+    assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert responses[-1].status_code == 200
+    feed.delete.assert_called_once()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/routes/test_feeds.py -v -k "admin or non_admin"`
+Expected: FAIL — `test_post_admin_targets_other_staff` asserts the target id but current code keys the feed to the session id; `_resolve_target_staff_id` / 400-guard do not yet exist.
+
+- [ ] **Step 3: Implement target resolution and the calendar guard**
+
+In `external_calendar_busy_blocks/routes/feeds.py`, add the `is_admin` import:
+
+```python
+from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
+```
+
+Add a helper method to `FeedsAPI`:
+
+```python
+    def _resolve_target_staff_id(self, logged_in: str, body: dict) -> str:
+        """Return the staff id to act on.
+
+        An admin may target another provider by sending ``staff_id`` in the
+        body; the id is canonicalized to the dashless form used for Staff.id.
+        For everyone else (and when no staff_id is sent), the logged-in staff is
+        authoritative — a non-admin's body staff_id is ignored, so it can never
+        escalate privilege.
+        """
+        requested = (body.get("staff_id") or "").strip()
+        if requested and is_admin(logged_in, self.secrets):
+            return requested.replace("-", "")
+        return logged_in
+```
+
+Rewrite `create_feed` so the target is resolved, the calendar is provisioned
+before the feed row is written, and an unresolvable calendar returns `400`
+before any write. Replace the body of `create_feed` from the `existing = ...`
+block onward with:
+
+```python
+        target_id = self._resolve_target_staff_id(staff_id, body)
+
+        # Provision the target's Admin calendar first. An empty id means the
+        # staff (or their name) could not be resolved — fail before writing a
+        # feed row that would have no calendar to land busy blocks on.
+        cal_id, cal_effects = get_admin_calendar_id(target_id)
+        if not cal_id:
+            return [JSONResponse(
+                {"error": "Could not resolve the provider's calendar"},
+                status_code=400,
+            )]
+
+        existing = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
+        if existing:
+            existing.ics_url = url
+            existing.is_active = True
+            existing.last_error = None
+            existing.last_etag = None
+            existing.last_modified = None
+            existing.save()
+        else:
+            StaffCalendarFeed(staff_id=target_id, ics_url=url, is_active=True).save()
+
+        return [*cal_effects, JSONResponse({"status": "connected"}, status_code=200)]
+```
+
+Rewrite `delete_feed` to resolve the target. Replace its body (after the auth
+check) with:
+
+```python
+        try:
+            body = json.loads(self.request.body or b"{}")
+        except json.JSONDecodeError:
+            return [JSONResponse({"error": "Invalid JSON"}, status_code=400)]
+
+        target_id = self._resolve_target_staff_id(staff_id, body)
+
+        feed = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
+        if feed is None:
+            return [JSONResponse({"status": "no feed"}, status_code=200)]
+
+        effects: list[Effect] = []
+        for row in ImportedEvent.objects.filter(staff_id=target_id):
+            effects.append(Event(event_id=row.canvas_event_id).delete())
+            row.delete()
+
+        feed.delete()
+        return [*effects, JSONResponse({"status": "disconnected"}, status_code=200)]
+```
+
+- [ ] **Step 4: Run the full feeds test file**
+
+Run: `.venv/bin/pytest tests/routes/test_feeds.py -v`
+Expected: PASS — new admin/non-admin tests pass and all pre-existing tests
+(SSRF allowlist, whitespace, provisioning, self-service) still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add external_calendar_busy_blocks/routes/feeds.py tests/routes/test_feeds.py
+git commit -m "feat(external-calendar-busy-blocks): admins can connect/disconnect feeds for any provider"
+```
+
+---
+
+### Task 3: Admin-only `GET /feeds/status` route
+
+**Files:**
+- Modify: `external_calendar_busy_blocks/routes/feeds.py`
+- Test: `tests/routes/test_feeds.py`
+
+**Interfaces:**
+- Consumes: `is_admin` (Task 1), `StaffCalendarFeed`, `_logged_in_staff_id`.
+- Produces: `FeedsAPI.feed_status()` handling `GET /feeds/status?staff_id=<id>`. Admin-only. Returns JSON `{"connected": bool, "last_sync_at": str | None, "last_error": str | None}`. Never returns the ICS URL. `401` unauthenticated, `403` non-admin, `400` missing `staff_id`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/routes/test_feeds.py`:
+
+```python
+def test_status_requires_admin() -> None:
+    api = _api_with_request(
+        "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000002",
+        secrets={},  # not an admin
+        query_params={"staff_id": "00000000000000000000000000000099"},
+    )
+    responses = api.feed_status()
+    assert responses[0].status_code == 403
+
+
+def test_status_requires_staff_id() -> None:
+    api = _api_with_request(
+        "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
+        secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        query_params={},
+    )
+    responses = api.feed_status()
+    assert responses[0].status_code == 400
+
+
+def test_status_reports_connected_feed_without_url() -> None:
+    feed = MagicMock(is_active=True, last_sync_at="2026-07-11T00:00:00Z", last_error=None)
+    with patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed:
+        MockFeed.objects.filter.return_value.first.return_value = feed
+        api = _api_with_request(
+            "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+            query_params={"staff_id": "00000000-0000-0000-0000-000000000099"},
+        )
+        responses = api.feed_status()
+    assert responses[0].status_code == 200
+    body = json.loads(responses[0].content)
+    assert body["connected"] is True
+    assert "ics_url" not in body
+    # Lookup was scoped to the canonicalized target id.
+    assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+
+
+def test_status_reports_no_feed() -> None:
+    with patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed:
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+            query_params={"staff_id": "00000000000000000000000000000099"},
+        )
+        responses = api.feed_status()
+    body = json.loads(responses[0].content)
+    assert body["connected"] is False
+```
+
+Note: `responses[0].content` is the `JSONResponse` body. If `JSONResponse`
+stores bytes, `json.loads` accepts bytes directly; if the attribute name
+differs in this SDK build, inspect the object in a scratch REPL
+(`.venv/bin/python -c "from canvas_sdk.effects.simple_api import JSONResponse; print(dir(JSONResponse(...)))"`)
+and adjust the accessor — do not change the assertion intent.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/routes/test_feeds.py -v -k status`
+Expected: FAIL with `AttributeError: 'FeedsAPI' object has no attribute 'feed_status'`.
+
+- [ ] **Step 3: Implement the route**
+
+In `external_calendar_busy_blocks/routes/feeds.py`, add after `delete_feed`:
+
+```python
+    @api.get("/feeds/status")
+    def feed_status(self) -> list[Response | Effect]:
+        staff_id = self._logged_in_staff_id()
+        if not staff_id:
+            return [JSONResponse({"error": "Not authenticated"}, status_code=401)]
+        if not is_admin(staff_id, self.secrets):
+            return [JSONResponse({"error": "Forbidden"}, status_code=403)]
+
+        target_id = (self.request.query_params.get("staff_id") or "").strip().replace("-", "")
+        if not target_id:
+            return [JSONResponse({"error": "Missing staff_id"}, status_code=400)]
+
+        feed = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
+        if feed is None:
+            return [JSONResponse({"connected": False}, status_code=200)]
+        # Never return ics_url — it is a bearer token.
+        return [JSONResponse(
+            {
+                "connected": bool(feed.is_active),
+                "last_sync_at": str(feed.last_sync_at) if feed.last_sync_at else None,
+                "last_error": feed.last_error,
+            },
+            status_code=200,
+        )]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/routes/test_feeds.py -v -k status`
+Expected: PASS (4 status tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add external_calendar_busy_blocks/routes/feeds.py tests/routes/test_feeds.py
+git commit -m "feat(external-calendar-busy-blocks): add admin-only feed status endpoint"
+```
+
+---
+
+### Task 4: `ConfigPage` admin context (staff dropdown data)
+
+**Files:**
+- Modify: `external_calendar_busy_blocks/ui/pages.py`
+- Create: `tests/ui/__init__.py`
+- Create: `tests/ui/test_pages.py`
+
+**Interfaces:**
+- Consumes: `is_admin` (Task 1), `canonical_staff_id`, SDK `Staff`.
+- Produces: `ConfigPage.render` passes `is_admin` (bool), `staff_options` (list of `{"id": str, "name": str}`, only populated for admins), and `status_url` into the template context. `render_to_string` cannot execute outside plugin context, so tests patch it and assert the context.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ui/__init__.py` (empty file), then create `tests/ui/test_pages.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from external_calendar_busy_blocks.ui.pages import ConfigPage
+
+
+def _page(logged_in_staff: str | None, secrets: dict | None = None) -> ConfigPage:
+    headers = {}
+    if logged_in_staff:
+        headers["canvas-logged-in-user-id"] = logged_in_staff
+    request = MagicMock(headers=headers)
+    page = ConfigPage.__new__(ConfigPage)
+    page.request = request
+    page.secrets = secrets or {}
+    return page
+
+
+def test_render_non_admin_has_no_staff_options() -> None:
+    with (
+        patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
+        patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = None
+        _page("00000000-0000-0000-0000-000000000002", secrets={}).render()
+    context = mock_render.call_args.args[1]
+    assert context["is_admin"] is False
+    assert context["staff_options"] == []
+
+
+def test_render_admin_lists_active_staff() -> None:
+    staff_a = MagicMock(id="00000000000000000000000000000010", full_name="Bea Adams")
+    staff_b = MagicMock(id="00000000000000000000000000000011", full_name="Cy Brown")
+    with (
+        patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
+        patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.ui.pages.Staff") as MockStaff,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = None
+        MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b]
+        _page(
+            "00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        ).render()
+    context = mock_render.call_args.args[1]
+    assert context["is_admin"] is True
+    assert context["staff_options"] == [
+        {"id": "00000000000000000000000000000010", "name": "Bea Adams"},
+        {"id": "00000000000000000000000000000011", "name": "Cy Brown"},
+    ]
+    MockStaff.objects.filter.assert_called_once_with(active=True)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/ui/test_pages.py -v`
+Expected: FAIL — `render` does not yet put `is_admin`/`staff_options` in context (KeyError), and `Staff` is not yet imported/patched in `pages`.
+
+- [ ] **Step 3: Implement the context**
+
+Replace `external_calendar_busy_blocks/ui/pages.py` with:
+
+```python
+from http import HTTPStatus
+
+from canvas_sdk.effects.simple_api import HTMLResponse, PlainTextResponse, Response
+from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
+from canvas_sdk.templates import render_to_string
+from canvas_sdk.v1.data.staff import Staff
+
+from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
+from external_calendar_busy_blocks.data.models import StaffCalendarFeed
+
+
+class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
+    """GET /pages/config — renders the connect/disconnect HTML page."""
+
+    @api.get("/pages/config")
+    def render(self) -> list[Response]:
+        staff_id = canonical_staff_id(self.request.headers)
+        feed = StaffCalendarFeed.objects.filter(staff_id=staff_id).first() if staff_id else None
+
+        admin = is_admin(staff_id, self.secrets)
+        staff_options: list[dict] = []
+        if admin:
+            staff_options = [
+                {"id": s.id, "name": s.full_name}
+                for s in Staff.objects.filter(active=True).order_by("last_name", "first_name")
+            ]
+
+        html = render_to_string(
+            "templates/config.html",
+            {
+                "feed": feed,
+                "connected": feed is not None and feed.is_active,
+                "is_admin": admin,
+                "staff_options": staff_options,
+                "post_url": "/plugin-io/api/external_calendar_busy_blocks/feeds",
+                "delete_url": "/plugin-io/api/external_calendar_busy_blocks/feeds/delete",
+                "status_url": "/plugin-io/api/external_calendar_busy_blocks/feeds/status",
+            },
+        )
+        # render_to_string is typed `str | None`. The current SDK raises
+        # FileNotFoundError on a missing template rather than returning None,
+        # but guard against the declared contract so a None can never reach
+        # HTMLResponse (whose content.encode() would raise) — return an
+        # explicit 500 instead.
+        if html is None:
+            return [PlainTextResponse(
+                "Unable to render the configuration page.",
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )]
+        return [HTMLResponse(html, status_code=HTTPStatus.OK)]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/ui/test_pages.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add external_calendar_busy_blocks/ui/pages.py tests/ui/
+git commit -m "feat(external-calendar-busy-blocks): pass admin staff list to config page"
+```
+
+---
+
+### Task 5: Admin section in `config.html`
+
+**Files:**
+- Modify: `external_calendar_busy_blocks/templates/config.html`
+
+**Interfaces:**
+- Consumes: context keys `is_admin`, `staff_options`, `post_url`, `delete_url`, `status_url` from Task 4.
+- Produces: no Python interface. Rendered HTML gains a "Manage another provider" section (staff `<select>`, a status line, and Connect/Disconnect controls) only when `is_admin` is truthy. Admin actions POST the same `post_url`/`delete_url` with a `staff_id` field; status is fetched from `status_url`.
+
+This task has no unit test (the SDK forbids rendering templates outside plugin
+context, and the repo does not unit-test the page JS). Verify by inspection in
+Step 2 and rely on the Task 4 context tests plus Task 6's manifest.
+
+- [ ] **Step 1: Add the admin section and its script**
+
+In `external_calendar_busy_blocks/templates/config.html`, insert the admin
+block immediately after the closing `</div>` of `#content` (before
+`<p id="msg"></p>`):
+
+```html
+  {% if is_admin %}
+  <hr style="margin:24px 0;" />
+  <div id="admin-content">
+    <h2>Manage another provider</h2>
+    <p>Connect or disconnect a personal calendar on behalf of a provider. The provider never has to paste their own URL.</p>
+    <label for="admin_staff">Provider</label>
+    <select id="admin_staff">
+      <option value="">— Select a provider —</option>
+      {% for option in staff_options %}
+      <option value="{{ option.id }}">{{ option.name }}</option>
+      {% endfor %}
+    </select>
+    <p id="admin-status"></p>
+    <div id="admin-actions" style="display:none;">
+      <label for="admin_ics_url">Secret iCal URL</label>
+      <input type="url" id="admin_ics_url" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics" />
+      <button type="button" id="admin-connect">Connect / Replace</button>
+      <button type="button" id="admin-disconnect">Disconnect</button>
+    </div>
+    <p id="admin-msg"></p>
+  </div>
+  {% endif %}
+```
+
+- [ ] **Step 2: Add the admin script and verify markup**
+
+Inside the existing `<script>`'s IIFE, just before the final `bindConnect();
+bindDisconnect();` lines, add the admin wiring (reusing `submitJson`, `postUrl`,
+`deleteUrl`):
+
+```javascript
+      var statusUrl = "{{ status_url }}";
+      var adminSelect = document.getElementById("admin_staff");
+      if (adminSelect) {
+        var adminActions = document.getElementById("admin-actions");
+        var adminStatus = document.getElementById("admin-status");
+        var adminMsg = document.getElementById("admin-msg");
+        var adminUrlInput = document.getElementById("admin_ics_url");
+
+        function refreshAdminStatus(staffId) {
+          adminMsg.textContent = "";
+          if (!staffId) { adminActions.style.display = "none"; adminStatus.textContent = ""; return; }
+          adminActions.style.display = "block";
+          adminStatus.textContent = "Loading…";
+          fetch(statusUrl + "?staff_id=" + encodeURIComponent(staffId), { credentials: "same-origin" })
+            .then(function (r) { return r.json(); })
+            .then(function (d) {
+              if (d.connected) {
+                adminStatus.textContent = "Connected." +
+                  (d.last_sync_at ? " Last sync: " + d.last_sync_at : "") +
+                  (d.last_error ? " Last error: " + d.last_error : "");
+              } else {
+                adminStatus.textContent = "Not connected.";
+              }
+            })
+            .catch(function () { adminStatus.textContent = "Could not load status."; });
+        }
+
+        adminSelect.addEventListener("change", function () { refreshAdminStatus(adminSelect.value); });
+
+        document.getElementById("admin-connect").addEventListener("click", function () {
+          var staffId = adminSelect.value;
+          var url = adminUrlInput.value.trim();
+          if (!staffId || !url) { adminMsg.textContent = "Pick a provider and enter a URL."; adminMsg.className = "error"; return; }
+          submitJson(postUrl, { ics_url: url, staff_id: staffId }, this, function () {
+            adminMsg.textContent = "Connected."; adminMsg.className = "status";
+            adminUrlInput.value = ""; refreshAdminStatus(staffId);
+          });
+        });
+
+        document.getElementById("admin-disconnect").addEventListener("click", function () {
+          var staffId = adminSelect.value;
+          if (!staffId) { return; }
+          submitJson(deleteUrl, { staff_id: staffId }, this, function () {
+            adminMsg.textContent = "Disconnected."; adminMsg.className = "status";
+            refreshAdminStatus(staffId);
+          });
+        });
+      }
+```
+
+Note: `submitJson` disables the button it is passed and re-enables it on error;
+the admin buttons are passed as `this`, so they behave like the self-service
+button. Verify the inserted markup by eye: the `{% if is_admin %}` block wraps
+the whole admin section, `{% for option in staff_options %}` renders one
+`<option>` per provider, and no stored ICS URL is ever printed into the page.
+
+- [ ] **Step 3: Run the full plugin test suite (nothing should regress)**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS — template changes don't touch Python; all tests from Tasks 1–4
+and the pre-existing suite pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add external_calendar_busy_blocks/templates/config.html
+git commit -m "feat(external-calendar-busy-blocks): admin section in config page for managing provider feeds"
+```
+
+---
+
+### Task 6: Manifest, data access, README, version bump
+
+**Files:**
+- Modify: `external_calendar_busy_blocks/CANVAS_MANIFEST.json`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `ADMIN_STAFF_IDS` declared as a secret; `Staff` added to the `read` data-access of `FeedsAPI` and `ConfigPage`; README documents admin setup/usage; `plugin_version` bumped.
+
+- [ ] **Step 1: Update the manifest**
+
+In `external_calendar_busy_blocks/CANVAS_MANIFEST.json`:
+
+1. Bump `"plugin_version"` from `"0.2.0"` to `"0.3.0"`.
+2. In the `FeedsAPI` protocol entry, change its `data_access` to:
+
+```json
+                "data_access": {"event": "", "read": ["Staff"], "write": ["Event", "Calendar"]}
+```
+
+3. In the `ConfigPage` protocol entry, change its `data_access` to:
+
+```json
+                "data_access": {"event": "", "read": ["Staff"], "write": []}
+```
+
+4. Change the `secrets` array to:
+
+```json
+    "secrets": ["LOOKAHEAD_DAYS", "ADMIN_STAFF_IDS", "namespace_read_write_access_key"],
+```
+
+- [ ] **Step 2: Update the README**
+
+In `README.md`, add a row to the Configuration table:
+
+```markdown
+| `ADMIN_STAFF_IDS` | _(unset)_ | Comma-separated Canvas staff IDs allowed to manage other providers' feeds from the admin section. Unset means no one has admin access (the admin section is hidden). |
+```
+
+And add a subsection after "How it works":
+
+```markdown
+## Admin: connect feeds on behalf of providers
+
+Staff whose IDs are listed in the `ADMIN_STAFF_IDS` secret see an extra
+**Manage another provider** section when they open **Calendar Busy Blocks**.
+There they pick any active provider, see whether that provider already has a
+feed connected, and connect/replace or disconnect the provider's secret iCal
+URL — so providers never have to paste their own URL. Everyone else sees only
+their own self-service form; the admin section and its API are denied to
+non-admins (fail closed). Admin-connected feeds sync exactly like self-service
+feeds, and the stored URL is never shown back in the UI.
+```
+
+- [ ] **Step 3: Verify manifest is valid JSON and matches class paths**
+
+Run:
+```bash
+.venv/bin/python -c "import json; m=json.load(open('external_calendar_busy_blocks/CANVAS_MANIFEST.json')); print(m['plugin_version']); print(m['secrets'])"
+```
+Expected: prints `0.3.0` and a list containing `ADMIN_STAFF_IDS`.
+
+- [ ] **Step 4: Run the full suite once more**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (whole suite green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add external_calendar_busy_blocks/CANVAS_MANIFEST.json README.md
+git commit -m "docs(external-calendar-busy-blocks): declare ADMIN_STAFF_IDS and Staff read; document admin flow; bump to 0.3.0"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Authorization (`ADMIN_STAFF_IDS`, fail closed) → Task 1.
+- §2 UI admin section (server-rendered dropdown, admin-only) → Tasks 4 + 5.
+- §3 API target-staff dimension + `GET /feeds/status` → Tasks 2 + 3.
+- §4 Manifest & data access (secret, Staff reads) → Task 6.
+- §5 Error handling (non-admin ignored, unresolvable staff → 400, 403 on status) → Tasks 2 + 3.
+- §6 Testing + README + version bump → Tasks 1–4 (tests), Task 6 (README/version).
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. The only
+uncertainty (Task 3 Step 1 note) gives an exact fallback command rather than a
+vague instruction.
+
+**Type consistency:** `is_admin(staff_id, secrets)` signature identical across
+Tasks 1–4. `_resolve_target_staff_id(logged_in, body) -> str` used consistently
+in Task 2. Context keys `is_admin`/`staff_options`/`status_url` defined in Task 4
+and consumed in Task 5. Route name `feed_status` consistent between Task 3 impl
+and tests.

--- a/docs/superpowers/specs/2026-07-10-admin-manage-calendar-feeds-design.md
+++ b/docs/superpowers/specs/2026-07-10-admin-manage-calendar-feeds-design.md
@@ -1,0 +1,111 @@
+# Admin management of provider calendar feeds — Design
+
+**Plugin:** `extensions/external-calendar-busy-blocks`
+**Date:** 2026-07-10
+**Status:** Approved
+
+## Goal
+
+Let an authorized admin connect, view, and disconnect a personal calendar feed
+**on behalf of any active provider**, so providers don't have to paste their own
+secret iCal URL. The existing provider self-service flow is unchanged.
+
+## Background
+
+The plugin today:
+
+- Stores one feed per provider in the `StaffCalendarFeed` custom-data model,
+  keyed by `staff_id`.
+- Exposes `FeedsAPI` (`POST /feeds`, `POST /feeds/delete`) which always acts on
+  the **logged-in** staff, resolved from the `canvas-logged-in-user-id` session
+  header via `auth.canonical_staff_id`. A `staff_id` in the request body is
+  deliberately ignored today (session is authoritative).
+- Renders a self-service modal via `ConfigPage` (`GET /pages/config`) launched
+  from the global-scope `BusyBlocksApplication`.
+- Runs `SyncCron` every 15 minutes over all active feeds.
+
+## Design
+
+### 1. Authorization — `ADMIN_STAFF_IDS` secret (fail closed)
+
+- New plugin secret `ADMIN_STAFF_IDS`: a comma-separated list of staff UUIDs
+  (dashed or dashless accepted).
+- New helper `auth.is_admin(staff_id: str | None, secrets: Mapping) -> bool`:
+  parses the secret, canonicalizes each entry to dashless form (same
+  normalization as `canonical_staff_id`), and returns `True` only when the
+  caller's canonical id is in the set.
+- Unset / empty / whitespace-only secret → `False` (nobody is admin). This is
+  the fail-closed pattern required by `CLAUDE.md`; a missing secret denies
+  access, it never grants it.
+
+### 2. UI — one app, admin section (server-rendered)
+
+- `ConfigPage` output is unchanged for regular providers.
+- When the logged-in staff `is_admin`, the template additionally renders a
+  **"Manage another provider"** section below the self-service form:
+  - A `<select>` of **active staff**, server-rendered from
+    `Staff.objects.filter(active=True).order_by("last_name", "first_name")`;
+    `value` = staff id, label = `full_name`.
+  - A status line (populated on selection) plus Connect / Disconnect controls.
+- The template context gains `is_admin` and `staff_options`. Non-admins receive
+  neither, so the section is never rendered — defense in depth on top of the
+  API-level authorization check.
+
+### 3. API — `FeedsAPI` gains a target-staff dimension
+
+- `create_feed` / `delete_feed` read an optional `staff_id` from the JSON body.
+  - Target resolution: if `staff_id` is present **and** the caller `is_admin`,
+    the target is the canonicalized body `staff_id`; otherwise the target is the
+    logged-in staff. A non-admin's body `staff_id` is still ignored (preserves
+    today's property and backward compatibility; cannot escalate privilege).
+  - All existing validation (HTTPS, whitespace rejection, host allowlist,
+    `BEGIN:VCALENDAR` probe) and Admin-calendar provisioning run against the
+    **target** staff.
+- New route `GET /feeds/status?staff_id=<id>`: **admin-only** (`403` for
+  non-admins). Returns JSON `{connected, last_sync_at, last_error}` for the
+  selected provider so the dropdown can display live status. It never returns
+  the stored ICS URL — the URL is a bearer token and follows the same privacy
+  stance as the self-service page.
+
+### 4. Manifest & data access
+
+- Add `ADMIN_STAFF_IDS` to the manifest `secrets` array.
+- `FeedsAPI` `data_access.read` gains `"Staff"` (already used transitively by
+  `get_admin_calendar_id`).
+- `ConfigPage` `data_access.read` gains `"Staff"` (it now lists staff).
+- No data-model changes. `StaffCalendarFeed` is already keyed by `staff_id`, so
+  an admin-created feed is byte-identical to a self-created one and `SyncCron`
+  processes it with no changes.
+
+### 5. Error handling
+
+- Non-admin hitting an admin-only path or targeting another staff: act on self
+  (POST) or `403` (status endpoint). Never fail open.
+- Admin targeting a non-existent/inactive staff: `get_admin_calendar_id` returns
+  `("", [])` when the staff or name cannot be resolved. `create_feed` treats an
+  empty calendar id as a failure and returns a clear `400` rather than writing a
+  feed row with no calendar to land busy blocks on.
+- No broad `try/except` around handler logic. JSON parse failures keep the
+  existing `400`.
+
+### 6. Testing
+
+- `auth.is_admin`: unset / empty / whitespace → `False`; dashed and dashless
+  membership → `True`; non-member → `False`.
+- `FeedsAPI`:
+  - Admin connects for another staff → feed keyed to the target, target's Admin
+    calendar provisioned.
+  - Admin disconnects for another staff → target's imported events deleted.
+  - Non-admin's body `staff_id` is ignored (rewrite of the current
+    `test_post_ignores_staff_id_in_body`).
+  - `GET /feeds/status` returns data for an admin and `403` for a non-admin.
+- `ConfigPage`: admin render includes the staff dropdown; non-admin render omits
+  it.
+- Update `README.md` (new `ADMIN_STAFF_IDS` config row + admin usage notes) and
+  bump `plugin_version` in the manifest.
+
+## Out of scope (YAGNI)
+
+- Bulk connect for many providers in one action.
+- Editing the `ADMIN_STAFF_IDS` list from the UI.
+- An audit log of admin actions.

--- a/docs/superpowers/specs/2026-07-12-admin-staff-table-design.md
+++ b/docs/superpowers/specs/2026-07-12-admin-staff-table-design.md
@@ -1,0 +1,81 @@
+# Admin staff table (replace dropdown) — Design
+
+**Plugin:** `extensions/external-calendar-busy-blocks`
+**Date:** 2026-07-12
+**Status:** Approved
+
+## Goal
+
+Replace the admin section's single provider `<select>` + one connect form with a
+**table listing every active provider**, one row each, so an admin can attach,
+replace, or disconnect a calendar for any provider inline without selecting one
+at a time.
+
+## Motivation
+
+During testing, the dropdown forced connecting providers one at a time and made
+editing an already-selected provider awkward. A table gives a line-item view of
+all providers with per-row actions.
+
+## Design
+
+### Data — `ConfigPage` (server-rendered, one bulk query)
+
+For admins, enrich each active-staff row with its current feed status using a
+**single** `StaffCalendarFeed.objects.filter(staff_id__in=[...])` query (no
+per-row query — avoids N+1). Each `staff_options` entry becomes:
+
+```
+{"id": str, "name": str, "connected": bool,
+ "last_sync_at": str | None, "last_error": str | None}
+```
+
+`connected` is `True` only when a feed row exists and `is_active`. Nameless and
+inactive staff are still excluded (unchanged). Non-admins get `staff_options == []`.
+
+### Template — table
+
+Replace the `<select>` + `#admin-actions` block with a table: columns
+**Provider | Status | Secret iCal URL | Actions**. Each `<tr data-staff-id>` has:
+
+- Status cell rendered server-side ("Connected · last sync …" / "Not connected").
+- An **empty** `type="url"` input — the stored ICS URL is a bearer token and is
+  never returned to the browser; "Replace" means typing a new URL.
+- **Connect / Replace** and **Disconnect** buttons; Disconnect is `disabled` when
+  the row is not connected.
+
+Widen the page (`max-width`) and add minimal table styling.
+
+### Behavior — per-row JS (event delegation)
+
+One click listener on the table body dispatches by button class and `data-staff-id`:
+
+- **Connect / Replace** → `submitJson(post_url, {ics_url, staff_id})`.
+- **Disconnect** → `submitJson(delete_url, {staff_id})`.
+
+After either succeeds, that single row refreshes via the existing
+`GET /feeds/status?staff_id=` and updates its status cell + Disconnect enabled
+state. Reuses the existing `submitJson` helper; the self-service section and its
+MessagePort-safe in-place DOM update are untouched.
+
+### No API / data-model / manifest changes
+
+`POST /feeds`, `POST /feeds/delete`, and `GET /feeds/status` already accept a
+target `staff_id` (admin-gated) and already omit the ICS URL from responses. This
+change is confined to `ui/pages.py`, `templates/config.html`, and
+`tests/ui/test_pages.py`.
+
+## Testing
+
+- `test_pages`: admin `staff_options` carry `connected`/`last_sync_at`/
+  `last_error`; a provider with an active feed is `connected: True` with its sync
+  time; a provider without a feed is `connected: False`; nameless staff excluded;
+  the feed status is resolved with one bulk `staff_id__in` query (not per row);
+  non-admin still gets `[]`.
+- Template/JS verified by inspection (SDK forbids rendering templates outside
+  plugin context; repo has no JS tests) — consistent with prior tasks.
+
+## Out of scope (YAGNI)
+
+Pagination/search for very large staff lists (noted caveat); showing or masking
+the stored URL; bulk connect across rows.

--- a/extensions/external-calendar-busy-blocks/README.md
+++ b/extensions/external-calendar-busy-blocks/README.md
@@ -24,11 +24,23 @@ Each provider opens the **Calendar Busy Blocks** application from the Canvas glo
 
 Canvas users see only "Busy" — the original event titles never leave the personal calendar.
 
+## Admin: connect feeds on behalf of providers
+
+Staff whose IDs are listed in the `ADMIN_STAFF_IDS` secret see an extra
+**Manage another provider** section when they open **Calendar Busy Blocks**.
+There they pick any active provider, see whether that provider already has a
+feed connected, and connect/replace or disconnect the provider's secret iCal
+URL — so providers never have to paste their own URL. Everyone else sees only
+their own self-service form; the admin section and its API are denied to
+non-admins (fail closed). Admin-connected feeds sync exactly like self-service
+feeds, and the stored URL is never shown back in the UI.
+
 ## Configuration
 
 | Plugin secret | Default | Notes |
 |---|---|---|
 | `LOOKAHEAD_DAYS` | `90` | How far in advance to expand recurring events. |
+| `ADMIN_STAFF_IDS` | _(unset)_ | Comma-separated Canvas staff IDs allowed to manage other providers' feeds from the admin section. Unset means no one has admin access (the admin section is hidden). |
 
 ## Privacy & security
 

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.3.1",
+    "plugin_version": "0.3.2",
     "name": "external_calendar_busy_blocks",
     "description": "Subscribe Canvas to a provider's personal calendar via ICS and mirror busy times as Admin events.",
     "components": {

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.2.0",
+    "plugin_version": "0.3.0",
     "name": "external_calendar_busy_blocks",
     "description": "Subscribe Canvas to a provider's personal calendar via ICS and mirror busy times as Admin events.",
     "components": {
@@ -8,12 +8,12 @@
             {
                 "class": "external_calendar_busy_blocks.routes.feeds:FeedsAPI",
                 "description": "POST /feeds to connect; POST /feeds/delete to disconnect.",
-                "data_access": {"event": "", "read": [], "write": ["Event", "Calendar"]}
+                "data_access": {"event": "", "read": ["Staff"], "write": ["Event", "Calendar"]}
             },
             {
                 "class": "external_calendar_busy_blocks.ui.pages:ConfigPage",
                 "description": "GET /pages/config — renders the connect/disconnect HTML page.",
-                "data_access": {"event": "", "read": [], "write": []}
+                "data_access": {"event": "", "read": ["Staff"], "write": []}
             },
             {
                 "class": "external_calendar_busy_blocks.sync.cron:SyncCron",
@@ -35,7 +35,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["LOOKAHEAD_DAYS", "namespace_read_write_access_key"],
+    "secrets": ["LOOKAHEAD_DAYS", "ADMIN_STAFF_IDS", "namespace_read_write_access_key"],
     "tags": {},
     "references": [],
     "license": "MIT",

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.3.2",
+    "plugin_version": "0.3.3",
     "name": "external_calendar_busy_blocks",
     "description": "Subscribe Canvas to a provider's personal calendar via ICS and mirror busy times as Admin events.",
     "components": {

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.3.0",
+    "plugin_version": "0.3.1",
     "name": "external_calendar_busy_blocks",
     "description": "Subscribe Canvas to a provider's personal calendar via ICS and mirror busy times as Admin events.",
     "components": {

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/auth.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/auth.py
@@ -17,3 +17,25 @@ def canonical_staff_id(headers) -> str | None:
     if not raw:
         return None
     return raw.replace("-", "")
+
+
+def _canonical(raw: str) -> str:
+    """Dashless, lowercased form for case/format-insensitive UUID comparison."""
+    return raw.replace("-", "").strip().lower()
+
+
+def is_admin(staff_id, secrets) -> bool:
+    """Return True only if ``staff_id`` is listed in the ADMIN_STAFF_IDS secret.
+
+    Fails closed: an unset, empty, or whitespace-only secret means no one is an
+    admin. Both the caller id and each configured id are canonicalized to the
+    dashless, lowercased form so dashed/uppercase entries still match Staff.id
+    (uuid4().hex).
+    """
+    if not staff_id:
+        return False
+    raw = (secrets or {}).get("ADMIN_STAFF_IDS") or ""
+    admins = {_canonical(part) for part in raw.split(",") if part.strip()}
+    if not admins:
+        return False
+    return _canonical(staff_id) in admins

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/auth.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/auth.py
@@ -16,12 +16,18 @@ def canonical_staff_id(headers) -> str | None:
     raw = headers.get(_HEADER)
     if not raw:
         return None
-    return raw.replace("-", "")
+    return canonicalize_staff_id(raw)
 
 
-def _canonical(raw: str) -> str:
-    """Dashless, lowercased form for case/format-insensitive UUID comparison."""
-    return raw.replace("-", "").strip().lower()
+def canonicalize_staff_id(value: str) -> str:
+    """Dashless, stripped, lowercased form for case/format-insensitive UUID comparison.
+
+    Staff.id is stored as ``uuid4().hex`` (always lowercase, no dashes). Every
+    path that stores, compares, or looks up a staff id must route through this
+    single primitive so a mixed-case or dashed id never diverges from the
+    stored key.
+    """
+    return value.replace("-", "").strip().lower()
 
 
 def is_admin(staff_id, secrets) -> bool:
@@ -35,7 +41,7 @@ def is_admin(staff_id, secrets) -> bool:
     if not staff_id:
         return False
     raw = (secrets or {}).get("ADMIN_STAFF_IDS") or ""
-    admins = {_canonical(part) for part in raw.split(",") if part.strip()}
+    admins = {canonicalize_staff_id(part) for part in raw.split(",") if part.strip()}
     if not admins:
         return False
-    return _canonical(staff_id) in admins
+    return canonicalize_staff_id(staff_id) in admins

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
@@ -107,6 +107,31 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         feed.delete()
         return [*effects, JSONResponse({"status": "disconnected"}, status_code=200)]
 
+    @api.get("/feeds/status")
+    def feed_status(self) -> list[Response | Effect]:
+        staff_id = self._logged_in_staff_id()
+        if not staff_id:
+            return [JSONResponse({"error": "Not authenticated"}, status_code=401)]
+        if not is_admin(staff_id, self.secrets):
+            return [JSONResponse({"error": "Forbidden"}, status_code=403)]
+
+        target_id = (self.request.query_params.get("staff_id") or "").strip().replace("-", "")
+        if not target_id:
+            return [JSONResponse({"error": "Missing staff_id"}, status_code=400)]
+
+        feed = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
+        if feed is None:
+            return [JSONResponse({"connected": False}, status_code=200)]
+        # Never return ics_url — it is a bearer token.
+        return [JSONResponse(
+            {
+                "connected": bool(feed.is_active),
+                "last_sync_at": str(feed.last_sync_at) if feed.last_sync_at else None,
+                "last_error": feed.last_error,
+            },
+            status_code=200,
+        )]
+
     def _logged_in_staff_id(self) -> str | None:
         return canonical_staff_id(self.request.headers)
 

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
@@ -119,15 +119,21 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         if not target_id:
             return [JSONResponse({"error": "Missing staff_id"}, status_code=400)]
 
+        event_count = ImportedEvent.objects.filter(staff_id=target_id).count()
+
         feed = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
         if feed is None:
-            return [JSONResponse({"connected": False}, status_code=200)]
+            return [JSONResponse(
+                {"connected": False, "event_count": event_count},
+                status_code=200,
+            )]
         # Never return ics_url — it is a bearer token.
         return [JSONResponse(
             {
                 "connected": bool(feed.is_active),
                 "last_sync_at": str(feed.last_sync_at) if feed.last_sync_at else None,
                 "last_error": feed.last_error,
+                "event_count": event_count,
             },
             status_code=200,
         )]

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
@@ -6,7 +6,7 @@ from canvas_sdk.effects.calendar import Event
 from canvas_sdk.effects.simple_api import JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 
-from external_calendar_busy_blocks.auth import canonical_staff_id
+from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
 from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
 from external_calendar_busy_blocks.data.models import (
     ImportedEvent,
@@ -57,7 +57,19 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
                 status_code=400,
             )]
 
-        existing = StaffCalendarFeed.objects.filter(staff_id=staff_id).first()
+        target_id = self._resolve_target_staff_id(staff_id, body)
+
+        # Provision the target's Admin calendar first. An empty id means the
+        # staff (or their name) could not be resolved — fail before writing a
+        # feed row that would have no calendar to land busy blocks on.
+        cal_id, cal_effects = get_admin_calendar_id(target_id)
+        if not cal_id:
+            return [JSONResponse(
+                {"error": "Could not resolve the provider's calendar"},
+                status_code=400,
+            )]
+
+        existing = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
         if existing:
             existing.ics_url = url
             existing.is_active = True
@@ -66,11 +78,8 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
             existing.last_modified = None
             existing.save()
         else:
-            StaffCalendarFeed(staff_id=staff_id, ics_url=url, is_active=True).save()
+            StaffCalendarFeed(staff_id=target_id, ics_url=url, is_active=True).save()
 
-        # Provision the provider's Admin calendar so the busy blocks have a
-        # calendar to land on (find-or-create; empty effects if it exists).
-        _, cal_effects = get_admin_calendar_id(staff_id)
         return [*cal_effects, JSONResponse({"status": "connected"}, status_code=200)]
 
     @api.post("/feeds/delete")
@@ -79,12 +88,19 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         if not staff_id:
             return [JSONResponse({"error": "Not authenticated"}, status_code=401)]
 
-        feed = StaffCalendarFeed.objects.filter(staff_id=staff_id).first()
+        try:
+            body = json.loads(self.request.body or b"{}")
+        except json.JSONDecodeError:
+            return [JSONResponse({"error": "Invalid JSON"}, status_code=400)]
+
+        target_id = self._resolve_target_staff_id(staff_id, body)
+
+        feed = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
         if feed is None:
             return [JSONResponse({"status": "no feed"}, status_code=200)]
 
         effects: list[Effect] = []
-        for row in ImportedEvent.objects.filter(staff_id=staff_id):
+        for row in ImportedEvent.objects.filter(staff_id=target_id):
             effects.append(Event(event_id=row.canvas_event_id).delete())
             row.delete()
 
@@ -93,6 +109,20 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
 
     def _logged_in_staff_id(self) -> str | None:
         return canonical_staff_id(self.request.headers)
+
+    def _resolve_target_staff_id(self, logged_in: str, body: dict) -> str:
+        """Return the staff id to act on.
+
+        An admin may target another provider by sending ``staff_id`` in the
+        body; the id is canonicalized to the dashless form used for Staff.id.
+        For everyone else (and when no staff_id is sent), the logged-in staff is
+        authoritative — a non-admin's body staff_id is ignored, so it can never
+        escalate privilege.
+        """
+        requested = (body.get("staff_id") or "").strip()
+        if requested and is_admin(logged_in, self.secrets):
+            return requested.replace("-", "")
+        return logged_in
 
     _HTTPS_URL_REGEX = re.compile(r"^https://[^/?#\s]+", re.IGNORECASE)
 

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
@@ -6,7 +6,7 @@ from canvas_sdk.effects.calendar import Event
 from canvas_sdk.effects.simple_api import JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 
-from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
+from external_calendar_busy_blocks.auth import canonical_staff_id, canonicalize_staff_id, is_admin
 from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
 from external_calendar_busy_blocks.data.models import (
     ImportedEvent,
@@ -115,7 +115,7 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         if not is_admin(staff_id, self.secrets):
             return [JSONResponse({"error": "Forbidden"}, status_code=403)]
 
-        target_id = (self.request.query_params.get("staff_id") or "").strip().replace("-", "")
+        target_id = canonicalize_staff_id(self.request.query_params.get("staff_id") or "")
         if not target_id:
             return [JSONResponse({"error": "Missing staff_id"}, status_code=400)]
 
@@ -146,7 +146,7 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         """
         requested = (body.get("staff_id") or "").strip()
         if requested and is_admin(logged_in, self.secrets):
-            return requested.replace("-", "")
+            return canonicalize_staff_id(requested)
         return logged_in
 
     _HTTPS_URL_REGEX = re.compile(r"^https://[^/?#\s]+", re.IGNORECASE)

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
@@ -45,8 +45,8 @@
   {% if is_admin %}
   <hr style="margin:24px 0;" />
   <div id="admin-content">
-    <h2>Manage providers</h2>
-    <p>Connect or disconnect a personal calendar on behalf of any provider — they never have to paste their own URL. Each provider's secret URL is stored privately and is never shown here; to change one, enter a new URL and click Connect / Replace.</p>
+    <h2>Manage staff</h2>
+    <p>Connect or disconnect a personal calendar on behalf of any staff member — they never have to paste their own URL. Each staff member's secret URL is stored privately and is never shown here; to change one, enter a new URL and click Connect / Replace.</p>
     <table id="admin-table">
       <thead>
         <tr>

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Calendar Busy Blocks</title>
   <style>
-    body { font-family: system-ui, sans-serif; padding: 24px; max-width: 600px; }
+    body { font-family: system-ui, sans-serif; padding: 24px; max-width: 860px; }
     label { display: block; margin: 12px 0 4px; font-weight: 600; }
     input[type="url"] { width: 100%; padding: 8px; font-size: 14px; box-sizing: border-box; }
     button { padding: 8px 16px; font-size: 14px; cursor: pointer; margin-top: 12px; }
@@ -12,6 +12,15 @@
     .error { color: #b00; }
     .status { color: #060; }
     #msg { margin-top: 12px; }
+    table#admin-table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+    table#admin-table th, table#admin-table td {
+      text-align: left; padding: 8px; border-bottom: 1px solid #ddd; vertical-align: top; font-size: 14px;
+    }
+    table#admin-table th { font-weight: 600; }
+    table#admin-table input[type="url"] { min-width: 240px; margin: 0; }
+    table#admin-table button { margin-top: 0; margin-right: 6px; }
+    td.admin-status { white-space: nowrap; }
+    td.admin-status.is-connected { color: #060; }
   </style>
 </head>
 <body>
@@ -36,22 +45,31 @@
   {% if is_admin %}
   <hr style="margin:24px 0;" />
   <div id="admin-content">
-    <h2>Manage another provider</h2>
-    <p>Connect or disconnect a personal calendar on behalf of a provider. The provider never has to paste their own URL.</p>
-    <label for="admin_staff">Provider</label>
-    <select id="admin_staff">
-      <option value="">— Select a provider —</option>
-      {% for option in staff_options %}
-      <option value="{{ option.id }}">{{ option.name }}</option>
-      {% endfor %}
-    </select>
-    <p id="admin-status"></p>
-    <div id="admin-actions" style="display:none;">
-      <label for="admin_ics_url">Secret iCal URL</label>
-      <input type="url" id="admin_ics_url" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics" />
-      <button type="button" id="admin-connect">Connect / Replace</button>
-      <button type="button" id="admin-disconnect">Disconnect</button>
-    </div>
+    <h2>Manage providers</h2>
+    <p>Connect or disconnect a personal calendar on behalf of any provider — they never have to paste their own URL. Each provider's secret URL is stored privately and is never shown here; to change one, enter a new URL and click Connect / Replace.</p>
+    <table id="admin-table">
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Status</th>
+          <th>Secret iCal URL</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for option in staff_options %}
+        <tr data-staff-id="{{ option.id }}">
+          <td>{{ option.name }}</td>
+          <td class="admin-status{% if option.connected %} is-connected{% endif %}">{% if option.connected %}Connected{% if option.last_sync_at %} · last sync {{ option.last_sync_at }}{% endif %}{% if option.last_error %} · error: {{ option.last_error }}{% endif %}{% else %}Not connected{% endif %}</td>
+          <td><input type="url" class="admin-url" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics" /></td>
+          <td>
+            <button type="button" class="admin-connect">Connect / Replace</button>
+            <button type="button" class="admin-disconnect"{% if not option.connected %} disabled{% endif %}>Disconnect</button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
     <p id="admin-msg"></p>
   </div>
   {% endif %}
@@ -139,51 +157,63 @@
       }
 
       var statusUrl = "{{ status_url }}";
-      var adminSelect = document.getElementById("admin_staff");
-      if (adminSelect) {
-        var adminActions = document.getElementById("admin-actions");
-        var adminStatus = document.getElementById("admin-status");
+      var adminTable = document.getElementById("admin-table");
+      if (adminTable) {
         var adminMsg = document.getElementById("admin-msg");
-        var adminUrlInput = document.getElementById("admin_ics_url");
 
-        function refreshAdminStatus(staffId) {
-          adminMsg.textContent = "";
-          if (!staffId) { adminActions.style.display = "none"; adminStatus.textContent = ""; return; }
-          adminActions.style.display = "block";
-          adminStatus.textContent = "Loading…";
-          fetch(statusUrl + "?staff_id=" + encodeURIComponent(staffId), { credentials: "same-origin" })
-            .then(function (r) { return r.json(); })
-            .then(function (d) {
-              if (d.connected) {
-                adminStatus.textContent = "Connected." +
-                  (d.last_sync_at ? " Last sync: " + d.last_sync_at : "") +
-                  (d.last_error ? " Last error: " + d.last_error : "");
-              } else {
-                adminStatus.textContent = "Not connected.";
-              }
-            })
-            .catch(function () { adminStatus.textContent = "Could not load status."; });
+        function providerName(row) { return row.cells[0].textContent; }
+
+        // Update one row's status cell + Disconnect button from a status payload.
+        function setRowStatus(row, d) {
+          var cell = row.querySelector(".admin-status");
+          var disconnectBtn = row.querySelector(".admin-disconnect");
+          if (d && d.connected) {
+            cell.textContent = "Connected" +
+              (d.last_sync_at ? " · last sync " + d.last_sync_at : "") +
+              (d.last_error ? " · error: " + d.last_error : "");
+            cell.className = "admin-status is-connected";
+            disconnectBtn.disabled = false;
+          } else {
+            cell.textContent = "Not connected";
+            cell.className = "admin-status";
+            disconnectBtn.disabled = true;
+          }
         }
 
-        adminSelect.addEventListener("change", function () { refreshAdminStatus(adminSelect.value); });
+        function refreshRow(row) {
+          var staffId = row.getAttribute("data-staff-id");
+          fetch(statusUrl + "?staff_id=" + encodeURIComponent(staffId), { credentials: "same-origin" })
+            .then(function (r) { return r.json(); })
+            .then(function (d) { setRowStatus(row, d); })
+            .catch(function () { /* leave the server-rendered status in place */ });
+        }
 
-        document.getElementById("admin-connect").addEventListener("click", function () {
-          var staffId = adminSelect.value;
-          var url = adminUrlInput.value.trim();
-          if (!staffId || !url) { adminMsg.textContent = "Pick a provider and enter a URL."; adminMsg.className = "error"; return; }
-          submitJson(postUrl, { ics_url: url, staff_id: staffId }, this, function () {
-            adminMsg.textContent = "Connected."; adminMsg.className = "status";
-            adminUrlInput.value = ""; refreshAdminStatus(staffId);
-          });
-        });
+        // One delegated listener handles every row's buttons.
+        adminTable.addEventListener("click", function (e) {
+          var btn = e.target;
+          if (!btn.classList || !(btn.classList.contains("admin-connect") || btn.classList.contains("admin-disconnect"))) return;
+          var row = btn.closest("tr");
+          var staffId = row.getAttribute("data-staff-id");
+          adminMsg.textContent = ""; adminMsg.className = "";
 
-        document.getElementById("admin-disconnect").addEventListener("click", function () {
-          var staffId = adminSelect.value;
-          if (!staffId) { return; }
-          submitJson(deleteUrl, { staff_id: staffId }, this, function () {
-            adminMsg.textContent = "Disconnected."; adminMsg.className = "status";
-            refreshAdminStatus(staffId);
-          });
+          if (btn.classList.contains("admin-connect")) {
+            var input = row.querySelector(".admin-url");
+            var url = input.value.trim();
+            if (!url) {
+              adminMsg.textContent = "Enter a URL for " + providerName(row) + ".";
+              adminMsg.className = "error";
+              return;
+            }
+            submitJson(postUrl, { ics_url: url, staff_id: staffId }, btn, function () {
+              adminMsg.textContent = "Connected " + providerName(row) + "."; adminMsg.className = "status";
+              input.value = ""; btn.disabled = false; refreshRow(row);
+            });
+          } else {
+            submitJson(deleteUrl, { staff_id: staffId }, btn, function () {
+              adminMsg.textContent = "Disconnected " + providerName(row) + "."; adminMsg.className = "status";
+              btn.disabled = false; refreshRow(row);
+            });
+          }
         });
       }
 

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
@@ -52,6 +52,7 @@
         <tr>
           <th>Provider</th>
           <th>Status</th>
+          <th>Events</th>
           <th>Secret iCal URL</th>
           <th>Actions</th>
         </tr>
@@ -61,6 +62,7 @@
         <tr data-staff-id="{{ option.id }}">
           <td>{{ option.name }}</td>
           <td class="admin-status{% if option.connected %} is-connected{% endif %}">{% if option.connected %}Connected{% if option.last_sync_at %} · last sync {{ option.last_sync_at }}{% endif %}{% if option.last_error %} · error: {{ option.last_error }}{% endif %}{% else %}Not connected{% endif %}</td>
+          <td class="admin-events">{{ option.event_count }}</td>
           <td><input type="url" class="admin-url" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics" /></td>
           <td>
             <button type="button" class="admin-connect">Connect / Replace</button>
@@ -166,7 +168,11 @@
         // Update one row's status cell + Disconnect button from a status payload.
         function setRowStatus(row, d) {
           var cell = row.querySelector(".admin-status");
+          var eventsCell = row.querySelector(".admin-events");
           var disconnectBtn = row.querySelector(".admin-disconnect");
+          if (eventsCell && d && typeof d.event_count === "number") {
+            eventsCell.textContent = d.event_count;
+          }
           if (d && d.connected) {
             cell.textContent = "Connected" +
               (d.last_sync_at ? " · last sync " + d.last_sync_at : "") +

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/templates/config.html
@@ -33,6 +33,28 @@
       </form>
     {% endif %}
   </div>
+  {% if is_admin %}
+  <hr style="margin:24px 0;" />
+  <div id="admin-content">
+    <h2>Manage another provider</h2>
+    <p>Connect or disconnect a personal calendar on behalf of a provider. The provider never has to paste their own URL.</p>
+    <label for="admin_staff">Provider</label>
+    <select id="admin_staff">
+      <option value="">— Select a provider —</option>
+      {% for option in staff_options %}
+      <option value="{{ option.id }}">{{ option.name }}</option>
+      {% endfor %}
+    </select>
+    <p id="admin-status"></p>
+    <div id="admin-actions" style="display:none;">
+      <label for="admin_ics_url">Secret iCal URL</label>
+      <input type="url" id="admin_ics_url" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics" />
+      <button type="button" id="admin-connect">Connect / Replace</button>
+      <button type="button" id="admin-disconnect">Disconnect</button>
+    </div>
+    <p id="admin-msg"></p>
+  </div>
+  {% endif %}
   <p id="msg"></p>
 
   <script>
@@ -113,6 +135,55 @@
         form.addEventListener("submit", function (e) {
           e.preventDefault();
           submitJson(deleteUrl, {}, form.querySelector("button"), renderConnectForm);
+        });
+      }
+
+      var statusUrl = "{{ status_url }}";
+      var adminSelect = document.getElementById("admin_staff");
+      if (adminSelect) {
+        var adminActions = document.getElementById("admin-actions");
+        var adminStatus = document.getElementById("admin-status");
+        var adminMsg = document.getElementById("admin-msg");
+        var adminUrlInput = document.getElementById("admin_ics_url");
+
+        function refreshAdminStatus(staffId) {
+          adminMsg.textContent = "";
+          if (!staffId) { adminActions.style.display = "none"; adminStatus.textContent = ""; return; }
+          adminActions.style.display = "block";
+          adminStatus.textContent = "Loading…";
+          fetch(statusUrl + "?staff_id=" + encodeURIComponent(staffId), { credentials: "same-origin" })
+            .then(function (r) { return r.json(); })
+            .then(function (d) {
+              if (d.connected) {
+                adminStatus.textContent = "Connected." +
+                  (d.last_sync_at ? " Last sync: " + d.last_sync_at : "") +
+                  (d.last_error ? " Last error: " + d.last_error : "");
+              } else {
+                adminStatus.textContent = "Not connected.";
+              }
+            })
+            .catch(function () { adminStatus.textContent = "Could not load status."; });
+        }
+
+        adminSelect.addEventListener("change", function () { refreshAdminStatus(adminSelect.value); });
+
+        document.getElementById("admin-connect").addEventListener("click", function () {
+          var staffId = adminSelect.value;
+          var url = adminUrlInput.value.trim();
+          if (!staffId || !url) { adminMsg.textContent = "Pick a provider and enter a URL."; adminMsg.className = "error"; return; }
+          submitJson(postUrl, { ics_url: url, staff_id: staffId }, this, function () {
+            adminMsg.textContent = "Connected."; adminMsg.className = "status";
+            adminUrlInput.value = ""; refreshAdminStatus(staffId);
+          });
+        });
+
+        document.getElementById("admin-disconnect").addEventListener("click", function () {
+          var staffId = adminSelect.value;
+          if (!staffId) { return; }
+          submitJson(deleteUrl, { staff_id: staffId }, this, function () {
+            adminMsg.textContent = "Disconnected."; adminMsg.className = "status";
+            refreshAdminStatus(staffId);
+          });
         });
       }
 

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
@@ -20,11 +20,29 @@ class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
         admin = is_admin(staff_id, self.secrets)
         staff_options: list[dict] = []
         if admin:
-            staff_options = [
-                {"id": s.id, "name": s.full_name}
+            active_staff = [
+                s
                 for s in Staff.objects.filter(active=True).order_by("last_name", "first_name")
                 if (s.full_name or "").strip()
             ]
+            # One bulk query for every provider's current feed (no per-row query).
+            feeds_by_staff = {
+                f.staff_id: f
+                for f in StaffCalendarFeed.objects.filter(
+                    staff_id__in=[s.id for s in active_staff]
+                )
+            }
+            for s in active_staff:
+                f = feeds_by_staff.get(s.id)
+                staff_options.append(
+                    {
+                        "id": s.id,
+                        "name": s.full_name,
+                        "connected": bool(f and f.is_active),
+                        "last_sync_at": str(f.last_sync_at) if f and f.last_sync_at else None,
+                        "last_error": f.last_error if f else None,
+                    }
+                )
 
         html = render_to_string(
             "templates/config.html",

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
@@ -23,6 +23,7 @@ class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
             staff_options = [
                 {"id": s.id, "name": s.full_name}
                 for s in Staff.objects.filter(active=True).order_by("last_name", "first_name")
+                if (s.full_name or "").strip()
             ]
 
         html = render_to_string(

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
@@ -3,8 +3,9 @@ from http import HTTPStatus
 from canvas_sdk.effects.simple_api import HTMLResponse, PlainTextResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 from canvas_sdk.templates import render_to_string
+from canvas_sdk.v1.data.staff import Staff
 
-from external_calendar_busy_blocks.auth import canonical_staff_id
+from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
 from external_calendar_busy_blocks.data.models import StaffCalendarFeed
 
 
@@ -15,13 +16,25 @@ class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
     def render(self) -> list[Response]:
         staff_id = canonical_staff_id(self.request.headers)
         feed = StaffCalendarFeed.objects.filter(staff_id=staff_id).first() if staff_id else None
+
+        admin = is_admin(staff_id, self.secrets)
+        staff_options: list[dict] = []
+        if admin:
+            staff_options = [
+                {"id": s.id, "name": s.full_name}
+                for s in Staff.objects.filter(active=True).order_by("last_name", "first_name")
+            ]
+
         html = render_to_string(
             "templates/config.html",
             {
                 "feed": feed,
                 "connected": feed is not None and feed.is_active,
+                "is_admin": admin,
+                "staff_options": staff_options,
                 "post_url": "/plugin-io/api/external_calendar_busy_blocks/feeds",
                 "delete_url": "/plugin-io/api/external_calendar_busy_blocks/feeds/delete",
+                "status_url": "/plugin-io/api/external_calendar_busy_blocks/feeds/status",
             },
         )
         # render_to_string is typed `str | None`. The current SDK raises

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
@@ -6,7 +6,7 @@ from canvas_sdk.templates import render_to_string
 from canvas_sdk.v1.data.staff import Staff
 
 from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
-from external_calendar_busy_blocks.data.models import StaffCalendarFeed
+from external_calendar_busy_blocks.data.models import ImportedEvent, StaffCalendarFeed
 
 
 class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
@@ -25,13 +25,19 @@ class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
                 for s in Staff.objects.filter(active=True).order_by("last_name", "first_name")
                 if (s.full_name or "").strip()
             ]
+            staff_ids = [s.id for s in active_staff]
             # One bulk query for every provider's current feed (no per-row query).
             feeds_by_staff = {
                 f.staff_id: f
-                for f in StaffCalendarFeed.objects.filter(
-                    staff_id__in=[s.id for s in active_staff]
-                )
+                for f in StaffCalendarFeed.objects.filter(staff_id__in=staff_ids)
             }
+            # One bulk query for imported-event counts per provider. values_list
+            # avoids pulling full rows; tally in Python (no Count/Counter import).
+            event_counts: dict[str, int] = {}
+            for sid in ImportedEvent.objects.filter(staff_id__in=staff_ids).values_list(
+                "staff_id", flat=True
+            ):
+                event_counts[sid] = event_counts.get(sid, 0) + 1
             for s in active_staff:
                 f = feeds_by_staff.get(s.id)
                 staff_options.append(
@@ -41,6 +47,7 @@ class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
                         "connected": bool(f and f.is_active),
                         "last_sync_at": str(f.last_sync_at) if f and f.last_sync_at else None,
                         "last_error": f.last_error if f else None,
+                        "event_count": event_counts.get(s.id, 0),
                     }
                 )
 

--- a/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
+++ b/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
@@ -426,8 +426,12 @@ def test_status_requires_staff_id() -> None:
 
 def test_status_reports_connected_feed_without_url() -> None:
     feed = MagicMock(is_active=True, last_sync_at="2026-07-11T00:00:00Z", last_error=None)
-    with patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed:
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+    ):
         MockFeed.objects.filter.return_value.first.return_value = feed
+        MockImported.objects.filter.return_value.count.return_value = 5
         api = _api_with_request(
             "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
             secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
@@ -437,14 +441,20 @@ def test_status_reports_connected_feed_without_url() -> None:
     assert responses[0].status_code == 200
     body = json.loads(responses[0].content)
     assert body["connected"] is True
+    assert body["event_count"] == 5
     assert "ics_url" not in body
-    # Lookup was scoped to the canonicalized target id.
+    # Both the feed lookup and the event count were scoped to the canonical id.
     assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert MockImported.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
 
 
 def test_status_reports_no_feed() -> None:
-    with patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed:
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+    ):
         MockFeed.objects.filter.return_value.first.return_value = None
+        MockImported.objects.filter.return_value.count.return_value = 0
         api = _api_with_request(
             "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
             secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
@@ -453,3 +463,4 @@ def test_status_reports_no_feed() -> None:
         responses = api.feed_status()
     body = json.loads(responses[0].content)
     assert body["connected"] is False
+    assert body["event_count"] == 0

--- a/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
+++ b/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
@@ -146,6 +146,29 @@ def test_post_admin_targets_other_staff() -> None:
     assert mock_get_cal.call_args.args[0] == "00000000000000000000000000000099"
 
 
+def test_post_admin_targets_other_staff_uppercase_dashed_id() -> None:
+    """An admin's UPPERCASE dashed body staff_id is canonicalized to the
+    dashless LOWERCASE form that matches Staff.id (uuid4().hex)."""
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])),
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics",'
+            b'"staff_id":"0000000000000000000000000000AABB"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        api.create_feed()
+    assert MockFeed.call_args.kwargs["staff_id"] == "0000000000000000000000000000aabb"
+
+
 def test_post_admin_returns_400_when_calendar_unresolvable() -> None:
     """If the target staff can't be resolved, no feed is written and we 400."""
     with (
@@ -186,6 +209,28 @@ def test_delete_admin_targets_other_staff() -> None:
         responses = api.delete_feed()
     # Feed and imported-event lookups were scoped to the target staff id.
     assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert responses[-1].status_code == 200
+    feed.delete.assert_called_once()
+
+
+def test_delete_non_admin_ignores_staff_id() -> None:
+    """A non-admin's body staff_id is ignored; the delete acts on self."""
+    feed = MagicMock(staff_id="00000000000000000000000000000002")
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = feed
+        MockImported.objects.filter.return_value = []
+        api = _api_with_request(
+            "POST",
+            b'{"staff_id":"00000000000000000000000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000002",
+            secrets={},  # not an admin
+        )
+        responses = api.delete_feed()
+    # Lookup was scoped to the canonicalized SESSION id, not the body id.
+    assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000002"
     assert responses[-1].status_code == 200
     feed.delete.assert_called_once()
 

--- a/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
+++ b/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
@@ -6,7 +6,13 @@ import pytest
 from external_calendar_busy_blocks.routes.feeds import FeedsAPI
 
 
-def _api_with_request(method: str, body: bytes, logged_in_staff: str | None) -> FeedsAPI:
+def _api_with_request(
+    method: str,
+    body: bytes,
+    logged_in_staff: str | None,
+    secrets: dict | None = None,
+    query_params: dict | None = None,
+) -> FeedsAPI:
     headers = {}
     if logged_in_staff:
         headers["canvas-logged-in-user-id"] = logged_in_staff
@@ -15,10 +21,11 @@ def _api_with_request(method: str, body: bytes, logged_in_staff: str | None) -> 
         body=body,
         headers=headers,
         path_params={},
+        query_params=query_params or {},
     )
     api = FeedsAPI.__new__(FeedsAPI)
     api.request = request
-    api.secrets = {}
+    api.secrets = secrets or {}
     return api
 
 
@@ -94,8 +101,8 @@ def test_post_creates_feed_when_valid() -> None:
     assert kwargs["ics_url"] == "https://calendar.google.com/calendar/ical/me/basic.ics"
 
 
-def test_post_ignores_staff_id_in_body() -> None:
-    """Even if the body claims a different staff_id, the session is authoritative."""
+def test_post_non_admin_ignores_staff_id_in_body() -> None:
+    """A non-admin's body staff_id is ignored; the session stays authoritative."""
     with (
         patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
@@ -108,12 +115,79 @@ def test_post_ignores_staff_id_in_body() -> None:
         api = _api_with_request(
             "POST",
             b'{"ics_url":"https://outlook.office365.com/owa/calendar/x/calendar.ics",'
-            b'"staff_id":"impersonated"}',
+            b'"staff_id":"00000000000000000000000000000099"}',
             logged_in_staff="00000000-0000-0000-0000-000000000002",
+            secrets={},  # not an admin
         )
         api.create_feed()
-    # Session header wins (canonicalized), body staff_id ignored.
     assert MockFeed.call_args.kwargs["staff_id"] == "00000000000000000000000000000002"
+
+
+def test_post_admin_targets_other_staff() -> None:
+    """An admin's body staff_id is honored: the feed is keyed to the target."""
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("cal-1", [])) as mock_get_cal,
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics",'
+            b'"staff_id":"00000000-0000-0000-0000-000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        api.create_feed()
+    assert MockFeed.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert mock_get_cal.call_args.args[0] == "00000000000000000000000000000099"
+
+
+def test_post_admin_returns_400_when_calendar_unresolvable() -> None:
+    """If the target staff can't be resolved, no feed is written and we 400."""
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.fetch_feed") as mock_fetch,
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.get_admin_calendar_id",
+              return_value=("", [])),
+    ):
+        from external_calendar_busy_blocks.http.fetcher import FetchOk
+        mock_fetch.return_value = FetchOk(b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", None, None)
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "POST",
+            b'{"ics_url":"https://calendar.google.com/calendar/ical/me/basic.ics",'
+            b'"staff_id":"00000000000000000000000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        responses = api.create_feed()
+    assert responses[0].status_code == 400
+    MockFeed.assert_not_called()
+
+
+def test_delete_admin_targets_other_staff() -> None:
+    feed = MagicMock(staff_id="00000000000000000000000000000099")
+    with (
+        patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = feed
+        MockImported.objects.filter.return_value = []
+        api = _api_with_request(
+            "POST",
+            b'{"staff_id":"00000000-0000-0000-0000-000000000099"}',
+            logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        )
+        responses = api.delete_feed()
+    # Feed and imported-event lookups were scoped to the target staff id.
+    assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert responses[-1].status_code == 200
+    feed.delete.assert_called_once()
 
 
 def test_delete_idempotent_when_no_feed() -> None:

--- a/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
+++ b/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
@@ -357,3 +357,54 @@ def test_connect_no_calendar_effect_when_exists() -> None:
     effects_emitted = [r for r in responses if hasattr(r, "type")]
     assert effects_emitted == []
     assert responses[0].status_code == 200
+
+
+def test_status_requires_admin() -> None:
+    api = _api_with_request(
+        "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000002",
+        secrets={},  # not an admin
+        query_params={"staff_id": "00000000000000000000000000000099"},
+    )
+    responses = api.feed_status()
+    assert responses[0].status_code == 403
+
+
+def test_status_requires_staff_id() -> None:
+    api = _api_with_request(
+        "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
+        secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        query_params={},
+    )
+    responses = api.feed_status()
+    assert responses[0].status_code == 400
+
+
+def test_status_reports_connected_feed_without_url() -> None:
+    feed = MagicMock(is_active=True, last_sync_at="2026-07-11T00:00:00Z", last_error=None)
+    with patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed:
+        MockFeed.objects.filter.return_value.first.return_value = feed
+        api = _api_with_request(
+            "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+            query_params={"staff_id": "00000000-0000-0000-0000-000000000099"},
+        )
+        responses = api.feed_status()
+    assert responses[0].status_code == 200
+    body = json.loads(responses[0].content)
+    assert body["connected"] is True
+    assert "ics_url" not in body
+    # Lookup was scoped to the canonicalized target id.
+    assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+
+
+def test_status_reports_no_feed() -> None:
+    with patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed:
+        MockFeed.objects.filter.return_value.first.return_value = None
+        api = _api_with_request(
+            "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+            query_params={"staff_id": "00000000000000000000000000000099"},
+        )
+        responses = api.feed_status()
+    body = json.loads(responses[0].content)
+    assert body["connected"] is False

--- a/extensions/external-calendar-busy-blocks/tests/test_auth.py
+++ b/extensions/external-calendar-busy-blocks/tests/test_auth.py
@@ -1,4 +1,4 @@
-from external_calendar_busy_blocks.auth import canonical_staff_id
+from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
 
 
 def test_canonicalizes_dashed_uuid_to_hex() -> None:
@@ -17,3 +17,31 @@ def test_returns_none_when_header_absent() -> None:
 
 def test_returns_none_when_header_empty() -> None:
     assert canonical_staff_id({"canvas-logged-in-user-id": ""}) is None
+
+
+def test_is_admin_false_when_secret_unset() -> None:
+    assert is_admin("00000000000000000000000000000001", {}) is False
+
+
+def test_is_admin_false_when_secret_blank() -> None:
+    assert is_admin("00000000000000000000000000000001", {"ADMIN_STAFF_IDS": "   "}) is False
+
+
+def test_is_admin_false_when_staff_id_none() -> None:
+    assert is_admin(None, {"ADMIN_STAFF_IDS": "00000000000000000000000000000001"}) is False
+
+
+def test_is_admin_true_for_member_dashless() -> None:
+    secrets = {"ADMIN_STAFF_IDS": "00000000000000000000000000000001,0000000000000000000000000000ffff"}
+    assert is_admin("0000000000000000000000000000ffff", secrets) is True
+
+
+def test_is_admin_matches_regardless_of_dashes_and_case() -> None:
+    # Secret entered with dashes and uppercase; caller id is dashless lowercase.
+    secrets = {"ADMIN_STAFF_IDS": "00000000-0000-0000-0000-0000000000AB"}
+    assert is_admin("000000000000000000000000000000ab", secrets) is True
+
+
+def test_is_admin_false_for_non_member() -> None:
+    secrets = {"ADMIN_STAFF_IDS": "00000000000000000000000000000001"}
+    assert is_admin("00000000000000000000000000000002", secrets) is False

--- a/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
+++ b/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
@@ -29,13 +29,14 @@ def test_render_non_admin_has_no_staff_options() -> None:
 def test_render_admin_lists_active_staff() -> None:
     staff_a = MagicMock(id="00000000000000000000000000000010", full_name="Bea Adams")
     staff_b = MagicMock(id="00000000000000000000000000000011", full_name="Cy Brown")
+    staff_nameless = MagicMock(id="00000000000000000000000000000012", full_name="")
     with (
         patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
         patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
         patch("external_calendar_busy_blocks.ui.pages.Staff") as MockStaff,
     ):
         MockFeed.objects.filter.return_value.first.return_value = None
-        MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b]
+        MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b, staff_nameless]
         _page(
             "00000000-0000-0000-0000-000000000001",
             secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
@@ -46,4 +47,5 @@ def test_render_admin_lists_active_staff() -> None:
         {"id": "00000000000000000000000000000010", "name": "Bea Adams"},
         {"id": "00000000000000000000000000000011", "name": "Cy Brown"},
     ]
+    assert all(opt["id"] != "00000000000000000000000000000012" for opt in context["staff_options"])
     MockStaff.objects.filter.assert_called_once_with(active=True)

--- a/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
+++ b/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
@@ -52,12 +52,17 @@ def test_render_admin_lists_active_staff_with_per_row_status() -> None:
         self_lookup.first.return_value = None
         return self_lookup
 
+    # Bea has 7 imported events; Cy has none. Returned as values_list rows.
+    imported_staff_ids = ["00000000000000000000000000000010"] * 7
+
     with (
         patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
         patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.ui.pages.ImportedEvent") as MockImported,
         patch("external_calendar_busy_blocks.ui.pages.Staff") as MockStaff,
     ):
         MockFeed.objects.filter.side_effect = filter_side_effect
+        MockImported.objects.filter.return_value.values_list.return_value = imported_staff_ids
         MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b, staff_nameless]
         _page(
             "00000000-0000-0000-0000-000000000001",
@@ -72,6 +77,7 @@ def test_render_admin_lists_active_staff_with_per_row_status() -> None:
             "connected": True,
             "last_sync_at": "2026-07-12T10:00:00Z",
             "last_error": None,
+            "event_count": 7,
         },
         {
             "id": "00000000000000000000000000000011",
@@ -79,10 +85,15 @@ def test_render_admin_lists_active_staff_with_per_row_status() -> None:
             "connected": False,
             "last_sync_at": None,
             "last_error": None,
+            "event_count": 0,
         },
     ]
     assert all(opt["id"] != "00000000000000000000000000000012" for opt in context["staff_options"])
     MockStaff.objects.filter.assert_called_once_with(active=True)
-    # Exactly one bulk status query (staff_id__in), plus the admin's own lookup.
-    bulk_calls = [c for c in MockFeed.objects.filter.call_args_list if "staff_id__in" in c.kwargs]
-    assert len(bulk_calls) == 1
+    # Exactly one bulk feed query and one bulk event-count query (no N+1).
+    bulk_feed_calls = [c for c in MockFeed.objects.filter.call_args_list if "staff_id__in" in c.kwargs]
+    assert len(bulk_feed_calls) == 1
+    assert set(MockImported.objects.filter.call_args.kwargs["staff_id__in"]) == {
+        "00000000000000000000000000000010",
+        "00000000000000000000000000000011",
+    }

--- a/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
+++ b/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
@@ -26,16 +26,38 @@ def test_render_non_admin_has_no_staff_options() -> None:
     assert context["staff_options"] == []
 
 
-def test_render_admin_lists_active_staff() -> None:
+def test_render_admin_lists_active_staff_with_per_row_status() -> None:
     staff_a = MagicMock(id="00000000000000000000000000000010", full_name="Bea Adams")
     staff_b = MagicMock(id="00000000000000000000000000000011", full_name="Cy Brown")
     staff_nameless = MagicMock(id="00000000000000000000000000000012", full_name="")
+    # Bea has an active feed; Cy has none.
+    feed_a = MagicMock(
+        staff_id="00000000000000000000000000000010",
+        is_active=True,
+        last_sync_at="2026-07-12T10:00:00Z",
+        last_error=None,
+    )
+
+    def filter_side_effect(*args, **kwargs):
+        if "staff_id__in" in kwargs:
+            # The single bulk status query. Assert it asked for exactly the
+            # active, named staff ids (no per-row query → no N+1).
+            assert set(kwargs["staff_id__in"]) == {
+                "00000000000000000000000000000010",
+                "00000000000000000000000000000011",
+            }
+            return [feed_a]
+        # The admin's own self-service feed lookup.
+        self_lookup = MagicMock()
+        self_lookup.first.return_value = None
+        return self_lookup
+
     with (
         patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
         patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
         patch("external_calendar_busy_blocks.ui.pages.Staff") as MockStaff,
     ):
-        MockFeed.objects.filter.return_value.first.return_value = None
+        MockFeed.objects.filter.side_effect = filter_side_effect
         MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b, staff_nameless]
         _page(
             "00000000-0000-0000-0000-000000000001",
@@ -44,8 +66,23 @@ def test_render_admin_lists_active_staff() -> None:
     context = mock_render.call_args.args[1]
     assert context["is_admin"] is True
     assert context["staff_options"] == [
-        {"id": "00000000000000000000000000000010", "name": "Bea Adams"},
-        {"id": "00000000000000000000000000000011", "name": "Cy Brown"},
+        {
+            "id": "00000000000000000000000000000010",
+            "name": "Bea Adams",
+            "connected": True,
+            "last_sync_at": "2026-07-12T10:00:00Z",
+            "last_error": None,
+        },
+        {
+            "id": "00000000000000000000000000000011",
+            "name": "Cy Brown",
+            "connected": False,
+            "last_sync_at": None,
+            "last_error": None,
+        },
     ]
     assert all(opt["id"] != "00000000000000000000000000000012" for opt in context["staff_options"])
     MockStaff.objects.filter.assert_called_once_with(active=True)
+    # Exactly one bulk status query (staff_id__in), plus the admin's own lookup.
+    bulk_calls = [c for c in MockFeed.objects.filter.call_args_list if "staff_id__in" in c.kwargs]
+    assert len(bulk_calls) == 1

--- a/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
+++ b/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+from external_calendar_busy_blocks.ui.pages import ConfigPage
+
+
+def _page(logged_in_staff: str | None, secrets: dict | None = None) -> ConfigPage:
+    headers = {}
+    if logged_in_staff:
+        headers["canvas-logged-in-user-id"] = logged_in_staff
+    request = MagicMock(headers=headers)
+    page = ConfigPage.__new__(ConfigPage)
+    page.request = request
+    page.secrets = secrets or {}
+    return page
+
+
+def test_render_non_admin_has_no_staff_options() -> None:
+    with (
+        patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
+        patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = None
+        _page("00000000-0000-0000-0000-000000000002", secrets={}).render()
+    context = mock_render.call_args.args[1]
+    assert context["is_admin"] is False
+    assert context["staff_options"] == []
+
+
+def test_render_admin_lists_active_staff() -> None:
+    staff_a = MagicMock(id="00000000000000000000000000000010", full_name="Bea Adams")
+    staff_b = MagicMock(id="00000000000000000000000000000011", full_name="Cy Brown")
+    with (
+        patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
+        patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
+        patch("external_calendar_busy_blocks.ui.pages.Staff") as MockStaff,
+    ):
+        MockFeed.objects.filter.return_value.first.return_value = None
+        MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b]
+        _page(
+            "00000000-0000-0000-0000-000000000001",
+            secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
+        ).render()
+    context = mock_render.call_args.args[1]
+    assert context["is_admin"] is True
+    assert context["staff_options"] == [
+        {"id": "00000000000000000000000000000010", "name": "Bea Adams"},
+        {"id": "00000000000000000000000000000011", "name": "Cy Brown"},
+    ]
+    MockStaff.objects.filter.assert_called_once_with(active=True)


### PR DESCRIPTION
## What & why

Adds an **admin capability** to the `external-calendar-busy-blocks` plugin: staff listed in a new `ADMIN_STAFF_IDS` secret can connect, view, and disconnect a provider's personal iCal feed **on their behalf** — so providers never have to paste their own secret URL. The existing self-service flow is unchanged.

Builds on the auto-provisioning work from #401 (now merged).

## How it works

- **Authorization** — `is_admin()` gates admin actions against the comma-separated `ADMIN_STAFF_IDS` secret. **Fails closed**: an unset/empty secret means nobody is an admin.
- **One app, admin section** — when an admin opens *Calendar Busy Blocks*, the config page renders an extra "Manage another provider" section: a dropdown of active staff, live feed status, and connect/disconnect controls. Non-admins never receive that markup.
- **`FeedsAPI`** — `POST /feeds` and `/feeds/delete` accept an optional `staff_id`, honored **only for admins**. A non-admin's `staff_id` is silently ignored (acts on self) — no privilege escalation. New admin-only `GET /feeds/status` reports a provider's feed state without ever returning the stored ICS URL (it's a bearer token).
- **No data-model or cron changes** — an admin-created `StaffCalendarFeed` is identical to a self-created one, so the 15-minute sync picks it up unchanged.

## Safety properties

- Fail-closed admin check; a non-admin can never target another provider or reach the status endpoint (403).
- Pre-existing SSRF guards (HTTPS, whitespace rejection, host allowlist, `VCALENDAR` probe) run before target resolution — unchanged.
- The stored ICS URL is never returned by any endpoint or rendered into the page.
- All staff-id handling routes through a single `canonicalize_staff_id` primitive (dashless + lowercased), so admin-created feeds key correctly against `Staff.id`.

## Testing

157 tests pass. New coverage: `is_admin` edge cases (fail-closed, dashed/uppercase membership), admin vs. non-admin connect/disconnect targeting, calendar-unresolvable → 400, `GET /feeds/status` (403 for non-admins, no `ics_url` in body), and `ConfigPage` admin-context rendering (dropdown for admins, excluded for non-admins and nameless staff).

Manifest bumped to `0.3.0`; declares `ADMIN_STAFF_IDS` and `Staff` read access. README documents the admin flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — admin UI iterations (v0.3.1 → v0.3.3)

Refinements from hands-on testing on a dev instance, on top of the original feature above:

- **Staff table replaces the provider dropdown** (0.3.1) — the admin section now renders every active, named staff member as its own row (Provider · Status · Events · Secret iCal URL · Actions), so any provider can be connected/replaced/disconnected inline instead of one-at-a-time. Per-row status is server-rendered from a single bulk feed query (no N+1) and each row refreshes itself after an action.
- **Per-provider synced-event count** (0.3.2) — `GET /feeds/status` now returns `event_count`, surfaced as an "Events" column so an admin can see how many busy events have synced for each staff member. Counts are computed in one bulk `ImportedEvent` query; the stored ICS URL is still never returned.
- **Section relabeled "Manage staff"** (0.3.3) — the list intentionally covers all active staff, not only clinical providers, so the label matches. (The org-level `SCHEDULABLE_STAFF_ROLES` setting isn't exposed through the plugin SDK, so role-scoping was left out by design.)

A provider's own self-service connect and an admin-created connect share the same `StaffCalendarFeed` table, so self-service feeds appear as Connected in the admin table with no extra bookkeeping.

157 tests pass.
