### PR TITLE
feat(sticky_note): indicate note content on the chart-header button

### DIFF
--- a/extensions/sticky_note/sticky_note/CANVAS_MANIFEST.json
+++ b/extensions/sticky_note/sticky_note/CANVAS_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-    "sdk_version": "0.177.0",
+    "sdk_version": "0.179.0",
     "plugin_version": "0.2.0",
     "name": "sticky_note",
     "description": "Sticky note action button in patient chart header with shared and user-specific notes",

--- a/extensions/sticky_note/sticky_note/CANVAS_MANIFEST.json
+++ b/extensions/sticky_note/sticky_note/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
-    "sdk_version": "0.112.0",
-    "plugin_version": "0.1.0",
+    "sdk_version": "0.177.0",
+    "plugin_version": "0.2.0",
     "name": "sticky_note",
     "description": "Sticky note action button in patient chart header with shared and user-specific notes",
     "url_permissions": [],
@@ -8,10 +8,10 @@
         "protocols": [
             {
                 "class": "sticky_note.protocols.sticky_note_button:StickyNoteButton",
-                "description": "Action button in patient chart header that opens a sticky note modal",
+                "description": "Action button in patient chart header that opens a sticky note modal and indicates whether the note has content",
                 "data_access": {
                     "event": "",
-                    "read": [],
+                    "read": ["Patient", "Staff"],
                     "write": []
                 }
             },

--- a/extensions/sticky_note/sticky_note/CANVAS_MANIFEST.json
+++ b/extensions/sticky_note/sticky_note/CANVAS_MANIFEST.json
@@ -11,7 +11,7 @@
                 "description": "Action button in patient chart header that opens a sticky note modal and indicates whether the note has content",
                 "data_access": {
                     "event": "",
-                    "read": ["Patient", "Staff"],
+                    "read": [],
                     "write": []
                 }
             },

--- a/extensions/sticky_note/sticky_note/protocols/sticky_note_api.py
+++ b/extensions/sticky_note/sticky_note/protocols/sticky_note_api.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from hmac import compare_digest
 
 from canvas_sdk.effects import Effect
+from canvas_sdk.effects.action_button import ReloadPatientActionButtonsEffect
 from canvas_sdk.effects.simple_api import JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPIRoute, BearerCredentials
 from canvas_sdk.v1.data import Patient, Staff
@@ -322,10 +323,16 @@ class StickyNoteAPI(SimpleAPIRoute):
                 audit=audit,
             )
 
+            responses: list[Response | Effect] = [JSONResponse(result)]
             if result["status"] == "ok":
                 log.info(
                     "StickyNoteAPI: saved %s note (v%s) for patient %s by %s"
                     % (note_type, result["version"], patient_id, staff_id)
+                )
+                # Re-render the chart-header button so its content indicator
+                # (📝/⛔) updates immediately for anyone viewing this patient.
+                responses.append(
+                    ReloadPatientActionButtonsEffect(id=patient_id).apply()
                 )
             else:
                 log.info(
@@ -333,7 +340,7 @@ class StickyNoteAPI(SimpleAPIRoute):
                     % (note_type, patient_id, staff_id)
                 )
 
-            return [JSONResponse(result)]
+            return responses
         except Staff.DoesNotExist:
             return [JSONResponse({"status": "error", "message": "Staff not found"})]
         except Exception as e:

--- a/extensions/sticky_note/sticky_note/protocols/sticky_note_button.py
+++ b/extensions/sticky_note/sticky_note/protocols/sticky_note_button.py
@@ -1,16 +1,60 @@
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.launch_modal import LaunchModalEffect
+from canvas_sdk.events import EventType
 from canvas_sdk.handlers.action_button import ActionButton
 from canvas_sdk.templates import render_to_string
+from django.db.models import Q
 
 from logger import log
 
+from sticky_note.models import StickyNote
+
+SHOW_EVENT = EventType.Name(EventType.SHOW_CHART_PATIENT_HEADER_BUTTON)
+
 
 class StickyNoteButton(ActionButton):
