### PR TITLE
Fix timezone drift in Availability Manager schedule templates

### DIFF
--- a/extensions/provider-calendaring/provider_scheduling/handlers/availability_web_app.py
+++ b/extensions/provider-calendaring/provider_scheduling/handlers/availability_web_app.py
@@ -96,8 +96,8 @@ class AvailabilityWebApp(StaffSessionAuthMixin, SimpleAPI):
                         if event.calendar.title and ":" in event.calendar.title
                         else ""
                     ),
-                    "startTime": event.starts_at.strftime("%Y-%m-%dT%H:%M"),
-                    "endTime": event.ends_at.strftime("%Y-%m-%dT%H:%M"),
+                    "startTime": event.starts_at.isoformat(),
+                    "endTime": event.ends_at.isoformat(),
                     "daysOfWeek": (
                         event.recurrence
                         and "BYDAY=" in event.recurrence

--- a/extensions/provider-calendaring/tests/test_availability_web_app.py
+++ b/extensions/provider-calendaring/tests/test_availability_web_app.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for provider_scheduling availability_web_app."""
 
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import Mock, patch
@@ -461,3 +462,53 @@ def test_index_handles_empty_events() -> None:
         context = call_args[0][1]
 
         assert context["events"] == []
+
+
+def test_index_serializes_event_times_as_utc_instants() -> None:
+    """Test index endpoint serializes event times with their UTC offset.
+
+    JavaScript's Date() parses a date-time string with no offset as local
+    time, so a naive "2026-07-29T17:00" is read by the browser as 5pm local
+    rather than 5pm UTC. The offset has to survive serialization.
+    """
+    # Create web app instance
+    dummy_context = {"method": "GET", "path": "/app/availability-app"}
+    app = AvailabilityWebApp(event=DummyEvent(context=dummy_context))  # type: ignore[arg-type]
+    app.request = DummyRequest()
+
+    # A non-recurring event, so only the time serialization is under test
+    mock_event = Mock()
+    mock_event.id = "event-1"
+    mock_event.title = "Regular Weekday Schedule"
+    mock_event.calendar.title = "Dr. John Smith: Clinic: Main Clinic"
+    mock_event.starts_at = datetime(2026, 7, 29, 17, 0, tzinfo=timezone.utc)
+    mock_event.ends_at = datetime(2026, 7, 29, 18, 30, tzinfo=timezone.utc)
+    mock_event.recurrence = None
+    mock_event.recurrence_ends_at = None
+    mock_event.allowed_note_types.all.return_value = []
+
+    with (
+        patch("provider_scheduling.handlers.availability_web_app.Staff") as mock_staff_class,
+        patch("provider_scheduling.handlers.availability_web_app.PracticeLocation") as mock_location_class,
+        patch("provider_scheduling.handlers.availability_web_app.NoteType") as mock_note_type_class,
+        patch("provider_scheduling.handlers.availability_web_app.Event") as mock_event_class,
+        patch("provider_scheduling.handlers.availability_web_app.render_to_string") as mock_render,
+    ):
+        mock_filter_result = Mock()
+        mock_filter_result.distinct.return_value = []
+        mock_staff_class.objects.filter.return_value = mock_filter_result
+        mock_location_class.objects.filter.return_value = []
+        mock_note_type_class.objects.filter.return_value = []
+        mock_event_class.objects.all.return_value = [mock_event]
+
+        mock_render.return_value = "<html>Test</html>"
+
+        app.index()
+
+        # Verify times carry their UTC offset
+        call_args = mock_render.call_args
+        context = call_args[0][1]
+        serialized = context["events"][0]
+
+        assert serialized["startTime"] == "2026-07-29T17:00:00+00:00"
+        assert serialized["endTime"] == "2026-07-29T18:30:00+00:00"


### PR DESCRIPTION
## The bug

In `provider_scheduling`, schedule template times shift by the viewer's UTC offset, and shift **again on every save**.

This [Loom video](https://www.loom.com/share/71c3e7950c8a46bba67e574a7fb47d04) demonstrates the problem clearly.

Recorded in Eastern Daylight Time:

1. Create a template for 1:00pm–2:30pm, daily Mon–Fri. Save, refresh → displays **5:00pm–6:30pm**.
2. Reopen it and change only the allowed note type. Save, refresh → displays **9:00pm–10:30pm**.

The second step changes no time field, but the time moves another four hours. This is corrupting stored data, not just rendering it wrong.

## Root cause

`handlers/availability_web_app.py:99-100` serialized event times with:

```python
"startTime": event.starts_at.strftime("%Y-%m-%dT%H:%M"),
```

`starts_at` is a timezone-aware UTC datetime. `strftime` formats the UTC wall clock and **discards the offset**, producing a naive string like `"2026-07-29T17:00"`.

Per ECMA-262 §21.4.3.2, `new Date()` parses a date-*time* string with no offset as **local** time (date-only strings parse as UTC — that asymmetry matters below). So the browser reads each UTC instant as a local one.

The drift compounds because `editEvent` (`static/availability/main.js:348`) seeds the edit form from that same mis-parsed value, and `updateEvent` converts it back to UTC on save:

| Step | Value |
|---|---|
| User enters 1:00pm | `"2026-07-29T13:00"` |
| `toUTCISOString` → stored | `17:00Z` ✅ |
| Server re-serializes | `"2026-07-29T17:00"` ← offset lost |
| `new Date()` → display | **5:00pm** |
| Edit form seeded with | `17:00` |
| Saved again | **`21:00Z`** |

## The fix

Serialize with `isoformat()` so the offset survives. No client changes needed — the existing helpers are already correct for offset-bearing input: `formatTime`/`formatDate` render correct local time, and `editEvent`'s `toLocalDateTimeString(new Date(...))` round-trips cleanly.

## Testing

Added `test_index_serializes_event_times_as_utc_instants`, which fails on `main` with `assert '2026-07-29T17:00' == '2026-07-29T17:00:00+00:00'` and passes with the fix. Full plugin suite: 66 passed.

Also deployed to a dev Canvas instance and confirmed both steps of the repro above now hold the entered time, including the edit-and-resave that previously drifted.

Note: this fixes new writes. Templates already saved N times are sitting at `true_time + N × offset` in the database and will now render their true stored value. Instances may want to audit existing templates.

## Deliberately out of scope

`recurrence_ends_at` (line 131) uses the same `strftime` but is **not** changed here. It is semantically a date, not an instant, and the current bug cancels out for it: the `<input type="date">` value parses as UTC midnight and `.split('T')[0]` recovers the right date. Applying `isoformat()` there would make it read a day early in negative-offset zones. It has a separate pre-existing off-by-one in `formatDate` on the card display. Happy to follow up in its own PR.

## Question for maintainers

Should `plugin_version` in `CANVAS_MANIFEST.json` be bumped for a bugfix? Left at `0.0.1` to keep the diff minimal — happy to bump if that is the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
