### PR TITLE
Extend Alert facility field to Prescribe, Adjust Prescription, and Refill

### DIFF
--- a/extensions/alert-facility-fields/.gitignore
+++ b/extensions/alert-facility-fields/.gitignore
@@ -1,1 +1,25 @@
+# Claude Code / CPA
 .claude
+.cpa-workflow-artifacts/
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+
+# Virtual environments
+.venv/
+venv/
+
+# Test & type-check caches
+.pytest_cache/
+.mypy_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# OS cruft
+.DS_Store

--- a/extensions/alert-facility-fields/alert_facility_fields/CANVAS_MANIFEST.json
+++ b/extensions/alert-facility-fields/alert_facility_fields/CANVAS_MANIFEST.json
@@ -1,13 +1,13 @@
 {
   "sdk_version": "0.141.0",
-  "plugin_version": "0.0.5",
+  "plugin_version": "0.0.6",
   "name": "alert_facility_fields",
-  "description": "Adds a required Alert facility Yes/No form field to the Medication Statement and Stop Medication commands. Persists the choice as command metadata under the key 'alert_facility' and blocks commit until a value is selected.",
+  "description": "Adds a required Alert facility Yes/No form field to the Medication Statement, Stop Medication, Prescribe, Adjust Prescription, and Refill commands. Persists the choice as command metadata under the key 'alert_facility' and blocks commit until a value is selected.",
   "components": {
     "protocols": [
       {
         "class": "alert_facility_fields.protocols.alert_facility_form:AlertFacilityFormHandler",
-        "description": "Adds the Alert facility form field to Medication Statement and Stop Medication commands in the chart UI and the note printout.",
+        "description": "Adds the Alert facility form field to Medication Statement, Stop Medication, Prescribe, Adjust Prescription, and Refill commands in the chart UI and the note printout.",
         "data_access": {
           "event": "",
           "read": [],
@@ -16,7 +16,7 @@
       },
       {
         "class": "alert_facility_fields.protocols.alert_facility_form:AlertFacilityRequiredValidator",
-        "description": "Blocks commit of Medication Statement and Stop Medication commands until the Alert facility field is set.",
+        "description": "Blocks commit of Medication Statement, Stop Medication, Prescribe, Adjust Prescription, and Refill commands until the Alert facility field is set.",
         "data_access": {
           "event": "",
           "read": [],

--- a/extensions/alert-facility-fields/alert_facility_fields/README.md
+++ b/extensions/alert-facility-fields/alert_facility_fields/README.md
@@ -1,14 +1,14 @@
 # alert_facility_fields
 
-A Canvas SDK plugin that adds an **Alert facility** Yes/No field to the **Medication Statement** and **Stop Medication** commands and blocks committing those commands until the field is set.
+A Canvas SDK plugin that adds an **Alert facility** Yes/No field to the **Medication Statement**, **Stop Medication**, **Prescribe**, **Adjust Prescription**, and **Refill** commands and blocks committing those commands until the field is set.
 
 ## Why
 
-Healthcare teams routinely need to flag whether a medication change should trigger a notification to the patient's facility (skilled nursing facility, group home, school, etc.). Capturing this signal at the point of charting — and refusing to commit a Medication Statement or Stop Medication without it — keeps the data consistent and makes downstream automation (alerting, reporting, integrations) trivial: the answer is on the command itself, not buried in free text.
+Healthcare teams routinely need to flag whether a medication change should trigger a notification to the patient's facility (skilled nursing facility, group home, school, etc.). Capturing this signal at the point of charting — and refusing to commit a medication command (Medication Statement, Stop Medication, Prescribe, Adjust Prescription, or Refill) without it — keeps the data consistent and makes downstream automation (alerting, reporting, integrations) trivial: the answer is on the command itself, not buried in free text.
 
 ## What it does
 
-When a clinician opens or prints a note containing a Medication Statement or Stop Medication command, the plugin contributes one extra form field:
+When a clinician opens or prints a note containing a Medication Statement, Stop Medication, Prescribe, Adjust Prescription, or Refill command, the plugin contributes one extra form field:
 
 | Property | Value |
 |---|---|
@@ -36,11 +36,11 @@ Two `BaseHandler` subclasses, both registered in `CANVAS_MANIFEST.json`:
 
 ### `AlertFacilityFormHandler`
 
-Subscribes to `EventType.COMMAND__FORM__GET_ADDITIONAL_FIELDS`. On each event it inspects `event.context["schema_key"]`; for `medicationStatement` or `stopMedication` it returns a `CommandMetadataCreateFormEffect` declaring the Alert facility field. The same effect is returned regardless of `event.context["purpose"]` (`"form"` for chart UI, `"print"` for the printout), so the field surfaces in both contexts.
+Subscribes to `EventType.COMMAND__FORM__GET_ADDITIONAL_FIELDS`. On each event it inspects `event.context["schema_key"]`; for `medicationStatement`, `stopMedication`, `prescribe`, `adjustPrescription`, or `refill` it returns a `CommandMetadataCreateFormEffect` declaring the Alert facility field. The same effect is returned regardless of `event.context["purpose"]` (`"form"` for chart UI, `"print"` for the printout), so the field surfaces in both contexts.
 
 ### `AlertFacilityRequiredValidator`
 
-Subscribes to `MEDICATION_STATEMENT_COMMAND__POST_VALIDATION` and `STOP_MEDICATION_COMMAND__POST_VALIDATION`. On commit it reads the stored `alert_facility` metadata via `CommandMetadata.objects.filter(...)`. If the value is missing or blank it returns a `CommandValidationErrorEffect` with the message *"Alert Facility is a required field."* — the platform surfaces the error inline and refuses the commit until the user makes a choice.
+Subscribes to `MEDICATION_STATEMENT_COMMAND__POST_VALIDATION`, `STOP_MEDICATION_COMMAND__POST_VALIDATION`, `PRESCRIBE_COMMAND__POST_VALIDATION`, `ADJUST_PRESCRIPTION_COMMAND__POST_VALIDATION`, and `REFILL_COMMAND__POST_VALIDATION`. On commit it reads the stored `alert_facility` metadata via `CommandMetadata.objects.filter(...)`. If the value is missing or blank it returns a `CommandValidationErrorEffect` with the message *"Alert Facility is a required field."* — the platform surfaces the error inline and refuses the commit until the user makes a choice.
 
 ## Demo
 

--- a/extensions/alert-facility-fields/alert_facility_fields/protocols/alert_facility_form.py
+++ b/extensions/alert-facility-fields/alert_facility_fields/protocols/alert_facility_form.py
@@ -11,7 +11,15 @@ from canvas_sdk.events import EventType
 from canvas_sdk.handlers import BaseHandler
 from canvas_sdk.v1.data.command import CommandMetadata
 
-SUPPORTED_SCHEMA_KEYS = frozenset({"medicationStatement", "stopMedication"})
+SUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "medicationStatement",
+        "stopMedication",
+        "prescribe",
+        "adjustPrescription",
+        "refill",
+    }
+)
 ALERT_FACILITY_KEY = "alert_facility"
 ALERT_FACILITY_LABEL = "Alert facility"
 ALERT_FACILITY_OPTIONS = ["Yes", "No"]
@@ -58,6 +66,9 @@ class AlertFacilityRequiredValidator(BaseHandler):
     RESPONDS_TO = [
         EventType.Name(EventType.MEDICATION_STATEMENT_COMMAND__POST_VALIDATION),
         EventType.Name(EventType.STOP_MEDICATION_COMMAND__POST_VALIDATION),
+        EventType.Name(EventType.PRESCRIBE_COMMAND__POST_VALIDATION),
+        EventType.Name(EventType.ADJUST_PRESCRIPTION_COMMAND__POST_VALIDATION),
+        EventType.Name(EventType.REFILL_COMMAND__POST_VALIDATION),
     ]
 
     def compute(self) -> list[Effect]:

--- a/extensions/alert-facility-fields/mypy.ini
+++ b/extensions/alert-facility-fields/mypy.ini
@@ -1,0 +1,23 @@
+[mypy]
+explicit_package_bases = True
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = False
+disallow_untyped_defs = True
+error_summary = True
+show_error_context = True
+strict_equality = True
+strict_optional = True
+warn_no_return = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_configs = True
+warn_unused_ignores = True
+follow_imports = silent
+ignore_missing_imports = True
+no_implicit_optional = True
+pretty = False
+python_version = 3.12
+exclude = debug

--- a/extensions/alert-facility-fields/pyproject.toml
+++ b/extensions/alert-facility-fields/pyproject.toml
@@ -6,12 +6,12 @@ dependencies = [
   "canvas[test-utils]",
   "pytest-cov>=7.0.0",
 ]
-description = "Adds a required Alert facility Yes/No form field to Medication Statement and Stop Medication commands and blocks commit until a value is selected."
+description = "Adds a required Alert facility Yes/No form field to Medication Statement, Stop Medication, Prescribe, Adjust Prescription, and Refill commands and blocks commit until a value is selected."
 license = "MIT"
 name = "alert-facility-fields"
 readme = "alert_facility_fields/README.md"
 requires-python = ">=3.11"
-version = "0.0.5"
+version = "0.0.6"
 
 [tool.pytest.ini_options]
 python_files = ["*_tests.py", "test_*.py", "tests.py"]

--- a/extensions/alert-facility-fields/tests/test_alert_facility_form.py
+++ b/extensions/alert-facility-fields/tests/test_alert_facility_form.py
@@ -49,7 +49,10 @@ def _set_form_value(mock_metadata: Any, value: str | None) -> None:
     mock_metadata.objects.filter.return_value.values_list.return_value.first.return_value = value
 
 
-@pytest.mark.parametrize("schema_key", ["medicationStatement", "stopMedication"])
+@pytest.mark.parametrize(
+    "schema_key",
+    ["medicationStatement", "stopMedication", "prescribe", "adjustPrescription", "refill"],
+)
 def test_emits_alert_facility_field_for_supported_commands(
     patched_form_metadata: Any, schema_key: str
 ) -> None:
@@ -94,10 +97,11 @@ def test_no_op_for_other_schema_keys(
 
 
 @pytest.mark.parametrize("purpose", ["form", "print"])
+@pytest.mark.parametrize("schema_key", ["medicationStatement", "prescribe"])
 def test_same_field_emitted_for_form_and_print_purposes(
-    patched_form_metadata: Any, purpose: str
+    patched_form_metadata: Any, purpose: str, schema_key: str
 ) -> None:
-    handler = AlertFacilityFormHandler(_make_event("medicationStatement", purpose=purpose))
+    handler = AlertFacilityFormHandler(_make_event(schema_key, purpose=purpose))
 
     effects = handler.compute()
 
@@ -199,3 +203,14 @@ def test_validator_no_op_when_metadata_set(patched_metadata: Any, value: str) ->
     handler = AlertFacilityRequiredValidator(_validator_event())
 
     assert handler.compute() == []
+
+
+def test_validator_responds_to_all_supported_command_validations() -> None:
+    """The validator must be wired to every medication command's POST_VALIDATION event."""
+    assert set(AlertFacilityRequiredValidator.RESPONDS_TO) == {
+        "MEDICATION_STATEMENT_COMMAND__POST_VALIDATION",
+        "STOP_MEDICATION_COMMAND__POST_VALIDATION",
+        "PRESCRIBE_COMMAND__POST_VALIDATION",
+        "ADJUST_PRESCRIPTION_COMMAND__POST_VALIDATION",
+        "REFILL_COMMAND__POST_VALIDATION",
+    }

--- a/extensions/alert-facility-fields/uv.lock
+++ b/extensions/alert-facility-fields/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "alert-facility-fields"
-version = "0.0.5"
+version = "0.0.6"
 source = { virtual = "." }
 dependencies = [
     { name = "canvas", extra = ["test-utils"] },


### PR DESCRIPTION
## Summary

Extends the `alert_facility_fields` plugin so the required **Alert facility** (Yes/No) field — and its commit-blocking validation — also applies to the **Prescribe**, **Adjust Prescription**, and **Refill** commands, alongside the existing Medication Statement and Stop Medication support.

The two `BaseHandler`s were already written generically:
- `AlertFacilityFormHandler` filters on a `SUPPORTED_SCHEMA_KEYS` frozenset.
- `AlertFacilityRequiredValidator` subscribes to a list of per-command `POST_VALIDATION` events.

So this is a data-only extension — no new handler logic.

| Command | `POST_VALIDATION` event | `schema_key` |
|---|---|---|
| Prescribe | `PRESCRIBE_COMMAND__POST_VALIDATION` | `prescribe` |
| Adjust Prescription | `ADJUST_PRESCRIPTION_COMMAND__POST_VALIDATION` | `adjustPrescription` |
| Refill | `REFILL_COMMAND__POST_VALIDATION` | `refill` |

## Changes

- Add the three schema keys to `SUPPORTED_SCHEMA_KEYS` and the three events to the validator's `RESPONDS_TO`.
- Bump plugin to **v0.0.6** (manifest + pyproject); update descriptions.
- Update README to list all five commands and the new identifiers.
- Extend tests (parametrized cases for the new schema keys + a guard asserting all five events are wired in `RESPONDS_TO`).
- Add `mypy.ini` (matching the repo's other annotated plugins) and expand the plugin-local `.gitignore`.

## Verification

- `uv run pytest --cov` → **28 passed, 100%** statement + branch coverage.
- `uv run mypy --config-file=mypy.ini alert_facility_fields tests` → clean.
- Security review: no findings (no secrets, scope, HTTP, or endpoints).
- DB performance review: PASS (two single-row `CommandMetadata` lookups; no N+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)