-    BUTTON_TITLE = "Sticky Note"
+    """Chart-header button that opens the sticky note modal.
+
+    The button reflects whether the patient has any sticky-note content visible to
+    the current user (the shared note or the user's own note): filled shows a memo
+    glyph on a yellow background, empty shows a no-entry glyph on a gray one. The
+    appearance is recomputed on every chart render, so it tracks the note's state.
+    """
+
+    FILLED_BACKGROUND_COLOR = "#feff86"  # yellow — a sticky note has content
+    EMPTY_BACKGROUND_COLOR = "#c7c7c7"  # gray — no content yet
+
+    BUTTON_TITLE = "⛔ Sticky Note"
     BUTTON_KEY = "STICKY_NOTE"
     BUTTON_LOCATION = ActionButton.ButtonLocation.CHART_PATIENT_HEADER
-    BUTTON_BACKGROUND_COLOR = "#feff86"
+    BUTTON_BACKGROUND_COLOR = EMPTY_BACKGROUND_COLOR
+
+    def _has_content(self) -> bool:
+        """Whether the patient has a non-empty sticky note visible to the current user.
+
+        Considers the shared note (``owner`` is null) and the current user's own note
+        in a single query.
+        """
+        patient_id = self.event.target.id
+        staff_id = self.event.context.get("user", {}).get("id", "")
+        contents = (
+            StickyNote.objects.filter(patient__id=patient_id)
+            .filter(Q(owner__isnull=True) | Q(owner__id=staff_id))
+            .values_list("content", flat=True)
+        )
+        return any(content and content.strip() for content in contents)
+
+    def compute(self) -> list[Effect]:
+        """Reflect the patient's sticky-note content in the button title and color."""
+        log.info(
+            "StickyNoteButton: Check if button has content"
+        )
+        filled = self._has_content()
+        self.BUTTON_TITLE = "📝 Sticky Note" if filled else "⛔ Sticky Note"
+        self.BUTTON_BACKGROUND_COLOR = (
+            self.FILLED_BACKGROUND_COLOR if filled else self.EMPTY_BACKGROUND_COLOR
+        )
+        return super().compute()
 
     def handle(self) -> list[Effect]:
         patient_id = self.event.target.id

--- a/extensions/sticky_note/tests/test_sticky_note_api.py
+++ b/extensions/sticky_note/tests/test_sticky_note_api.py
@@ -79,7 +79,10 @@ class TestStickyNoteAPIPost:
         "sticky_note.protocols.sticky_note_api._resolve_patient_dbid",
         return_value=PATIENT_DBID,
     )
-    def test_post_saves_shared_note(self, mock_patient, mock_staff, mock_save):
+    @patch("sticky_note.protocols.sticky_note_api.ReloadPatientActionButtonsEffect")
+    def test_post_saves_shared_note(
+        self, mock_reload, mock_patient, mock_staff, mock_save
+    ):
         handler = _make_api(
             body={
                 "patient_id": "p-123",
@@ -91,7 +94,8 @@ class TestStickyNoteAPIPost:
         )
         effects = handler.post()
 
-        assert len(effects) == 1
+        assert len(effects) == 2
+        mock_reload.assert_called_once_with(id="p-123")
         mock_save.assert_called_once_with(
             patient_dbid=PATIENT_DBID,
             patient_uuid="p-123",
@@ -116,7 +120,10 @@ class TestStickyNoteAPIPost:
         "sticky_note.protocols.sticky_note_api._resolve_patient_dbid",
         return_value=PATIENT_DBID,
     )
-    def test_post_saves_user_note(self, mock_patient, mock_staff, mock_save):
+    @patch("sticky_note.protocols.sticky_note_api.ReloadPatientActionButtonsEffect")
+    def test_post_saves_user_note(
+        self, mock_reload, mock_patient, mock_staff, mock_save
+    ):
         handler = _make_api(
             body={
                 "patient_id": "p-123",
@@ -128,7 +135,8 @@ class TestStickyNoteAPIPost:
         )
         effects = handler.post()
 
-        assert len(effects) == 1
+        assert len(effects) == 2
+        mock_reload.assert_called_once_with(id="p-123")
         mock_save.assert_called_once_with(
             patient_dbid=PATIENT_DBID,
             patient_uuid="p-123",
@@ -205,7 +213,10 @@ class TestStickyNoteAPIPost:
         "sticky_note.protocols.sticky_note_api._resolve_patient_dbid",
         return_value=PATIENT_DBID,
     )
-    def test_post_passes_audit_true(self, mock_patient, mock_staff, mock_save):
+    @patch("sticky_note.protocols.sticky_note_api.ReloadPatientActionButtonsEffect")
+    def test_post_passes_audit_true(
+        self, mock_reload, mock_patient, mock_staff, mock_save
+    ):
         handler = _make_api(
             body={
                 "patient_id": "p-123",
@@ -218,7 +229,8 @@ class TestStickyNoteAPIPost:
         )
         effects = handler.post()
 
-        assert len(effects) == 1
+        assert len(effects) == 2
+        mock_reload.assert_called_once_with(id="p-123")
         mock_save.assert_called_once_with(
             patient_dbid=PATIENT_DBID,
             patient_uuid="p-123",
@@ -243,7 +255,10 @@ class TestStickyNoteAPIPost:
         "sticky_note.protocols.sticky_note_api._resolve_patient_dbid",
         return_value=PATIENT_DBID,
     )
-    def test_post_audit_defaults_false(self, mock_patient, mock_staff, mock_save):
+    @patch("sticky_note.protocols.sticky_note_api.ReloadPatientActionButtonsEffect")
+    def test_post_audit_defaults_false(
+        self, mock_reload, mock_patient, mock_staff, mock_save
+    ):
         """Omitting audit from body should pass audit=False to _save_note."""
         handler = _make_api(
             body={
@@ -268,6 +283,37 @@ class TestStickyNoteAPIPost:
             expected_version=2,
             audit=False,
         )
+
+    @patch(
+        "sticky_note.protocols.sticky_note_api._save_note",
+        return_value={"status": "conflict", "version": 5},
+    )
+    @patch(
+        "sticky_note.protocols.sticky_note_api._resolve_staff",
+        return_value=(STAFF_DBID, "Jane Doe"),
+    )
+    @patch(
+        "sticky_note.protocols.sticky_note_api._resolve_patient_dbid",
+        return_value=PATIENT_DBID,
+    )
+    @patch("sticky_note.protocols.sticky_note_api.ReloadPatientActionButtonsEffect")
+    def test_post_conflict_does_not_reload(
+        self, mock_reload, mock_patient, mock_staff, mock_save
+    ):
+        """A version conflict returns only the JSON response, no button reload."""
+        handler = _make_api(
+            body={
+                "patient_id": "p-123",
+                "staff_id": "s-456",
+                "type": "shared",
+                "content": "racing edit",
+                "version": 1,
+            },
+        )
+        effects = handler.post()
+
+        assert len(effects) == 1
+        mock_reload.assert_not_called()
 
 
 class TestSaveNoteAuditGating:

--- a/extensions/sticky_note/tests/test_sticky_note_button.py
+++ b/extensions/sticky_note/tests/test_sticky_note_button.py
@@ -17,7 +17,7 @@ def _make_button(patient_id="patient-uuid-123", staff_id="staff-uuid-456"):
 class TestStickyNoteButtonConfig:
     def test_button_title(self):
         button = _make_button()
-        assert button.BUTTON_TITLE == "Sticky Note"
+        assert button.BUTTON_TITLE == "⛔ Sticky Note"
 
     def test_button_key(self):
         button = _make_button()
@@ -31,7 +31,7 @@ class TestStickyNoteButtonConfig:
 
     def test_button_background_color(self):
         button = _make_button()
-        assert button.BUTTON_BACKGROUND_COLOR == "#feff86"
+        assert button.BUTTON_BACKGROUND_COLOR == "#c7c7c7"
 
 
 class TestStickyNoteButtonHandle:
@@ -57,3 +57,78 @@ class TestStickyNoteButtonHandle:
         context = mock_render.call_args[0][1]
         assert context["patient_id"] == "p-999"
         assert context["staff_id"] == "s-888"
+
+
+def _mock_note_contents(mock_model, contents):
+    """Wire the StickyNote query chain in _has_content to return ``contents``."""
+    chain = mock_model.objects.filter.return_value.filter.return_value
+    chain.values_list.return_value = contents
+
+
+def test_has_content_true_when_note_has_text():
+    """A visible note with non-whitespace text counts as content."""
+    button = _make_button()
+    with patch("sticky_note.protocols.sticky_note_button.StickyNote") as mock_model:
+        _mock_note_contents(mock_model, ["", "  call the pharmacy  "])
+        assert button._has_content() is True
+
+
+def test_has_content_false_when_notes_blank():
+    """Empty or whitespace-only notes do not count as content."""
+    button = _make_button()
+    with patch("sticky_note.protocols.sticky_note_button.StickyNote") as mock_model:
+        _mock_note_contents(mock_model, ["", "   "])
+        assert button._has_content() is False
+
+
+def test_has_content_false_when_no_notes():
+    """A patient with no sticky notes has no content."""
+    button = _make_button()
+    with patch("sticky_note.protocols.sticky_note_button.StickyNote") as mock_model:
+        _mock_note_contents(mock_model, [])
+        assert button._has_content() is False
+
+
+def test_compute_filled_shows_memo_on_yellow():
+    """A filled note renders the memo glyph on the filled (yellow) background."""
+    from sticky_note.protocols.sticky_note_button import StickyNoteButton
+
+    button = _make_button()
+    button.event.name = "SHOW_CHART_PATIENT_HEADER_BUTTON"
+    with patch.object(button, "_has_content", return_value=True):
+        effects = button.compute()
+
+    assert button.BUTTON_TITLE == "📝 Sticky Note"
+    assert button.BUTTON_BACKGROUND_COLOR == StickyNoteButton.FILLED_BACKGROUND_COLOR
+    assert len(effects) == 1
+
+
+def test_compute_empty_shows_no_entry_on_gray():
+    """An empty note renders the no-entry glyph on the empty (gray) background."""
+    from sticky_note.protocols.sticky_note_button import StickyNoteButton
+
+    button = _make_button()
+    button.event.name = "SHOW_CHART_PATIENT_HEADER_BUTTON"
+    with patch.object(button, "_has_content", return_value=False):
+        effects = button.compute()
+
+    assert button.BUTTON_TITLE == "⛔ Sticky Note"
+    assert button.BUTTON_BACKGROUND_COLOR == StickyNoteButton.EMPTY_BACKGROUND_COLOR
+    assert len(effects) == 1
+
+
+def test_compute_click_event_opens_modal():
+    """The click event opens the sticky note modal."""
+    button = _make_button()
+    button.event.name = "ACTION_BUTTON_CLICKED"
+    button.event.context = {"key": "STICKY_NOTE", "user": {"id": "staff-uuid-456"}}
+    with (
+        patch.object(button, "_has_content", return_value=True),
+        patch(
+            "sticky_note.protocols.sticky_note_button.render_to_string",
+            return_value="<html></html>",
+        ),
+    ):
+        effects = button.compute()
+
+    assert len(effects) == 1


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-5683


## What

The sticky-note chart-header button now reflects whether the patient has content:

- **Has content** → 📝 memo glyph on a yellow background
- **Empty** → ⛔ no-entry glyph on a gray background

"Has content" considers the **shared** note (`owner` null) and the **current user's own** note, resolved in a single query.

Saving a note (`StickyNoteAPI`) now emits `ReloadPatientActionButtonsEffect`, so the indicator refreshes **in real time** for anyone viewing that patient — no page reload. A version conflict does not trigger a reload.

## Testing

- `cd extensions/sticky_note && uv run --with-editable <local canvas-plugins> pytest tests/` → **31 passed**
- `ruff check` clean
- Verified live in a local instance (button toggles 📝/⛔ and refreshes on save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)