### PR TITLE
Port gcal_sync v0.6.1

### DIFF
--- a/extensions/gcal_sync/README.md
+++ b/extensions/gcal_sync/README.md
@@ -26,7 +26,9 @@ reflected in Canvas scheduling (and vice versa) without manual double-entry.
 | Channel renewal | `gcal_sync.handlers.channel_renewal:ChannelRenewalCron` | Renews watch channels before expiry. |
 | Reconciliation | `gcal_sync.handlers.reconciliation:ReconciliationCron` | Daily catch-up; sync-token recovery. |
 | Block sweep | `gcal_sync.handlers.block_sweep:BlockSweepCron` | Every 15 min, push admin blocks (Calendar events). |
-| Admin | `gcal_sync.applications.google_calendar_admin:GoogleCalendarAdmin` | Map staff→calendar; sync health; per-provider reconcile / re-import / purge. |
+| Reimport drain | `gcal_sync.handlers.reimport_drain:ReimportDrainCron` | Drains the "Re-import all" queue, rebuilding a few providers per tick. |
+| Outbound backfill | `gcal_sync.handlers.outbound_backfill:OutboundBackfillDrainCron` | Paced drain of Canvas→Google backfill for new/missed providers. |
+| Admin | `gcal_sync.applications.google_calendar_admin:GoogleCalendarAdmin` | Map staff→calendar; sync health; per-provider reconcile / re-import / purge / dry-run. Fleet-level re-import all and cancel controls. |
 
 Provider-created Google events are imported as admin holds (`ScheduleEvent`). Private/confidential
 events can be imported with their title masked to "Busy" — no event details from Google are written

--- a/extensions/gcal_sync/gcal_sync/CANVAS_MANIFEST.json
+++ b/extensions/gcal_sync/gcal_sync/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.164.0",
-    "plugin_version": "0.4.5",
+    "plugin_version": "0.6.1",
     "name": "gcal_sync",
     "description": "Two-way Google Calendar sync for Canvas: pushes appointments and admin blocks (lunch/PTO) into providers' Workspace calendars in near-real-time, and imports provider-created Google events back into Canvas as admin holds. Canvas remains the system of record. Service-account + domain-wide delegation; no PHI in event fields.",
     "components": {
@@ -81,6 +81,34 @@
                     ],
                     "write": []
                 }
+            },
+            {
+                "class": "gcal_sync.handlers.reimport_drain:ReimportDrainCron",
+                "description": "Drains the fleet re-import queue a few providers per tick so 'Re-import all' rebuilds apply across many short runs",
+                "data_access": {
+                    "event": "",
+                    "read": [
+                        "v1.Appointment",
+                        "v1.Staff",
+                        "v1.NoteType",
+                        "v1.PracticeLocation"
+                    ],
+                    "write": []
+                }
+            },
+            {
+                "class": "gcal_sync.handlers.outbound_backfill:OutboundBackfillDrainCron",
+                "description": "Paced drain of the outbound Canvas->Google backfill: advances the least-recently-synced providers a few at a time, deferring on rate limits so writes aren't dropped",
+                "data_access": {
+                    "event": "",
+                    "read": [
+                        "v1.Appointment",
+                        "v1.Staff",
+                        "v1.NoteType",
+                        "v1.PracticeLocation"
+                    ],
+                    "write": []
+                }
             }
         ],
         "applications": [
@@ -98,7 +126,7 @@
         "views": []
     },
     "custom_data": {
-        "namespace": "gcal_sync",
+        "namespace": "msf__gcal_sync",
         "access": "read_write"
     },
     "tags": {},

--- a/extensions/gcal_sync/gcal_sync/blocks.py
+++ b/extensions/gcal_sync/gcal_sync/blocks.py
@@ -77,8 +77,15 @@ class BlockSync:
         stats = {"pushed": 0, "deleted": 0}
         current = self._current_blocks(staff_id)
         client = self._client_factory(calendar_id)
+        # Prefetch this provider's block mappings in ONE query (keyed exactly by canvas_event_id, the
+        # unique key), so the per-block upsert below does no lookup of its own. Without this the sweep
+        # runs a CalendarEventMapping.get() per block every 15 minutes.
+        mapping_cache = {
+            m.canvas_event_id: m
+            for m in CalendarEventMapping.objects.filter(canvas_event_id__in=list(current.keys()))
+        }
         for event_id, event in current.items():
-            self._upsert(client, calendar_id, event_id, event, stats)
+            self._upsert(client, calendar_id, event_id, event, stats, mapping_cache)
         self._delete_removed(client, calendar_id, set(current.keys()), stats)
         return stats
 
@@ -112,11 +119,17 @@ class BlockSync:
         return result
 
     def _upsert(
-        self, client: GoogleCalendarClient, calendar_id: str, event_id: str, event: Event, stats: dict
+        self,
+        client: GoogleCalendarClient,
+        calendar_id: str,
+        event_id: str,
+        event: Event,
+        stats: dict,
+        mapping_cache: dict[str, CalendarEventMapping],
     ) -> None:
         body = build_event_body(block_snapshot(event))
         new_hash = content_hash(body)
-        mapping = CalendarEventMapping.objects.filter(canvas_event_id=event_id).first()
+        mapping = mapping_cache.get(event_id)
 
         if mapping is None:
             created = client.insert_event(calendar_id, body)

--- a/extensions/gcal_sync/gcal_sync/google/client.py
+++ b/extensions/gcal_sync/gcal_sync/google/client.py
@@ -25,6 +25,38 @@ class GoogleApiError(RuntimeError):
         self.status_code = status_code
 
 
+class GoogleRateLimitError(GoogleApiError):
+    """Google is throttling us (``403``/``429`` ``rateLimitExceeded``/``userRateLimitExceeded``).
+
+    A distinct type because it must be handled differently from a real error: it is transient, so the
+    caller should back off and retry later (the bulk pusher defers the provider to a later run rather
+    than dropping the write). The RestrictedPython sandbox has no ``time`` module, so backoff can't
+    sleep in-process — it is expressed as "stop and retry on the next cron tick".
+    """
+
+
+def _error_for(status_code: int, body: str) -> GoogleApiError:
+    """Map a non-success Google response to the right exception.
+
+    A ``403``/``429`` from Google's usage limits is throttling (``GoogleRateLimitError``); any other
+    non-success is a plain ``GoogleApiError``. Matching on the body is deliberate — a bare ``403`` can
+    be either throttling or a genuine permission error (e.g. calendar not shared), and only the latter
+    should be a hard failure. Every usage-limit response carries ``"domain": "usageLimits"`` (with a
+    reason of ``rateLimitExceeded``/``userRateLimitExceeded`` for per-minute limits, or
+    ``quotaExceeded``/``dailyLimitExceeded`` for the daily quota); the reason strings are kept too as a
+    belt-and-suspenders in case Google varies the body shape.
+    """
+    if status_code in (403, 429) and (
+        "usageLimits" in body
+        or "rateLimitExceeded" in body
+        or "userRateLimitExceeded" in body
+        or "quotaExceeded" in body
+        or "dailyLimitExceeded" in body
+    ):
+        return GoogleRateLimitError(status_code, body)
+    return GoogleApiError(status_code, body)
+
+
 class GoogleCalendarClient:
     """Calendar-event CRUD, watch-channel, and incremental-list operations for one access token."""
 
@@ -46,49 +78,80 @@ class GoogleCalendarClient:
     def insert_event(self, calendar_id: str, body: dict) -> dict:
         """Create an event; returns the created Google event (including its ``id``)."""
         resp = self._http.post(
-            self._url(f"/calendars/{self._cal(calendar_id)}/events"), json=body, headers=self._headers
+            self._url(f"/calendars/{self._cal(calendar_id)}/events"),
+            json=body,
+            headers=self._headers,
         )
         if resp.status_code not in (200, 201):
-            raise GoogleApiError(resp.status_code, resp.text)
+            raise _error_for(resp.status_code, resp.text)
         created: dict = resp.json()
         return created
 
     def patch_event(self, calendar_id: str, event_id: str, body: dict) -> dict:
         """Update an existing event in place."""
         resp = self._http.patch(
-            self._url(f"/calendars/{self._cal(calendar_id)}/events/{quote(event_id, safe='')}"),
+            self._url(
+                f"/calendars/{self._cal(calendar_id)}/events/{quote(event_id, safe='')}"
+            ),
             json=body,
             headers=self._headers,
         )
         if resp.status_code != 200:
-            raise GoogleApiError(resp.status_code, resp.text)
+            raise _error_for(resp.status_code, resp.text)
         patched: dict = resp.json()
         return patched
 
     def delete_event(self, calendar_id: str, event_id: str) -> None:
         """Delete an event. A ``404``/``410`` (already gone) is treated as success — idempotent."""
         resp = self._http.delete(
-            self._url(f"/calendars/{self._cal(calendar_id)}/events/{quote(event_id, safe='')}"),
+            self._url(
+                f"/calendars/{self._cal(calendar_id)}/events/{quote(event_id, safe='')}"
+            ),
             headers=self._headers,
         )
         if resp.status_code not in (200, 204, 404, 410):
-            raise GoogleApiError(resp.status_code, resp.text)
+            raise _error_for(resp.status_code, resp.text)
 
     def get_event(self, calendar_id: str, event_id: str) -> dict | None:
         """Fetch a single event, or ``None`` if it no longer exists."""
         resp = self._http.get(
-            self._url(f"/calendars/{self._cal(calendar_id)}/events/{quote(event_id, safe='')}"),
+            self._url(
+                f"/calendars/{self._cal(calendar_id)}/events/{quote(event_id, safe='')}"
+            ),
             headers=self._headers,
         )
         if resp.status_code in (404, 410):
             return None
         if resp.status_code != 200:
-            raise GoogleApiError(resp.status_code, resp.text)
+            raise _error_for(resp.status_code, resp.text)
         event: dict = resp.json()
         return event
 
+    def find_event_by_private_property(
+        self, calendar_id: str, key: str, value: str
+    ) -> dict | None:
+        """Return the first LIVE event whose private extended property ``key`` equals ``value``.
+
+        Lets an outbound push ADOPT an event it created earlier (matched by ``canvasApptId``) when the
+        local mapping is missing, instead of inserting a duplicate. ``showDeleted`` is left false so a
+        deleted/cancelled remnant is never adopted — a truly gone event falls through to a fresh insert.
+        """
+        params = {"privateExtendedProperty": f"{key}={value}", "maxResults": "1"}
+        url = self._url(
+            f"/calendars/{self._cal(calendar_id)}/events?{urlencode(params)}"
+        )
+        resp = self._http.get(url, headers=self._headers)
+        if resp.status_code != 200:
+            raise _error_for(resp.status_code, resp.text)
+        items = resp.json().get("items", [])
+        return items[0] if items else None
+
     def list_event_deltas(
-        self, calendar_id: str, sync_token: str = "", time_min: str = "", time_max: str = ""
+        self,
+        calendar_id: str,
+        sync_token: str = "",
+        time_min: str = "",
+        time_max: str = "",
     ) -> tuple[list[dict], str]:
         """Pull changed events, following pagination.
 
@@ -114,10 +177,12 @@ class GoogleCalendarClient:
             if page_token:
                 params["pageToken"] = page_token
 
-            url = self._url(f"/calendars/{self._cal(calendar_id)}/events?{urlencode(params)}")
+            url = self._url(
+                f"/calendars/{self._cal(calendar_id)}/events?{urlencode(params)}"
+            )
             resp = self._http.get(url, headers=self._headers)
             if resp.status_code != 200:
-                raise GoogleApiError(resp.status_code, resp.text)
+                raise _error_for(resp.status_code, resp.text)
 
             payload = resp.json()
             events.extend(payload.get("items", []))
@@ -128,8 +193,46 @@ class GoogleCalendarClient:
 
         return events, next_sync_token
 
+    def list_all_events(
+        self, calendar_id: str, time_min: str, time_max: str
+    ) -> list[dict]:
+        """Return all LIVE events on the calendar in ``[time_min, time_max]`` (paginated).
+
+        Used by the reconcile sweep to find events we pushed whose Canvas appointment is gone/terminal
+        (orphans to delete) or duplicated (extras to collapse). ``showDeleted`` is omitted so
+        already-deleted events aren't re-processed; ``singleEvents`` expands recurrences.
+        """
+        events: list[dict] = []
+        page_token = ""
+        while True:
+            params: dict[str, str] = {
+                "singleEvents": "true",
+                "timeMin": time_min,
+                "timeMax": time_max,
+                "maxResults": "250",
+            }
+            if page_token:
+                params["pageToken"] = page_token
+            url = self._url(
+                f"/calendars/{self._cal(calendar_id)}/events?{urlencode(params)}"
+            )
+            resp = self._http.get(url, headers=self._headers)
+            if resp.status_code != 200:
+                raise _error_for(resp.status_code, resp.text)
+            payload = resp.json()
+            events.extend(payload.get("items", []))
+            page_token = payload.get("nextPageToken", "")
+            if not page_token:
+                break
+        return events
+
     def watch_events(
-        self, calendar_id: str, channel_id: str, address: str, token: str, ttl_seconds: int
+        self,
+        calendar_id: str,
+        channel_id: str,
+        address: str,
+        token: str,
+        ttl_seconds: int,
     ) -> dict:
         """Open an ``events.watch`` push channel. Returns Google's channel resource (``resourceId``)."""
         body = {
@@ -145,7 +248,7 @@ class GoogleCalendarClient:
             headers=self._headers,
         )
         if resp.status_code != 200:
-            raise GoogleApiError(resp.status_code, resp.text)
+            raise _error_for(resp.status_code, resp.text)
         channel: dict = resp.json()
         return channel
 
@@ -157,4 +260,4 @@ class GoogleCalendarClient:
             headers=self._headers,
         )
         if resp.status_code not in (200, 204, 404):
-            raise GoogleApiError(resp.status_code, resp.text)
+            raise _error_for(resp.status_code, resp.text)

--- a/extensions/gcal_sync/gcal_sync/handlers/outbound_backfill.py
+++ b/extensions/gcal_sync/gcal_sync/handlers/outbound_backfill.py
@@ -1,0 +1,25 @@
+"""Frequent, paced drain of the outbound (Canvas -> Google) backfill.
+
+New providers (and any whose real-time pushes were missed) have a large backlog of appointments to
+push into Google. Pushing them all in the daily reconcile hammered individual calendars into Google's
+per-calendar rate limit, and the push path has no backoff, so the throttled writes were dropped —
+which is why most providers never finished backfilling. This cron advances the least-recently-synced
+providers a few at a time, each capped so no calendar is blasted; the tick cadence is the backoff
+(the RestrictedPython sandbox has no ``time`` to sleep with). It is a cheap no-op once every provider
+is fully backfilled. Outbound pushes go straight to Google, so there are no Canvas effects to return.
+"""
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.handlers.cron_task import CronTask
+
+from gcal_sync.reconcile import drain_outbound_backfill
+
+
+class OutboundBackfillDrainCron(CronTask):
+    """Advances the least-recently-synced providers' Canvas->Google push a bounded amount each run."""
+
+    SCHEDULE = "*/2 * * * *"
+
+    def execute(self) -> list[Effect]:
+        drain_outbound_backfill(self.secrets)
+        return []

--- a/extensions/gcal_sync/gcal_sync/handlers/reimport_drain.py
+++ b/extensions/gcal_sync/gcal_sync/handlers/reimport_drain.py
@@ -1,0 +1,23 @@
+"""Drains the fleet re-import queue a few providers at a time.
+
+"Re-import all" enqueues every active provider (a fast, synchronous DB write) and this cron does the
+actual rebuilds — a small batch per tick, each returning its hold effects for Canvas to apply. A
+whole-roster rebuild in one call returns tens of thousands of effects in a single batch that the
+platform can't apply reliably; draining a few providers per tick keeps each returned batch small
+enough to always land, and bounds per-tick memory. The cron is a cheap no-op when the queue is empty.
+"""
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.handlers.cron_task import CronTask
+
+from gcal_sync.reconcile import drain_reimport_queue
+
+
+class ReimportDrainCron(CronTask):
+    """Rebuilds a few queued providers' holds each run until the fleet re-import queue is empty."""
+
+    SCHEDULE = "*/2 * * * *"
+
+    def execute(self) -> list[Effect]:
+        _totals, effects = drain_reimport_queue(self.secrets)
+        return effects

--- a/extensions/gcal_sync/gcal_sync/inbound.py
+++ b/extensions/gcal_sync/gcal_sync/inbound.py
@@ -40,9 +40,64 @@ from gcal_sync.inbound_holds import (
     provider_and_location,
     schedule_event_note_type_id,
 )
-from gcal_sync.google.event_builder import extract_canvas_appt_id, google_event_content_hash
-from gcal_sync.models import AppointmentEventMapping, CalendarSyncState, InboundEventMapping
+from gcal_sync.google.event_builder import (
+    extract_canvas_appt_id,
+    google_event_content_hash,
+)
+from gcal_sync.models import (
+    AppointmentEventMapping,
+    CalendarSyncState,
+    InboundEventMapping,
+    PendingHoldCreate,
+)
 from gcal_sync.sync_service import ClientFactory, SyncService
+
+
+# Cap the dry-run trace so a very large calendar can't bloat the response.
+_MAX_TRACE = 500
+
+
+def _event_line(event: dict) -> str:
+    """A short, non-persisted one-liner for the dry-run preview: when + (masked) title.
+
+    Private/confidential events show the same ``Busy`` placeholder the imported hold would, so a
+    real (PHI-adjacent) title never surfaces even in the preview.
+    """
+    window = parse_event_window(event)
+    when = arrow.get(window[0]).format("ddd MMM DD HH:mm") if window else "(no start)"
+    title = (
+        PRIVATE_EVENT_LABEL if is_private(event) else (event.get("summary") or "Busy")
+    )
+    return f"{when} \u2014 {title[:60]}"
+
+
+def _dry_trace(stats: dict, outcome: str, event: dict) -> None:
+    """Append a preview line to ``stats['trace']`` when a dry run is collecting one (else a no-op)."""
+    trace = stats.get("trace")
+    if trace is None:
+        return
+    if len(trace) < _MAX_TRACE:
+        trace.append(f"{outcome}: {_event_line(event)}")
+    elif len(trace) == _MAX_TRACE:
+        trace.append(f"\u2026 (preview capped at {_MAX_TRACE} events)")
+
+
+def _event_log(
+    verbose: bool, outcome: str, calendar_id: str, provider_id: str | None, gid: str
+) -> None:
+    """Emit a title-free per-event log line — only when ``verbose`` (a single-provider re-import).
+
+    Bulk and steady-state paths pass ``verbose=False`` and log only the per-calendar summary, so a
+    fleet re-import or a routine webhook never floods the logs with one line per event.
+    """
+    if verbose:
+        log.info(
+            "gcal inbound: %s calendar=%s provider=%s event=%s",
+            outcome,
+            calendar_id,
+            provider_id,
+            gid,
+        )
 
 
 class InboundSync:
@@ -70,7 +125,8 @@ class InboundSync:
     ) -> None:
         self._secrets = secrets or {}
         self._sync = SyncService(
-            self._secrets.get("GOOGLE_SERVICE_ACCOUNT_JSON"), client_factory=client_factory
+            self._secrets.get("GOOGLE_SERVICE_ACCOUNT_JSON"),
+            client_factory=client_factory,
         )
         self._client_factory = self._sync._client_factory
         self._ingest_private = ingest_private_events(self._secrets)
@@ -81,7 +137,9 @@ class InboundSync:
         # changes (one InboundSync instance processes calendars sequentially in reconcile).
         self._import_ctx: tuple[str, str | None, str | None, str | None] | None = None
 
-    def _import_context(self, calendar_id: str) -> tuple[str | None, str | None, str | None]:
+    def _import_context(
+        self, calendar_id: str
+    ) -> tuple[str | None, str | None, str | None]:
         """Resolve (note_type_id, provider_id, location_id) for ``calendar_id``, cached per calendar."""
         if self._import_ctx is None or self._import_ctx[0] != calendar_id:
             note_type_id = schedule_event_note_type_id(self._secrets)
@@ -90,23 +148,48 @@ class InboundSync:
             self._import_ctx = (calendar_id, note_type_id, provider_id, location_id)
         return self._import_ctx[1], self._import_ctx[2], self._import_ctx[3]
 
-    def process_calendar(self, calendar_id: str) -> tuple[dict, list[Effect]]:
-        """Pull and apply the delta for ``calendar_id``. Returns ``(stats, effects)``."""
-        state, _ = CalendarSyncState.objects.get_or_create(google_calendar_id=calendar_id)
+    def process_calendar(
+        self,
+        calendar_id: str,
+        force_rebuild: bool = False,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> tuple[dict, list[Effect]]:
+        """Pull and apply the delta for ``calendar_id``. Returns ``(stats, effects)``.
+
+        ``force_rebuild`` is the deliberate admin "Re-import" path: it bypasses the convergence guard
+        so events whose only hold is cancelled are re-created. Every other caller (webhook, reconcile)
+        leaves it ``False`` so the routine steady state can never re-create a cancelled hold.
+
+        ``dry_run`` computes exactly the same create/update/skip decisions but makes NO side effects:
+        no mapping-table writes, no Google writes, and the sync token is not advanced. It also pulls
+        the FULL window (ignoring any stored token) so it previews the same thing a real re-import
+        does — a real re-import clears the token to force a full pull, which dry_run can't persist, so
+        without this a dry run would do a near-empty delta pull and preview almost nothing. The
+        returned effects are what WOULD be applied — the caller inspects ``stats`` and discards them.
+        """
+        state, _ = CalendarSyncState.objects.get_or_create(
+            google_calendar_id=calendar_id
+        )
         client = self._client_factory(calendar_id)
 
-        use_token = state.sync_token and not state.needs_full_resync
+        # A dry run always does a full-window pull (never a delta) so its preview matches a real
+        # re-import; the real re-import gets the full pull by clearing the token, which dry_run won't do.
+        use_token = state.sync_token and not state.needs_full_resync and not dry_run
         stats: dict = {
             "processed": 0,
             "echoes": 0,
             "reverted": 0,
             "holds_created": 0,
             "holds_updated": 0,
+            "holds_unchanged": 0,
             "holds_removed": 0,
             "ignored": 0,
             "full_resync": False,
             "capped": False,
         }
+        if dry_run:
+            stats["trace"] = []
         effects: list[Effect] = []
 
         try:
@@ -118,16 +201,22 @@ class InboundSync:
             )
         except GoogleApiError as exc:
             if exc.status_code == 410:
-                log.warning("syncToken for %s is gone (410); scheduling full resync", calendar_id)
+                log.warning(
+                    "syncToken for %s is gone (410); scheduling full resync",
+                    calendar_id,
+                )
                 state.sync_token = ""
                 state.needs_full_resync = True
-                state.save()
+                if not dry_run:
+                    state.save()
                 stats["full_resync"] = True
                 return stats, effects
             raise
 
         for event in events:
-            effects.extend(self._apply(calendar_id, event, stats))
+            effects.extend(
+                self._apply(calendar_id, event, stats, force_rebuild, dry_run, verbose)
+            )
             if stats["holds_created"] >= self._MAX_HOLDS_PER_RUN:
                 # Circuit breaker: abort without advancing the sync cursor so we don't snowball.
                 log.error(
@@ -138,10 +227,22 @@ class InboundSync:
                 stats["capped"] = True
                 return stats, effects
 
-        if next_token:
-            state.sync_token = next_token
-        state.needs_full_resync = False
-        state.save()
+        if not dry_run:
+            if next_token:
+                state.sync_token = next_token
+            state.needs_full_resync = False
+            state.save()
+        log.info(
+            "gcal inbound %s%s: processed=%s created=%s updated=%s unchanged=%s removed=%s ignored=%s",
+            calendar_id,
+            " (dry-run)" if dry_run else "",
+            stats["processed"],
+            stats["holds_created"],
+            stats["holds_updated"],
+            stats["holds_unchanged"],
+            stats["holds_removed"],
+            stats["ignored"],
+        )
         return stats, effects
 
     def _full_pull_time_min(self) -> str:
@@ -158,126 +259,370 @@ class InboundSync:
             .format("YYYY-MM-DD[T]HH:mm:ss[Z]")
         )
 
-    def _apply(self, calendar_id: str, event: dict, stats: dict) -> list[Effect]:
+    def _apply(
+        self,
+        calendar_id: str,
+        event: dict,
+        stats: dict,
+        force_rebuild: bool = False,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> list[Effect]:
         """Decide and act on a single changed Google event. Returns any Canvas effects to apply."""
         stats["processed"] = stats["processed"] + 1
         appt_id = extract_canvas_appt_id(event)
 
         if appt_id:
-            self._handle_marked_event(calendar_id, appt_id, event, stats)
+            self._handle_marked_event(
+                calendar_id, appt_id, event, stats, dry_run, verbose
+            )
             return []
 
         # Unmarked: a provider-created Google event -> admin-hold territory (Google -> Canvas).
-        return self._handle_unmarked_event(calendar_id, event, stats)
+        return self._handle_unmarked_event(
+            calendar_id, event, stats, force_rebuild, dry_run, verbose
+        )
 
-    def _handle_marked_event(self, calendar_id: str, appt_id: str, event: dict, stats: dict) -> None:
+    def _handle_marked_event(
+        self,
+        calendar_id: str,
+        appt_id: str,
+        event: dict,
+        stats: dict,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> None:
         """An event carrying our canvasApptId stamp — our own push echoing back, or a provider edit."""
-        mapping = AppointmentEventMapping.objects.filter(canvas_appointment_id=appt_id).first()
+        mapping = AppointmentEventMapping.objects.filter(
+            canvas_appointment_id=appt_id
+        ).first()
         if mapping is None:
             stats["ignored"] = stats["ignored"] + 1
             return
 
-        if event.get("status") != "cancelled" and google_event_content_hash(event) == mapping.last_pushed_hash:
+        if (
+            event.get("status") != "cancelled"
+            and google_event_content_hash(event) == mapping.last_pushed_hash
+        ):
             stats["echoes"] = stats["echoes"] + 1
             return
 
         # Genuine provider-side change to a Canvas appointment: revert to Canvas truth (Canvas wins).
+        _dry_trace(stats, "would re-push Canvas appointment", event)
+        _event_log(verbose, "re-push Canvas appointment", calendar_id, "", appt_id)
+        stats["reverted"] = stats["reverted"] + 1
+        if dry_run:
+            return
         result = build_snapshot(appt_id)
         if result is None:
             self._sync.remove(appt_id)
         else:
             snapshot, _provider_id, _is_schedule_event = result
             self._sync.push(calendar_id, snapshot)
-        stats["reverted"] = stats["reverted"] + 1
 
-    def _handle_unmarked_event(self, calendar_id: str, event: dict, stats: dict) -> list[Effect]:
+    def _handle_unmarked_event(
+        self,
+        calendar_id: str,
+        event: dict,
+        stats: dict,
+        force_rebuild: bool = False,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> list[Effect]:
         """A provider-created Google event -> create/update/delete the corresponding Canvas hold."""
         google_event_id = event.get("id")
         if not google_event_id:
             stats["ignored"] = stats["ignored"] + 1
             return []
 
-        existing = InboundEventMapping.objects.filter(google_event_id=google_event_id).first()
+        # Resolve this calendar's provider up front so every hold lookup below is scoped to it. A
+        # shared multi-attendee Google event carries the SAME id on every attendee's calendar, so an
+        # unscoped lookup finds another provider's hold and wrongly skips this one — the reason a
+        # provider's shared meetings never imported. (Note type / location come from the same cached
+        # resolve and are reused by the create path.)
+        note_type_id, provider_id, location_id = self._import_context(calendar_id)
+
+        # InboundEventMapping holds the last-applied content hash for the no-op guard. It is unique per
+        # google_event_id (shared across a shared event's attendees), which is fine for a content hash
+        # (identical on every calendar). Scope the read to this calendar so a row owned by another
+        # attendee doesn't feed this provider a stale hash.
+        existing = InboundEventMapping.objects.filter(
+            google_event_id=google_event_id, google_calendar_id=calendar_id
+        ).first()
+        # PendingHoldCreate is the per-(calendar, event) "create in flight" marker. Unlike the shared
+        # InboundEventMapping row, it is keyed per calendar, so a co-attendee's calendar can't clobber
+        # this one — which is what stops a webhook replay from minting a second hold for this provider
+        # while the create is still applying.
+        pending = PendingHoldCreate.objects.filter(
+            google_event_id=google_event_id, google_calendar_id=calendar_id
+        ).first()
         status = event.get("status")
 
         if status == "cancelled":
-            if existing is None:
-                stats["ignored"] = stats["ignored"] + 1
-                return []
-            effect = self._hold_delete_effect(google_event_id)
-            existing.delete()
-            stats["holds_removed"] = stats["holds_removed"] + 1
-            return [effect] if effect else []
-
-        # A mapping row alone does NOT prove a Canvas hold exists: the create effect is applied
-        # asynchronously, so a run that was interrupted or hit the safety cap can leave a mapping
-        # with no appointment behind it. Only take the UPDATE path when a live hold actually
-        # exists; otherwise fall through and (re)create it so partial prior runs self-heal.
-        if existing is not None and self._canvas_id_for_google_event(google_event_id) is not None:
-            effect = self._hold_update_effect(google_event_id, event)
+            # Remove only THIS provider's hold for the event (scoped); another attendee's hold for the
+            # same shared event id is left untouched.
+            effect = self._hold_delete_effect(google_event_id, provider_id)
+            if not dry_run:
+                if existing is not None:
+                    existing.delete()
+                # Clear this calendar's pending marker so a later legitimate re-create of the event
+                # isn't wrongly treated as still-in-flight.
+                if pending is not None:
+                    pending.delete()
             if effect is None:
                 stats["ignored"] = stats["ignored"] + 1
                 return []
+            _dry_trace(stats, "would remove hold", event)
+            _event_log(
+                verbose, "remove hold", calendar_id, provider_id, google_event_id
+            )
+            stats["holds_removed"] = stats["holds_removed"] + 1
+            return [effect]
+
+        # Bounded window. A delta pull (any calendar with a sync token) carries no ``timeMax``, so
+        # Google's ``singleEvents`` expansion returns a recurring event's instances with NO upper
+        # bound (we have imported instances dated to year 2099). The full-pull window is only applied
+        # on the FIRST pull; this per-event guard is what actually keeps recurring expansion bounded
+        # on every subsequent delta. Deletes are handled above so a hold that drifts out of window
+        # can still be removed.
+        if not self._within_import_window(event):
+            _dry_trace(stats, "skip (outside 6-month import window)", event)
+            _event_log(
+                verbose,
+                "skip (outside import window)",
+                calendar_id,
+                provider_id,
+                google_event_id,
+            )
+            stats["ignored"] = stats["ignored"] + 1
+            return []
+
+        # A live Canvas hold already exists for this event -> update it in place, never create a
+        # second one. Keyed on the external id (Canvas's own record), so this holds even if the
+        # ``InboundEventMapping`` row was lost — a mapping-less live hold used to fall through to
+        # create and duplicate.
+        if self._canvas_id_for_google_event(google_event_id, provider_id) is not None:
+            # No-op guard: a delta routinely re-delivers unchanged events, and a webhook that times
+            # out before advancing the sync token makes the SAME delta re-pull on every ping. Re-issuing
+            # an UPDATE for a hold whose content hasn't moved re-saves its appointment row for nothing —
+            # a large share of the appointment-table write load. Skip when the content hash matches what
+            # we last applied (mirrors the outbound push's change-only guard).
+            new_hash = google_event_content_hash(event)
+            # A live hold can exist without a mapping row (the mapping is only advisory here), so read
+            # the last-applied hash defensively — no mapping means "nothing applied yet" -> update.
+            last_applied = (
+                existing.last_applied_hash if existing is not None else ""
+            ) or ""
+            if new_hash == last_applied:
+                _dry_trace(stats, "already current (no change)", event)
+                _event_log(
+                    verbose,
+                    "already current (no change)",
+                    calendar_id,
+                    provider_id,
+                    google_event_id,
+                )
+                stats["holds_unchanged"] = stats["holds_unchanged"] + 1
+                return []
+            effect = self._hold_update_effect(google_event_id, event, provider_id)
+            if effect is None:
+                stats["ignored"] = stats["ignored"] + 1
+                return []
+            # Record the applied hash so an unchanged re-delivery is recognized next time. Upsert (not
+            # filter().update()) so a mapping-less live hold gets its row (re)created and the no-op
+            # guard self-heals.
+            if not dry_run:
+                InboundEventMapping.objects.update_or_create(
+                    google_event_id=google_event_id,
+                    defaults={
+                        "google_calendar_id": calendar_id,
+                        "last_applied_hash": new_hash,
+                    },
+                )
+            _dry_trace(stats, "would update hold", event)
+            _event_log(
+                verbose, "update hold", calendar_id, provider_id, google_event_id
+            )
             stats["holds_updated"] = stats["holds_updated"] + 1
             return [effect]
 
-        # Mapping exists but no live hold (the update branch above didn't fire). The create is
-        # applied asynchronously, so a recently-recorded mapping is a create still in flight —
-        # re-issuing it is what produced duplicate holds under load. Skip while pending; only fall
-        # through to re-create once the mapping predates the grace window (a genuine orphan).
-        if existing is not None:
-            created_at = getattr(existing, "created_at", None)
+        # Convergence guard: a hold was already created for this event but is no longer live — it was
+        # cancelled, either because Google deleted the event (handled above on a later delta) or
+        # because the purge drained it. ``ScheduleEvent`` has no revive, so re-creating it is exactly
+        # the create -> cancel -> re-create loop that minted 260k cancelled duplicate holds. One
+        # Google event maps to at most one Canvas hold for its whole life: leave the cancelled hold
+        # cancelled and do not mint another — unless this is a deliberate rebuild (admin re-import),
+        # which explicitly wants a drained provider's holds recreated.
+        if not force_rebuild and self._external_hold_exists(
+            google_event_id, provider_id
+        ):
+            _dry_trace(
+                stats,
+                "skip (prior hold for this provider was cancelled/drained)",
+                event,
+            )
+            _event_log(
+                verbose,
+                "skip (convergence: prior hold cancelled/drained)",
+                calendar_id,
+                provider_id,
+                google_event_id,
+            )
+            stats["ignored"] = stats["ignored"] + 1
+            return []
+
+        # No live hold exists for this (provider, event). A pending marker for THIS calendar means the
+        # create is applied asynchronously and still in flight — re-issuing within the grace window is
+        # what produced duplicate holds under load. Skip while pending; only fall through to (re)create
+        # once the marker predates the grace window (a genuine orphan whose create never applied) so
+        # partial prior runs self-heal. The marker is per (calendar, event), so a co-attendee syncing
+        # the same shared event can't clear it out from under this provider.
+        if pending is not None:
+            created_at = getattr(pending, "created_at", None)
             if created_at is None or (
                 (arrow.utcnow() - arrow.get(created_at)).total_seconds()
                 < self._PENDING_CREATE_GRACE_SECONDS
             ):
+                _dry_trace(stats, "skip (create already in flight)", event)
+                _event_log(
+                    verbose,
+                    "skip (create in flight)",
+                    calendar_id,
+                    provider_id,
+                    google_event_id,
+                )
                 stats["ignored"] = stats["ignored"] + 1
                 return []
 
         # Brand-new Google event (or a genuine orphan past the grace window) -> create a Canvas
         # admin hold, subject to the org's import filters.
         if is_all_day(event) and not self._ingest_all_day:
+            _dry_trace(stats, "skip (all-day event, not imported)", event)
+            _event_log(
+                verbose,
+                "skip (all-day event)",
+                calendar_id,
+                provider_id,
+                google_event_id,
+            )
             stats["ignored"] = stats["ignored"] + 1
             return []
         if is_private(event) and not self._ingest_private:
+            _dry_trace(stats, "skip (private event, not imported)", event)
+            _event_log(
+                verbose,
+                "skip (private event)",
+                calendar_id,
+                provider_id,
+                google_event_id,
+            )
             stats["ignored"] = stats["ignored"] + 1
             return []
 
-        note_type_id, provider_id, location_id = self._import_context(calendar_id)
         effect = build_hold_effect(event, note_type_id, provider_id, location_id)
         if effect is None:
+            _dry_trace(
+                stats,
+                "skip (could not build hold: unparseable time / no note type)",
+                event,
+            )
+            _event_log(
+                verbose,
+                "skip (could not build hold)",
+                calendar_id,
+                provider_id,
+                google_event_id,
+            )
             stats["ignored"] = stats["ignored"] + 1
             return []
-        # Record synchronously so a re-delivered webhook doesn't import it twice. Upsert rather than
-        # create: an orphaned mapping row for this event id may already exist (google_event_id is
-        # unique), and re-creating the hold must not collide with it.
-        InboundEventMapping.objects.update_or_create(
-            google_event_id=google_event_id,
-            defaults={"google_calendar_id": calendar_id},
-        )
+        # Record synchronously so a re-delivered webhook doesn't import it twice. The per-(calendar,
+        # event) PendingHoldCreate marker is the dedup that must not be clobbered by a co-attendee's
+        # calendar; its created_at is refreshed each attempt so a past-grace re-create gets a fresh
+        # window. InboundEventMapping stores the content hash for the no-op guard (event id unique;
+        # the hash is identical across a shared event's attendees, so a shared row is fine).
+        if not dry_run:
+            PendingHoldCreate.objects.update_or_create(
+                google_event_id=google_event_id,
+                google_calendar_id=calendar_id,
+                defaults={"created_at": arrow.utcnow().datetime},
+            )
+            InboundEventMapping.objects.update_or_create(
+                google_event_id=google_event_id,
+                defaults={
+                    "google_calendar_id": calendar_id,
+                    "last_applied_hash": google_event_content_hash(event),
+                },
+            )
+        _dry_trace(stats, "would import hold", event)
+        _event_log(verbose, "create hold", calendar_id, provider_id, google_event_id)
         stats["holds_created"] = stats["holds_created"] + 1
         return [effect]
 
+    def _within_import_window(self, event: dict) -> bool:
+        """Is this event's start within the same ``[now-1mo, now+6mo]`` window a full pull uses?
+
+        Returns ``True`` when the start can't be parsed (let downstream ignore it), so this only ever
+        *excludes* an event whose start is legibly outside the window — the guard against a recurring
+        series expanding without bound on token-based delta pulls (which send no ``timeMax``).
+        """
+        window = parse_event_window(event)
+        if window is None:
+            return True
+        start = arrow.get(window[0])
+        lower = arrow.utcnow().shift(months=self._FULL_PULL_TIME_MIN_SHIFT_MONTHS)
+        upper = arrow.utcnow().shift(months=self._FULL_PULL_TIME_MAX_SHIFT_MONTHS)
+        return lower <= start <= upper
+
     @staticmethod
-    def _canvas_id_for_google_event(google_event_id: str) -> str | None:
-        """Resolve the Canvas record id for an imported Google event via its external identifier."""
+    def _canvas_id_for_google_event(
+        google_event_id: str, provider_id: str | None
+    ) -> str | None:
+        """Resolve THIS provider's *live* Canvas hold id for a Google event via its external identifier.
+
+        Scoped to ``provider_id`` because a shared multi-attendee event carries the same id on every
+        attendee's calendar: an unscoped lookup would return another provider's hold and wrongly route
+        this provider's import into the update path. Excludes cancelled appointments, so this answers
+        "is there a live hold to UPDATE for this provider?" — not "was one ever created" (that is
+        :meth:`_external_hold_exists`).
+        """
         canvas_id = (
             AppointmentExternalIdentifier.objects.filter(
-                system=GOOGLE_ORIGIN_SYSTEM, value=google_event_id
+                system=GOOGLE_ORIGIN_SYSTEM,
+                value=google_event_id,
+                appointment__provider__id=provider_id,
             )
+            .exclude(appointment__status="cancelled")
             .values_list("appointment__id", flat=True)
             .first()
         )
         return str(canvas_id) if canvas_id else None
 
-    def _hold_delete_effect(self, google_event_id: str) -> Effect | None:
-        canvas_id = self._canvas_id_for_google_event(google_event_id)
+    @staticmethod
+    def _external_hold_exists(google_event_id: str, provider_id: str | None) -> bool:
+        """Has a hold ever been created FOR THIS PROVIDER for this Google event (any status)?
+
+        The convergence backstop, scoped per provider: one (provider, Google event) → at most one
+        Canvas hold for its whole life. Scoping is what lets each attendee of a shared event get their
+        own hold instead of all-but-the-first being skipped.
+        """
+        return AppointmentExternalIdentifier.objects.filter(
+            system=GOOGLE_ORIGIN_SYSTEM,
+            value=google_event_id,
+            appointment__provider__id=provider_id,
+        ).exists()
+
+    def _hold_delete_effect(
+        self, google_event_id: str, provider_id: str | None
+    ) -> Effect | None:
+        canvas_id = self._canvas_id_for_google_event(google_event_id, provider_id)
         if not canvas_id:
             return None
         return ScheduleEvent(instance_id=str(canvas_id)).delete()
 
-    def _hold_update_effect(self, google_event_id: str, event: dict) -> Effect | None:
-        canvas_id = self._canvas_id_for_google_event(google_event_id)
+    def _hold_update_effect(
+        self, google_event_id: str, event: dict, provider_id: str | None
+    ) -> Effect | None:
+        canvas_id = self._canvas_id_for_google_event(google_event_id, provider_id)
         if not canvas_id:
             return None
         window = parse_event_window(event)

--- a/extensions/gcal_sync/gcal_sync/models/__init__.py
+++ b/extensions/gcal_sync/gcal_sync/models/__init__.py
@@ -20,6 +20,7 @@ from django.db.models import (
     BooleanField,
     DateTimeField,
     Index,
+    IntegerField,
     TextField,
     UniqueConstraint,
 )
@@ -40,6 +41,10 @@ class StaffCalendarMapping(CustomModel):
     active = BooleanField(default=True)
     created_at = DateTimeField(auto_now_add=True)
     updated_at = DateTimeField(auto_now=True)
+    # When the outbound reconcile last finished pushing this provider's whole window. The bounded
+    # reconcile orders providers by this (nulls first) so a capped run rotates across the fleet and
+    # successive runs converge — the outbound analog of ``CalendarSyncState`` for inbound full pulls.
+    last_outbound_synced_at = DateTimeField(null=True)
 
     class Meta:
         constraints = [
@@ -97,16 +102,52 @@ class InboundEventMapping(CustomModel):
     Written synchronously the moment we decide to create a Canvas schedule event, so a re-delivered
     webhook for the same Google event is recognised and not imported twice (the Canvas create effect
     is applied asynchronously, so we can't rely on querying Canvas to dedup in the same request).
+
+    ``last_applied_hash`` is the content hash of the event we last wrote to the hold; an inbound delta
+    whose hash still matches is skipped, so an unchanged re-delivery doesn't re-save the appointment
+    row (mirrors ``AppointmentEventMapping.last_pushed_hash`` on the outbound side).
     """
 
     google_calendar_id = TextField()
     google_event_id = TextField()
     canvas_appointment_id = TextField(default="")
+    last_applied_hash = TextField(default="")
     created_at = DateTimeField(auto_now_add=True)
 
     class Meta:
         constraints = [
             UniqueConstraint(fields=["google_event_id"], name="uq_inbound_event"),
+        ]
+
+
+class PendingHoldCreate(CustomModel):
+    """Per-(calendar, event) marker that a hold create was issued and may still be applying.
+
+    The ``ScheduleEvent`` create is applied asynchronously, so for a short window after we decide to
+    create a hold there is no queryable Canvas hold yet. A re-delivered webhook for the SAME calendar
+    within that window must not re-issue the create (doing so duplicated holds under load).
+
+    This is deliberately keyed on ``(google_event_id, google_calendar_id)`` — NOT on the event id
+    alone like ``InboundEventMapping``. A shared multi-attendee event is one event id across every
+    attendee's calendar, so a single shared row (owned by whichever calendar wrote last) can't mark a
+    create as pending for one attendee without un-marking it for another — the gap that let a replay
+    mint a second hold for that attendee. A row per (calendar, event) gives each attendee its own
+    marker that no other calendar can clobber, closing the cross-calendar re-create race.
+
+    ``created_at`` is set explicitly (not ``auto_now_add``) so a past-grace re-create refreshes the
+    window rather than being pinned to the first attempt.
+    """
+
+    google_calendar_id = TextField()
+    google_event_id = TextField()
+    created_at = DateTimeField(null=True)
+
+    class Meta:
+        constraints = [
+            UniqueConstraint(
+                fields=["google_event_id", "google_calendar_id"],
+                name="uq_pending_hold_cal_event",
+            ),
         ]
 
 
@@ -127,6 +168,34 @@ class CalendarEventMapping(CustomModel):
     class Meta:
         constraints = [
             UniqueConstraint(fields=["canvas_event_id"], name="uq_calevt_event"),
+        ]
+
+
+class ReimportQueue(CustomModel):
+    """One pending "rebuild this provider's holds" work item for the fleet re-import drain.
+
+    "Re-import all" enqueues one row per active provider, and ``ReimportDrainCron`` pops a few per
+    tick and re-imports them, deleting each row when its provider is done. A whole-roster rebuild in
+    one call returns tens of thousands of hold effects in a single batch, which the platform doesn't
+    apply reliably (the returned effects cross a gRPC message size ceiling and the whole batch is
+    lost). Draining a few providers per cron tick keeps each returned batch small enough to always
+    apply, and bounds per-tick memory so the worker never grows unbounded.
+
+    Keyed unique on ``google_calendar_id`` so enqueuing is idempotent — clicking "Re-import all"
+    twice, or while a drain is mid-flight, never doubles a provider's work item. ``attempts`` bounds
+    retries so a provider whose calendar keeps erroring is dropped from the queue instead of wedging
+    the drain forever.
+    """
+
+    google_calendar_id = TextField()
+    attempts = IntegerField(default=0)
+    enqueued_at = DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            UniqueConstraint(
+                fields=["google_calendar_id"], name="uq_reimportqueue_cal"
+            ),
         ]
 
 
@@ -153,11 +222,33 @@ class WatchChannel(CustomModel):
         ]
 
 
+class ProviderSyncLock(CustomModel):
+    """A short-lived exclusivity lock for the per-provider admin actions (Reconcile / Re-import).
+
+    The admin buttons run synchronously and can land on different plugin-runner containers, so two
+    clicks race. Acquiring is atomic via the unique ``google_calendar_id`` constraint — a duplicate
+    insert raises ``IntegrityError``, which the caller treats as "already running". ``acquired_at``
+    lets a stale lock (a run that died before releasing) be reclaimed after a timeout so a provider
+    never wedges permanently.
+    """
+
+    google_calendar_id = TextField()
+    acquired_at = DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            UniqueConstraint(fields=["google_calendar_id"], name="uq_synclock_cal"),
+        ]
+
+
 __all__ = [
     "AppointmentEventMapping",
     "CalendarEventMapping",
     "CalendarSyncState",
     "InboundEventMapping",
+    "PendingHoldCreate",
+    "ProviderSyncLock",
+    "ReimportQueue",
     "StaffCalendarMapping",
     "WatchChannel",
 ]

--- a/extensions/gcal_sync/gcal_sync/reconcile.py
+++ b/extensions/gcal_sync/gcal_sync/reconcile.py
@@ -5,6 +5,7 @@ call exactly the same code path.
 """
 
 import arrow
+from django.db import IntegrityError
 from requests import RequestException
 
 from canvas_sdk.effects import Effect
@@ -20,13 +21,53 @@ from gcal_sync.appointment_snapshot import (
 from gcal_sync.blocks import sync_all_blocks
 from gcal_sync.channels import ChannelConfigError
 from gcal_sync.google.auth import GoogleAuthError
-from gcal_sync.google.client import GoogleApiError
+from gcal_sync.google.client import GoogleApiError, GoogleRateLimitError
 from gcal_sync.inbound import InboundSync
-from gcal_sync.models import CalendarSyncState, InboundEventMapping, StaffCalendarMapping
+from gcal_sync.models import (
+    AppointmentEventMapping,
+    CalendarSyncState,
+    InboundEventMapping,
+    PendingHoldCreate,
+    ProviderSyncLock,
+    ReimportQueue,
+    StaffCalendarMapping,
+)
 from gcal_sync.sync_service import SyncService
 
 # Statuses that mean "not on the books" — handled by delete events, never reconciled as upserts.
 _TERMINAL_STATUSES = {"cancelled", "noshowed"}
+
+# A per-provider admin action (Reconcile / Re-import) holds this lock so a double-click or a second
+# admin can't run the same provider concurrently (the buttons run synchronously and can land on
+# different plugin-runner containers). A lock older than the TTL is stale — a run that died before
+# releasing — and is reclaimed so a provider never wedges.
+_PROVIDER_LOCK_TTL_MINUTES = 15
+
+
+def acquire_provider_lock(calendar_id: str) -> bool:
+    """Atomically claim the per-provider action lock. Returns ``False`` if one is already held.
+
+    Acquisition is atomic via the unique ``google_calendar_id`` constraint: a duplicate insert
+    raises ``IntegrityError``, which means someone else holds it. A lock past the TTL is reclaimed
+    first so a crashed run doesn't wedge the provider forever.
+    """
+    ProviderSyncLock.objects.filter(
+        google_calendar_id=calendar_id,
+        acquired_at__lt=arrow.utcnow()
+        .shift(minutes=-_PROVIDER_LOCK_TTL_MINUTES)
+        .datetime,
+    ).delete()
+    try:
+        ProviderSyncLock.objects.create(google_calendar_id=calendar_id)
+        return True
+    except IntegrityError:
+        return False
+
+
+def release_provider_lock(calendar_id: str) -> None:
+    """Release the per-provider action lock (safe to call even if it was already reclaimed)."""
+    ProviderSyncLock.objects.filter(google_calendar_id=calendar_id).delete()
+
 
 # A first-time / recovery full pull imports a provider's whole 6-month window at once (hundreds of
 # holds). Bound how many run in a single reconcile so the bulk path — the nightly cron AND the
@@ -34,6 +75,61 @@ _TERMINAL_STATUSES = {"cancelled", "noshowed"}
 # in one pass. Cheap delta pulls (calendars with a live sync token) are NEVER capped; deferred full
 # pulls are picked up by later runs, least-recently-synced first, so coverage rotates and completes.
 _MAX_FULL_PULLS_PER_RUN = 5
+
+# Outbound backfill is bounded per run so one reconcile can't monopolise a worker for hours (or get
+# killed mid-run). The idempotent, change-only push makes re-runs safe and resumable: an already
+# synced appointment is skipped for free, so successive runs advance through the backlog. Providers
+# are processed least-recently-synced first (``last_outbound_synced_at``) so a capped run rotates.
+_MAX_OUTBOUND_PUSHES_PER_RUN = 2000
+
+# The fleet reconcile enumerates a provider's Google calendar to remove orphaned/duplicate events.
+# That is one full calendar listing per provider, so only this many providers are swept per fleet
+# run (least-recently-synced first); the rest rotate in on later runs. A single-provider admin
+# reconcile always sweeps that provider. Deletes are additionally capped for a small blast radius.
+_MAX_SWEEP_CALENDARS_PER_RUN = 10
+_MAX_SWEEP_DELETES_PER_CALENDAR = 500
+
+
+def _outbound_window() -> tuple:
+    """The [-1 month, +1 year] window the outbound sync maintains, as arrow objects."""
+    return arrow.utcnow().shift(months=-1), arrow.utcnow().shift(years=1)
+
+
+def _rfc3339(when) -> str:
+    return when.format("YYYY-MM-DD[T]HH:mm:ss[Z]")
+
+
+def _google_origin_ids() -> set:
+    """Appointment ids we imported FROM Google — never pushed back (loop suppression). One query."""
+    return set(
+        AppointmentExternalIdentifier.objects.filter(
+            system=GOOGLE_ORIGIN_SYSTEM
+        ).values_list("appointment__id", flat=True)
+    )
+
+
+def _pushable_appointments(
+    mapping, window_start, window_end, google_origin_ids: set
+) -> list[dict]:
+    """The provider's appointments that should each have exactly one Google event in the window."""
+    appts = Appointment.objects.filter(
+        provider__id=mapping.canvas_staff_id,
+        entered_in_error__isnull=True,
+        start_time__gte=window_start,
+        start_time__lte=window_end,
+    ).values(*APPOINTMENT_FIELDS)
+    return [
+        appt
+        for appt in appts
+        if appt.get("status") not in _TERMINAL_STATUSES
+        and appt.get("id") not in google_origin_ids
+    ]
+
+
+def _outbound_priority(mapping) -> tuple:
+    """Sort key: providers never fully synced (null) first, then least-recently-synced."""
+    ts = getattr(mapping, "last_outbound_synced_at", None)
+    return (0, 0.0) if ts is None else (1, ts.timestamp())
 
 
 def _needs_full_pull(state: CalendarSyncState | None) -> bool:
@@ -75,7 +171,10 @@ def inbound_recovery(
     if deferred:
         log.info(
             "Reconcile: %s delta pull(s), %s full pull(s) this run, %s full pull(s) deferred (cap %s).",
-            len(delta_ids), len(selected_full), deferred, max_full_pulls,
+            len(delta_ids),
+            len(selected_full),
+            deferred,
+            max_full_pulls,
         )
 
     effects: list = []
@@ -83,43 +182,83 @@ def inbound_recovery(
         try:
             _stats, calendar_effects = inbound.process_calendar(calendar_id)
             effects.extend(calendar_effects)
-        except (GoogleApiError, GoogleAuthError, RequestException, ChannelConfigError) as exc:
+        except (
+            GoogleApiError,
+            GoogleAuthError,
+            RequestException,
+            ChannelConfigError,
+        ) as exc:
             log.error("Reconcile inbound pull failed for %s: %s", calendar_id, exc)
     return effects
 
 
-def outbound_truth(secrets: dict, mappings: list) -> int:
-    """Re-push every upcoming, non-cancelled Canvas appointment for each enrolled provider.
+def outbound_truth(
+    secrets: dict,
+    mappings: list,
+    max_pushes: int | None = None,
+    skip_mapped: bool = False,
+) -> int:
+    """Push every upcoming, non-terminal Canvas appointment for each enrolled provider to Google.
 
-    Returns the number of appointments successfully pushed.
+    Bounded and resumable: ``max_pushes`` caps the push *attempts* per run (``None`` = unbounded, e.g.
+    a single-provider admin reconcile). Providers are processed least-recently-synced first, and a
+    provider is stamped ``last_outbound_synced_at`` only once its whole window is processed — so a
+    capped run rotates across the fleet and successive runs converge. The change-only guard makes an
+    already-synced appointment a cheap no-op (no Google call), so re-running is safe.
+
+    ``skip_mapped`` (the backfill drain) drops appointments that already have a mapping BEFORE the cap
+    applies, so the budget is spent only on never-pushed appointments (real inserts). Without it, a
+    small per-provider cap gets consumed re-checking a provider's already-synced prefix and never
+    reaches the un-pushed tail — a provider with more synced appointments than the cap can't advance.
+    Changed/deleted already-mapped events still re-push via the (uncapped-enough) daily reconcile,
+    which leaves ``skip_mapped`` off. Returns push attempts performed.
     """
     sync = SyncService(secrets.get("GOOGLE_SERVICE_ACCOUNT_JSON"))
-    window_start = arrow.utcnow().shift(months=-1).datetime
-    window_end = arrow.utcnow().shift(years=1).datetime
-
-    # Records we imported from Google must not be pushed back (loop suppression). One query.
-    google_origin_ids = set(
-        AppointmentExternalIdentifier.objects.filter(system=GOOGLE_ORIGIN_SYSTEM).values_list(
-            "appointment__id", flat=True
-        )
-    )
+    start, end = _outbound_window()
+    google_origin_ids = _google_origin_ids()
 
     total_pushed = 0
-    for mapping in mappings:
-        appts = Appointment.objects.filter(
-            provider__id=mapping.canvas_staff_id,
-            entered_in_error__isnull=True,
-            start_time__gte=window_start,
-            start_time__lte=window_end,
-        ).values(*APPOINTMENT_FIELDS)
-        for appt in appts:
-            if appt.get("status") in _TERMINAL_STATUSES:
-                continue
-            if appt.get("id") in google_origin_ids:
-                continue
+    for mapping in sorted(mappings, key=_outbound_priority):
+        if max_pushes is not None and total_pushed >= max_pushes:
+            break
+        pushable = _pushable_appointments(
+            mapping, start.datetime, end.datetime, google_origin_ids
+        )
+        # Prefetch this provider's mappings in ONE query so the per-appointment push does no lookup
+        # of its own (avoids an N+1 a busy provider would pay on every reconcile).
+        mapping_cache = {
+            m.canvas_appointment_id: m
+            for m in AppointmentEventMapping.objects.filter(
+                canvas_appointment_id__in=[str(appt["id"]) for appt in pushable]
+            )
+        }
+        if skip_mapped:
+            # Backfill only: push never-mapped appointments so the cap measures real inserts, not
+            # no-op re-checks of the already-synced prefix (which would otherwise wedge the drain).
+            pushable = [a for a in pushable if str(a["id"]) not in mapping_cache]
+        completed = True
+        for appt in pushable:
+            if max_pushes is not None and total_pushed >= max_pushes:
+                completed = False  # ran out of budget mid-provider -> retry it next run
+                break
             try:
-                sync.push(mapping.google_calendar_id, snapshot_from_values(appt))
+                sync.push(
+                    mapping.google_calendar_id,
+                    snapshot_from_values(appt),
+                    mapping_cache,
+                )
                 total_pushed += 1
+            except GoogleRateLimitError:
+                # Google is throttling THIS calendar. Stop pushing it now rather than hammering it
+                # (and dropping the writes as errors) — leave it incomplete so it is retried on a
+                # later run. The sandbox can't sleep, so the run cadence is the backoff. Move on to
+                # the next provider, which is a different calendar with its own per-user limit.
+                completed = False
+                log.info(
+                    "Reconcile push throttled on %s — deferring rest to next run",
+                    mapping.google_calendar_id,
+                )
+                break
             except (GoogleApiError, GoogleAuthError, RequestException) as exc:
                 log.error(
                     "Reconcile push failed for appt %s -> %s: %s",
@@ -127,10 +266,61 @@ def outbound_truth(secrets: dict, mappings: list) -> int:
                     mapping.google_calendar_id,
                     exc,
                 )
+        if completed and hasattr(mapping, "last_outbound_synced_at"):
+            mapping.last_outbound_synced_at = arrow.utcnow().datetime
+            try:
+                mapping.save()
+            except Exception:
+                # Bookkeeping only — never let a failed timestamp save abort the reconcile.
+                log.exception(
+                    "Could not record last_outbound_synced_at for %s",
+                    mapping.canvas_staff_id,
+                )
     return total_pushed
 
 
-def reconcile_provider(secrets: dict, mapping: StaffCalendarMapping) -> tuple[dict, list]:
+def sweep_outbound(
+    secrets: dict, mappings: list, max_calendars: int | None = None
+) -> int:
+    """Remove orphaned/duplicate Google events for the given providers. Returns events deleted.
+
+    Enumerates each provider's calendar (one listing per provider), so the fleet run only sweeps the
+    ``max_calendars`` least-recently-synced providers per run — the rest rotate in later. A
+    single-provider admin reconcile passes ``None`` to always sweep that one provider.
+    """
+    sync = SyncService(secrets.get("GOOGLE_SERVICE_ACCOUNT_JSON"))
+    start, end = _outbound_window()
+    start_rfc, end_rfc = _rfc3339(start), _rfc3339(end)
+    google_origin_ids = _google_origin_ids()
+
+    selected = sorted(mappings, key=_outbound_priority)
+    if max_calendars is not None:
+        selected = selected[:max_calendars]
+
+    total_deleted = 0
+    for mapping in selected:
+        pushable = _pushable_appointments(
+            mapping, start.datetime, end.datetime, google_origin_ids
+        )
+        live_ids = {str(appt["id"]) for appt in pushable}
+        try:
+            total_deleted += sync.sweep_calendar(
+                mapping.google_calendar_id,
+                live_ids,
+                start_rfc,
+                end_rfc,
+                _MAX_SWEEP_DELETES_PER_CALENDAR,
+            )
+        except (GoogleApiError, GoogleAuthError, RequestException) as exc:
+            log.error(
+                "Reconcile sweep failed for %s: %s", mapping.google_calendar_id, exc
+            )
+    return total_deleted
+
+
+def reconcile_provider(
+    secrets: dict, mapping: StaffCalendarMapping
+) -> tuple[dict, list]:
     """Reconcile a SINGLE provider (inbound delta + change-only outbound push + block sweep).
 
     Per-provider so the admin button never does all providers in one request (chunking for scale).
@@ -140,13 +330,30 @@ def reconcile_provider(secrets: dict, mapping: StaffCalendarMapping) -> tuple[di
     try:
         _stats, calendar_effects = inbound.process_calendar(mapping.google_calendar_id)
         effects.extend(calendar_effects)
-    except (GoogleApiError, GoogleAuthError, RequestException, ChannelConfigError) as exc:
-        log.error("Reconcile (provider) inbound failed for %s: %s", mapping.google_calendar_id, exc)
+    except (
+        GoogleApiError,
+        GoogleAuthError,
+        RequestException,
+        ChannelConfigError,
+    ) as exc:
+        log.error(
+            "Reconcile (provider) inbound failed for %s: %s",
+            mapping.google_calendar_id,
+            exc,
+        )
 
     pushed = outbound_truth(secrets, [mapping])
+    # Single-provider admin reconcile: always sweep this provider's calendar for orphaned/duplicate
+    # events (max_calendars=None), the thorough per-provider cleanup an admin reaches for.
+    swept = sweep_outbound(secrets, [mapping], max_calendars=None)
     blocks = sync_all_blocks(secrets, [mapping])
     return (
-        {"pushed": pushed, "blocks_pushed": blocks["pushed"], "blocks_deleted": blocks["deleted"]},
+        {
+            "pushed": pushed,
+            "swept": swept,
+            "blocks_pushed": blocks["pushed"],
+            "blocks_deleted": blocks["deleted"],
+        },
         effects,
     )
 
@@ -169,30 +376,293 @@ def reset_inbound_for_provider(mapping: StaffCalendarMapping) -> list[Effect]:
         .values_list("appointment__id", flat=True)
         .distinct()
     )
-    effects: list[Effect] = [ScheduleEvent(instance_id=str(i)).delete() for i in hold_ids]
-    InboundEventMapping.objects.filter(google_calendar_id=mapping.google_calendar_id).delete()
+    effects: list[Effect] = [
+        ScheduleEvent(instance_id=str(i)).delete() for i in hold_ids
+    ]
+    InboundEventMapping.objects.filter(
+        google_calendar_id=mapping.google_calendar_id
+    ).delete()
+    # Clear pending-create markers too, so the rebuild that follows isn't skipped as "in flight".
+    PendingHoldCreate.objects.filter(
+        google_calendar_id=mapping.google_calendar_id
+    ).delete()
     return effects
 
 
-def reimport_provider(secrets: dict, mapping: StaffCalendarMapping) -> tuple[dict, list]:
-    """Force a clean full re-pull of one provider's Google calendar, importing every event as a hold.
+def purge_holds_chunk(
+    mapping: StaffCalendarMapping, limit: int, after_id: str = ""
+) -> tuple[list[Effect], str, bool]:
+    """Cancel up to ``limit`` of a provider's non-cancelled Google-origin holds in one bounded request.
 
-    Resets the provider's imported state (cancels existing holds, drops inbound mappings) and clears
-    the stored sync token so ``events.list`` returns ALL current events (not just changes since the
-    last token). This is how *pre-existing* Google events get imported and how a provider whose holds
-    were wiped gets rebuilt from scratch. Troubleshooting / re-baseline aid.
+    Ordered by appointment id and resumed via the ``after_id`` cursor, so an admin can drain a heavy
+    provider across many small, fast calls instead of one request that exceeds the gateway timeout.
+    Returns ``(cancel_effects, last_id, done)``; ``done`` is True on the final chunk, which also drops
+    the provider's ``InboundEventMapping`` rows. The cursor advances by id regardless of when the
+    async cancels apply, so every hold is covered exactly once and the loop converges deterministically.
     """
-    reset_effects = reset_inbound_for_provider(mapping)
+    qs = AppointmentExternalIdentifier.objects.filter(
+        system=GOOGLE_ORIGIN_SYSTEM,
+        appointment__provider__id=mapping.canvas_staff_id,
+    ).exclude(appointment__status="cancelled")
+    if after_id:
+        qs = qs.filter(appointment__id__gt=after_id)
+    ids = list(
+        qs.order_by("appointment__id")
+        .values_list("appointment__id", flat=True)
+        .distinct()[:limit]
+    )
+    effects: list[Effect] = [ScheduleEvent(instance_id=str(i)).delete() for i in ids]
+    done = len(ids) < limit
+    if done:
+        InboundEventMapping.objects.filter(
+            google_calendar_id=mapping.google_calendar_id
+        ).delete()
+        PendingHoldCreate.objects.filter(
+            google_calendar_id=mapping.google_calendar_id
+        ).delete()
+    last_id = str(ids[-1]) if ids else after_id
+    return effects, last_id, done
 
-    state, _ = CalendarSyncState.objects.get_or_create(google_calendar_id=mapping.google_calendar_id)
-    state.sync_token = ""
-    state.needs_full_resync = True
-    state.save()
+
+def reimport_provider(
+    secrets: dict,
+    mapping: StaffCalendarMapping,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> tuple[dict, list]:
+    """Force a full re-pull of one provider's Google calendar, rebuilding holds from what's there now.
+
+    Non-destructive: clears the stored sync token and does a full ``force_rebuild`` pull so it ADOPTS
+    the provider's current live holds (updating them in place) and recreates any that are missing or
+    were cancelled — without cancelling the provider's holds first. The full pull returns ALL current
+    events (not just changes since the last token); ``force_rebuild`` bypasses the convergence guard
+    so a hold whose only prior copy was cancelled is recreated. To deliberately REMOVE a provider's
+    holds, use Purge — not Re-import.
+
+    ``dry_run`` previews what a re-import would do without any side effects: the sync token is left
+    untouched, no mapping rows are written, and the returned effects are discarded by the caller. Use
+    it to confirm a re-import would fill the right gaps and never double a live hold before running it
+    for real (see ``scripts/dry_run_holds.py``).
+
+    ``verbose`` logs a per-event line for each outcome (single-provider re-import). The fleet pass
+    leaves it ``False`` so a whole-roster rebuild logs only per-provider summaries.
+    """
+    if not dry_run:
+        state, _ = CalendarSyncState.objects.get_or_create(
+            google_calendar_id=mapping.google_calendar_id
+        )
+        state.sync_token = ""
+        state.needs_full_resync = True
+        state.save()
 
     inbound = InboundSync(secrets)
-    stats, effects = inbound.process_calendar(mapping.google_calendar_id)
-    log.info("Re-import for %s: %s", mapping.google_calendar_id, stats)
-    return stats, reset_effects + effects
+    stats, effects = inbound.process_calendar(
+        mapping.google_calendar_id, force_rebuild=True, dry_run=dry_run, verbose=verbose
+    )
+    log.info(
+        "Re-import%s for %s: %s",
+        " (dry-run)" if dry_run else "",
+        mapping.google_calendar_id,
+        stats,
+    )
+    return stats, effects
+
+
+# How many queued providers one drain-cron tick re-imports. Each provider is a full-window pull
+# (~1-2k events, a few hundred hold effects), so a small batch keeps a tick well under the worker
+# task time limit and bounds the effects applied per invocation. The rest drain on later ticks.
+_REIMPORT_DRAIN_BATCH = 4
+
+# A queued provider whose re-import keeps raising is dropped after this many attempts so one broken
+# calendar (e.g. access revoked) can't wedge the drain — logged so the failure is visible.
+_MAX_REIMPORT_ATTEMPTS = 3
+
+
+def enqueue_fleet_reimport(limit: int | None = None) -> int:
+    """Queue every active provider for a re-import. Idempotent; returns how many rows were newly added.
+
+    Fast, synchronous DB writes only — no Google calls — so the "Re-import all" request returns at
+    once and ``ReimportDrainCron`` does the actual rebuilds a few providers per tick. A provider
+    already queued (from an earlier click or an in-flight drain) is left as-is rather than doubled.
+    ``limit`` is a test/escape-hatch cap; ``None`` = the whole active roster.
+    """
+    mappings = StaffCalendarMapping.objects.filter(active=True).order_by(
+        "google_calendar_id"
+    )
+    if limit is not None:
+        mappings = mappings[:limit]
+    queued = 0
+    for mapping in mappings:
+        _obj, created = ReimportQueue.objects.get_or_create(
+            google_calendar_id=mapping.google_calendar_id
+        )
+        if created:
+            queued = queued + 1
+    return queued
+
+
+def reimport_queue_depth() -> int:
+    """How many providers are still waiting in (or mid-) the fleet re-import queue."""
+    return int(ReimportQueue.objects.count())
+
+
+def cancel_fleet_reimport() -> int:
+    """Empty the re-import queue so the drain cron stops rebuilding. Returns how many rows were cleared.
+
+    The cancel lever for a fleet re-import that is straining the instance: once the queue is empty,
+    ``ReimportDrainCron`` no-ops. A tick already mid-flight finishes its small current batch (those
+    rows are gone, so it picks up nothing new). Holds already rebuilt are untouched — cancel only
+    stops further work. Idempotent (clearing an empty queue is a no-op).
+    """
+    cleared = reimport_queue_depth()
+    ReimportQueue.objects.all().delete()
+    return cleared
+
+
+def drain_reimport_queue(
+    secrets: dict, batch_size: int = _REIMPORT_DRAIN_BATCH
+) -> tuple[dict, list]:
+    """Re-import up to ``batch_size`` queued providers, one lock each. Returns ``(totals, effects)``.
+
+    The per-tick body of the fleet re-import. Oldest-queued first, each under the same per-provider
+    lock the admin buttons use so a manual re-import and the drain never run the same provider at
+    once. A provider is deleted from the queue only once its re-import succeeds; a busy (locked) one
+    is left for the next tick, and a repeatedly-failing one is dropped after ``_MAX_REIMPORT_ATTEMPTS``.
+    A queued provider whose mapping has since been removed/deactivated is dropped. Effects are
+    returned for the cron to apply — a small batch per tick, small enough that the platform applies
+    it reliably (a whole-roster batch is too large to apply as one blob).
+    """
+    entries = list(ReimportQueue.objects.order_by("enqueued_at")[:batch_size])
+    totals = {
+        "processed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "dropped": 0,
+        "holds_created": 0,
+        "holds_updated": 0,
+        "holds_unchanged": 0,
+        "holds_removed": 0,
+        "remaining": 0,
+    }
+    effects: list = []
+    for entry in entries:
+        calendar_id = entry.google_calendar_id
+        mapping = StaffCalendarMapping.objects.filter(
+            google_calendar_id=calendar_id, active=True
+        ).first()
+        if mapping is None:
+            # Provider was deactivated or unmapped after being queued — nothing to rebuild.
+            totals["dropped"] = totals["dropped"] + 1
+            entry.delete()
+            continue
+        if not acquire_provider_lock(calendar_id):
+            # A manual action or an overlapping tick holds it; leave queued for the next tick.
+            totals["skipped"] = totals["skipped"] + 1
+            continue
+        try:
+            stats, eff = reimport_provider(secrets, mapping)
+            effects.extend(eff)
+            totals["processed"] = totals["processed"] + 1
+            for key in (
+                "holds_created",
+                "holds_updated",
+                "holds_unchanged",
+                "holds_removed",
+            ):
+                totals[key] = totals[key] + stats.get(key, 0)
+            entry.delete()
+        except (
+            GoogleApiError,
+            GoogleAuthError,
+            RequestException,
+            ChannelConfigError,
+        ) as exc:
+            totals["failed"] = totals["failed"] + 1
+            entry.attempts = entry.attempts + 1
+            if entry.attempts >= _MAX_REIMPORT_ATTEMPTS:
+                entry.delete()
+                totals["dropped"] = totals["dropped"] + 1
+                log.error(
+                    "Re-import drain: dropping %s after %s failed attempt(s): %s",
+                    calendar_id,
+                    entry.attempts,
+                    exc,
+                )
+            else:
+                entry.save()
+                log.error(
+                    "Re-import drain: %s failed (attempt %s), will retry: %s",
+                    calendar_id,
+                    entry.attempts,
+                    exc,
+                )
+        finally:
+            release_provider_lock(calendar_id)
+
+    totals["remaining"] = reimport_queue_depth()
+    if entries:
+        log.info(
+            "Re-import drain: %s rebuilt, %s created, %s busy, %s failed, %s dropped, %s remaining",
+            totals["processed"],
+            totals["holds_created"],
+            totals["skipped"],
+            totals["failed"],
+            totals["dropped"],
+            totals["remaining"],
+        )
+    return totals, effects
+
+
+# Outbound backfill drain. How many providers to advance per tick, and the per-provider push cap. The
+# cap keeps each calendar's write rate gentle — well under Google's 600/min per-user limit and the
+# stricter "quick succession" per-calendar throttle — and the tick cadence spreads the total across
+# time. A provider with a large backlog completes over several ticks. Sized conservatively; raise once
+# it's proven healthy. (~6 x 40 = 240 writes / 2-min tick ~= 120/min, far under every documented limit.)
+_OUTBOUND_DRAIN_PROVIDERS_PER_TICK = 6
+_OUTBOUND_DRAIN_PUSHES_PER_PROVIDER = 40
+
+
+def drain_outbound_backfill(
+    secrets: dict,
+    providers_per_tick: int = _OUTBOUND_DRAIN_PROVIDERS_PER_TICK,
+    pushes_per_provider: int = _OUTBOUND_DRAIN_PUSHES_PER_PROVIDER,
+) -> dict:
+    """Push a bounded, paced slice of the outbound (Canvas -> Google) backlog. Returns a totals dict.
+
+    The outbound analog of the inbound re-import drain. The daily reconcile tried to push the whole
+    fleet in one capped run, which hammered individual calendars into Google's rate limit and dropped
+    the throttled writes (they have no backoff), leaving most providers permanently un-backfilled.
+    This advances the least-recently-synced providers a few at a time, each capped so no calendar is
+    blasted, on a frequent cron whose cadence is the backoff. It is a cheap no-op once every provider
+    is fully backfilled. Outbound pushes go straight to Google, so there are no Canvas effects to return.
+    """
+    mappings = list(StaffCalendarMapping.objects.filter(active=True))
+    selected = sorted(mappings, key=_outbound_priority)[:providers_per_tick]
+    totals = {"providers": 0, "skipped": 0, "pushed": 0}
+    for mapping in selected:
+        if not acquire_provider_lock(mapping.google_calendar_id):
+            totals["skipped"] = totals["skipped"] + 1
+            continue
+        try:
+            pushed = outbound_truth(
+                secrets, [mapping], max_pushes=pushes_per_provider, skip_mapped=True
+            )
+            totals["providers"] = totals["providers"] + 1
+            totals["pushed"] = totals["pushed"] + pushed
+        finally:
+            release_provider_lock(mapping.google_calendar_id)
+    if selected:
+        remaining = StaffCalendarMapping.objects.filter(
+            active=True, last_outbound_synced_at__isnull=True
+        ).count()
+        log.info(
+            "Outbound drain: %s provider(s) advanced, %s pushed, %s busy, %s awaiting full backfill",
+            totals["providers"],
+            totals["pushed"],
+            totals["skipped"],
+            remaining,
+        )
+    return totals
 
 
 def reconcile_all(secrets: dict) -> tuple[dict, list]:
@@ -201,16 +671,25 @@ def reconcile_all(secrets: dict) -> tuple[dict, list]:
     if not mappings:
         return {"mappings": 0, "pushed": 0, "blocks_pushed": 0, "blocks_deleted": 0}, []
     effects = inbound_recovery(secrets, mappings)
-    pushed = outbound_truth(secrets, mappings)
+    pushed = outbound_truth(secrets, mappings, max_pushes=_MAX_OUTBOUND_PUSHES_PER_RUN)
+    swept = sweep_outbound(
+        secrets, mappings, max_calendars=_MAX_SWEEP_CALENDARS_PER_RUN
+    )
     blocks = sync_all_blocks(secrets, mappings)
     log.info(
-        "Reconciliation complete: %s mapping(s), %s appt(s) pushed, %s block(s) pushed/%s deleted",
-        len(mappings), pushed, blocks["pushed"], blocks["deleted"],
+        "Reconciliation complete: %s mapping(s), %s appt(s) pushed, %s stale event(s) swept, "
+        "%s block(s) pushed/%s deleted",
+        len(mappings),
+        pushed,
+        swept,
+        blocks["pushed"],
+        blocks["deleted"],
     )
     return (
         {
             "mappings": len(mappings),
             "pushed": pushed,
+            "swept": swept,
             "blocks_pushed": blocks["pushed"],
             "blocks_deleted": blocks["deleted"],
         },

--- a/extensions/gcal_sync/gcal_sync/routes/google_admin.py
+++ b/extensions/gcal_sync/gcal_sync/routes/google_admin.py
@@ -12,6 +12,8 @@ from html import escape
 from http import HTTPStatus
 from typing import Callable
 
+import arrow
+from django.db.models import Count
 from requests import RequestException
 
 from canvas_sdk.effects import Effect
@@ -24,11 +26,22 @@ from logger import log
 from gcal_sync.channels import ChannelConfigError, ChannelManager
 from gcal_sync.google.auth import GoogleAuthError
 from gcal_sync.google.client import GoogleApiError
-from gcal_sync.models import CalendarSyncState, StaffCalendarMapping, WatchChannel
+from gcal_sync.models import (
+    AppointmentEventMapping,
+    CalendarSyncState,
+    StaffCalendarMapping,
+    WatchChannel,
+)
 from gcal_sync.reconcile import (
+    acquire_provider_lock,
+    cancel_fleet_reimport,
+    enqueue_fleet_reimport,
+    purge_holds_chunk,
     reconcile_all,
     reconcile_provider,
     reimport_provider,
+    reimport_queue_depth,
+    release_provider_lock,
     reset_inbound_for_provider,
 )
 
@@ -68,13 +81,17 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         """True only when the caller is an explicitly-listed admin. Fails closed if unset."""
         raw = (self.secrets.get("ADMIN_STAFF_IDS") or "").strip()
         if not raw:
-            log.warning("ADMIN_STAFF_IDS not configured; denying Google sync admin access")
+            log.warning(
+                "ADMIN_STAFF_IDS not configured; denying Google sync admin access"
+            )
             return False
         admin_ids = {item.strip() for item in raw.split(",") if item.strip()}
         return self._logged_in_staff_id() in admin_ids
 
     def _forbidden(self) -> list[Response | Effect]:
-        return [JSONResponse({"error": "Not authorized"}, status_code=HTTPStatus.FORBIDDEN)]
+        return [
+            JSONResponse({"error": "Not authorized"}, status_code=HTTPStatus.FORBIDDEN)
+        ]
 
     @staticmethod
     def _notice_html(title: str, body_html: str) -> str:
@@ -132,7 +149,12 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         calendar_email = (body.get("calendar_email") or "").strip()
         active = bool(body.get("active", True))
         if not staff_id:
-            return [JSONResponse({"error": "staff_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+            return [
+                JSONResponse(
+                    {"error": "staff_id is required"},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
         if active and not calendar_email:
             return [
                 JSONResponse(
@@ -141,13 +163,19 @@ class GoogleCalendarAdminAPI(SimpleAPI):
                 )
             ]
 
-        mapping, _created = StaffCalendarMapping.objects.get_or_create(canvas_staff_id=staff_id)
+        mapping, _created = StaffCalendarMapping.objects.get_or_create(
+            canvas_staff_id=staff_id
+        )
         mapping.google_calendar_id = calendar_email
         mapping.active = active
         mapping.save()
 
         warning = self._open_channel_best_effort(calendar_email) if active else None
-        return [JSONResponse({"status": "saved", "warning": warning}, status_code=HTTPStatus.OK)]
+        return [
+            JSONResponse(
+                {"status": "saved", "warning": warning}, status_code=HTTPStatus.OK
+            )
+        ]
 
     @api.post("/google/admin/auto-map")
     def auto_map(self) -> list[Response | Effect]:
@@ -173,7 +201,11 @@ class GoogleCalendarAdminAPI(SimpleAPI):
 
         return [
             JSONResponse(
-                {"status": "ok", "mapped": created, "skipped_no_email": skipped_no_email},
+                {
+                    "status": "ok",
+                    "mapped": created,
+                    "skipped_no_email": skipped_no_email,
+                },
                 status_code=HTTPStatus.OK,
             )
         ]
@@ -190,7 +222,12 @@ class GoogleCalendarAdminAPI(SimpleAPI):
 
         emails = parse_provider_emails(self.request.json().get("csv") or "")
         if not emails:
-            return [JSONResponse({"error": "No emails found in CSV"}, status_code=HTTPStatus.BAD_REQUEST)]
+            return [
+                JSONResponse(
+                    {"error": "No emails found in CSV"},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
 
         email_to_staff = {
             (row.get("user__email") or "").strip().lower(): str(row["id"])
@@ -224,10 +261,16 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         except (GoogleApiError, GoogleAuthError, RequestException) as exc:
             log.error("Manual reconcile failed: %s", exc)
             return [
-                JSONResponse({"error": "Reconcile failed"}, status_code=HTTPStatus.SERVICE_UNAVAILABLE)
+                JSONResponse(
+                    {"error": "Reconcile failed"},
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
             ]
         # Apply any inbound admin-hold effects alongside the JSON summary.
-        return [*effects, JSONResponse({"status": "ok", **stats}, status_code=HTTPStatus.OK)]
+        return [
+            *effects,
+            JSONResponse({"status": "ok", **stats}, status_code=HTTPStatus.OK),
+        ]
 
     def _provider_action(
         self, action: Callable[[dict, StaffCalendarMapping], tuple[dict, list]]
@@ -242,15 +285,37 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         if mapping is None:
             return [
                 JSONResponse(
-                    {"error": "Provider is not enrolled"}, status_code=HTTPStatus.BAD_REQUEST
+                    {"error": "Provider is not enrolled"},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+        # One action per provider at a time: a double-click or a second admin gets a clean 409
+        # instead of racing (the buttons run synchronously across multiple containers).
+        if not acquire_provider_lock(mapping.google_calendar_id):
+            return [
+                JSONResponse(
+                    {
+                        "error": "A sync is already running for this provider; try again shortly."
+                    },
+                    status_code=HTTPStatus.CONFLICT,
                 )
             ]
         try:
             stats, effects = action(self.secrets, mapping)
         except (GoogleApiError, GoogleAuthError, RequestException) as exc:
             log.error("Provider action failed for %s: %s", staff_id, exc)
-            return [JSONResponse({"error": "Action failed"}, status_code=HTTPStatus.SERVICE_UNAVAILABLE)]
-        return [*effects, JSONResponse({"status": "ok", **stats}, status_code=HTTPStatus.OK)]
+            return [
+                JSONResponse(
+                    {"error": "Action failed"},
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+            ]
+        finally:
+            release_provider_lock(mapping.google_calendar_id)
+        return [
+            *effects,
+            JSONResponse({"status": "ok", **stats}, status_code=HTTPStatus.OK),
+        ]
 
     @api.post("/google/admin/reconcile-provider")
     def reconcile_one(self) -> list[Response | Effect]:
@@ -259,8 +324,94 @@ class GoogleCalendarAdminAPI(SimpleAPI):
 
     @api.post("/google/admin/reimport-provider")
     def reimport_one(self) -> list[Response | Effect]:
-        """Force a full re-pull of one provider's Google calendar (imports existing events as holds)."""
-        return self._provider_action(reimport_provider)
+        """Force a full re-pull of one provider's Google calendar (imports existing events as holds).
+
+        Runs ``verbose`` so the plugin logs a per-event line for each outcome — this is the single
+        provider case where per-event detail is wanted (the fleet re-import logs summaries only).
+        """
+        return self._provider_action(
+            lambda secrets, mapping: reimport_provider(secrets, mapping, verbose=True)
+        )
+
+    @api.post("/google/admin/dryrun-provider")
+    def dryrun_one(self) -> list[Response | Effect]:
+        """Preview a re-import for one provider WITHOUT changing anything.
+
+        Runs the real inbound logic with ``dry_run=True`` (no mapping writes, no Google writes, no
+        sync-token advance) and logs every decision through the SDK logger — the per-event
+        ``gcal inbound: …`` lines plus a per-calendar summary. Returns ONLY a JSON summary; the
+        would-be effects are deliberately discarded so a dry-run applies nothing. No provider lock is
+        taken because it is read-only and safe to run alongside anything.
+        """
+        if not self._is_admin():
+            return self._forbidden()
+        staff_id = (self.request.json().get("staff_id") or "").strip()
+        mapping = StaffCalendarMapping.objects.filter(
+            canvas_staff_id=staff_id, active=True
+        ).first()
+        if mapping is None:
+            return [
+                JSONResponse(
+                    {"error": "Provider is not enrolled"},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+        try:
+            stats, _effects = reimport_provider(self.secrets, mapping, dry_run=True)
+        except (GoogleApiError, GoogleAuthError, RequestException) as exc:
+            log.error("Dry-run re-import failed for %s: %s", staff_id, exc)
+            return [
+                JSONResponse(
+                    {"error": "Dry-run failed"},
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+            ]
+        # _effects intentionally discarded: a dry run must apply nothing. Detail is in the logs.
+        return [
+            JSONResponse(
+                {"status": "ok", "dry_run": True, **stats}, status_code=HTTPStatus.OK
+            )
+        ]
+
+    @api.post("/google/admin/reimport-all")
+    def reimport_all(self) -> list[Response | Effect]:
+        """Queue EVERY active provider for a re-import; ``ReimportDrainCron`` rebuilds them over time.
+
+        Enqueuing is fast, synchronous DB writes only (no Google calls), so this returns immediately —
+        no gateway timeout and no long-running background task. The drain cron then rebuilds a few
+        providers per tick, applying each provider's hold effects in its own short invocation, so a
+        whole-roster rebuild spreads across many minutes and its effects always land. Idempotent:
+        re-clicking while a drain is in flight doesn't double any provider's work. Progress shows in
+        the per-provider ``last synced`` column and the ``Re-import drain: …`` plugin logs.
+        """
+        if not self._is_admin():
+            return self._forbidden()
+        queued = enqueue_fleet_reimport()
+        pending = reimport_queue_depth()
+        return [
+            JSONResponse(
+                {"status": "ok", "queued": queued, "pending": pending},
+                status_code=HTTPStatus.OK,
+            )
+        ]
+
+    @api.post("/google/admin/cancel-reimport-all")
+    def cancel_reimport_all(self) -> list[Response | Effect]:
+        """Cancel an in-progress fleet re-import by emptying its queue; the drain cron then stops.
+
+        For when a running "Re-import all" is straining the instance. Clears every queued provider so
+        no further rebuilds start (a tick already mid-flight finishes its small current batch). Holds
+        already rebuilt are left as-is. Idempotent — safe to click when nothing is queued.
+        """
+        if not self._is_admin():
+            return self._forbidden()
+        cleared = cancel_fleet_reimport()
+        return [
+            JSONResponse(
+                {"status": "ok", "cleared": cleared, "pending": reimport_queue_depth()},
+                status_code=HTTPStatus.OK,
+            )
+        ]
 
     @api.post("/google/admin/purge-provider")
     def purge_one(self) -> list[Response | Effect]:
@@ -273,25 +424,50 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         """
         if not self._is_admin():
             return self._forbidden()
-        staff_id = (self.request.json().get("staff_id") or "").strip()
+        body = self.request.json()
+        staff_id = (body.get("staff_id") or "").strip()
         mapping = StaffCalendarMapping.objects.filter(canvas_staff_id=staff_id).first()
         if mapping is None:
             return [
                 JSONResponse(
-                    {"error": "Provider has no calendar mapping"}, status_code=HTTPStatus.BAD_REQUEST
+                    {"error": "Provider has no calendar mapping"},
+                    status_code=HTTPStatus.BAD_REQUEST,
                 )
+            ]
+        # Bounded, resumable mode: cancel up to `limit` holds per call so a heavy provider drains
+        # across many fast requests instead of one that exceeds the gateway timeout.
+        limit = body.get("limit")
+        if limit:
+            effects, next_after, done = purge_holds_chunk(
+                mapping, int(limit), (body.get("after_id") or "")
+            )
+            return [
+                *effects,
+                JSONResponse(
+                    {
+                        "status": "ok",
+                        "purged": len(effects),
+                        "next_after": next_after,
+                        "done": done,
+                    },
+                    status_code=HTTPStatus.OK,
+                ),
             ]
         effects = reset_inbound_for_provider(mapping)
         return [
             *effects,
-            JSONResponse({"status": "ok", "purged": len(effects)}, status_code=HTTPStatus.OK),
+            JSONResponse(
+                {"status": "ok", "purged": len(effects)}, status_code=HTTPStatus.OK
+            ),
         ]
 
     @staticmethod
     def _schedulable_providers() -> list[dict]:
         """Active staff with a Provider role — the ones who can be booked on appointments."""
         return list(
-            Staff.objects.filter(active=True, roles__role_type=StaffRole.RoleType.PROVIDER)
+            Staff.objects.filter(
+                active=True, roles__role_type=StaffRole.RoleType.PROVIDER
+            )
             .values("id", "first_name", "last_name", "user__email")
             .distinct()
             .order_by("last_name", "first_name")
@@ -299,7 +475,9 @@ class GoogleCalendarAdminAPI(SimpleAPI):
 
     @staticmethod
     def _upsert_mapping(staff_id: str, calendar_email: str) -> None:
-        mapping, _created = StaffCalendarMapping.objects.get_or_create(canvas_staff_id=staff_id)
+        mapping, _created = StaffCalendarMapping.objects.get_or_create(
+            canvas_staff_id=staff_id
+        )
         mapping.google_calendar_id = calendar_email
         mapping.active = True
         mapping.save()
@@ -309,7 +487,12 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         try:
             ChannelManager(self.secrets).open_channel(calendar_email)
             return None
-        except (ChannelConfigError, GoogleApiError, GoogleAuthError, RequestException) as exc:
+        except (
+            ChannelConfigError,
+            GoogleApiError,
+            GoogleAuthError,
+            RequestException,
+        ) as exc:
             log.error("Could not open watch channel for %s: %s", calendar_email, exc)
             return f"Mapping saved, but the watch channel could not be opened: {exc}"
 
@@ -317,6 +500,13 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         mappings = {m.canvas_staff_id: m for m in StaffCalendarMapping.objects.all()}
         channels = self._latest_channel_by_calendar()
         sync_states = {s.google_calendar_id: s for s in CalendarSyncState.objects.all()}
+        # One aggregate for how many events we're tracking per calendar (not a query per provider).
+        synced_counts = {
+            row["google_calendar_id"]: row["n"]
+            for row in AppointmentEventMapping.objects.values(
+                "google_calendar_id"
+            ).annotate(n=Count("dbid"))
+        }
 
         providers = []
         staff_rows = (
@@ -327,9 +517,16 @@ class GoogleCalendarAdminAPI(SimpleAPI):
         for staff in staff_rows:
             staff_id = str(staff["id"])
             mapping = mappings.get(staff_id)
-            calendar_id = mapping.google_calendar_id if mapping else (staff.get("user__email") or "")
+            calendar_id = (
+                mapping.google_calendar_id
+                if mapping
+                else (staff.get("user__email") or "")
+            )
             channel = channels.get(calendar_id) if calendar_id else None
             state = sync_states.get(calendar_id) if calendar_id else None
+            last_synced = (
+                getattr(mapping, "last_outbound_synced_at", None) if mapping else None
+            )
             providers.append(
                 {
                     "staff_id": staff_id,
@@ -339,14 +536,25 @@ class GoogleCalendarAdminAPI(SimpleAPI):
                     "mapped": mapping is not None,
                     "channel_expiration": channel.expiration if channel else None,
                     "needs_full_resync": bool(state and state.needs_full_resync),
+                    # Persistent completion signal: how many events are synced and when the last
+                    # outbound reconcile for this provider finished.
+                    "synced_count": synced_counts.get(calendar_id, 0),
+                    "last_synced_display": arrow.get(last_synced).humanize()
+                    if last_synced
+                    else "never",
                 }
             )
 
-        return {"providers": providers, "logged_in_staff_id": self._logged_in_staff_id()}
+        return {
+            "providers": providers,
+            "logged_in_staff_id": self._logged_in_staff_id(),
+        }
 
     @staticmethod
     def _latest_channel_by_calendar() -> dict:
         latest: dict = {}
         for channel in WatchChannel.objects.all().order_by("created_at"):
-            latest[channel.google_calendar_id] = channel  # later rows overwrite -> newest wins
+            latest[channel.google_calendar_id] = (
+                channel  # later rows overwrite -> newest wins
+            )
         return latest

--- a/extensions/gcal_sync/gcal_sync/sync_service.py
+++ b/extensions/gcal_sync/gcal_sync/sync_service.py
@@ -6,11 +6,20 @@ the Canvas event/cron machinery (it takes plain snapshots and ids) and from toke
 factory is injectable) so it can be unit-tested with a fake client.
 """
 
+from collections import defaultdict
 from typing import Callable
+
+from logger import log
 
 from gcal_sync.google.auth import GoogleAuth
 from gcal_sync.google.client import GoogleApiError, GoogleCalendarClient
-from gcal_sync.google.event_builder import AppointmentSnapshot, build_event_body, content_hash
+from gcal_sync.google.event_builder import (
+    CANVAS_APPT_ID_KEY,
+    AppointmentSnapshot,
+    build_event_body,
+    content_hash,
+    extract_canvas_appt_id,
+)
 from gcal_sync.models import AppointmentEventMapping
 
 ClientFactory = Callable[[str], GoogleCalendarClient]
@@ -29,18 +38,28 @@ class SyncService:
     def _default_client_factory(self, calendar_id: str) -> GoogleCalendarClient:
         return GoogleCalendarClient(self._auth.get_access_token(calendar_id))
 
-    def push(self, calendar_id: str, snapshot: AppointmentSnapshot) -> AppointmentEventMapping:
+    def push(
+        self,
+        calendar_id: str,
+        snapshot: AppointmentSnapshot,
+        mapping_cache: dict[str, AppointmentEventMapping] | None = None,
+    ) -> AppointmentEventMapping:
         """Upsert the Google event for an appointment and record the mapping + content hash.
 
         Insert when we have no event for this appointment yet, otherwise patch in place. Idempotent:
         the unique constraint on ``canvas_appointment_id`` plus ``get`` means a duplicate event
         delivery updates the existing row instead of creating a second event (spec §6.3).
+
+        ``mapping_cache`` lets a batch caller (the reconcile re-push) prefetch every appointment's
+        mapping in ONE query and pass it in, so a run over N appointments does 1 mapping query
+        instead of N. A missing key means "no mapping exists" (the cache is authoritative for the
+        ids it was built from); the real-time handler omits it and falls back to a per-id ``get``.
         """
         appointment_id = str(snapshot["appointment_id"])
         body = build_event_body(snapshot)
         new_hash = content_hash(body)
 
-        mapping = self._existing_mapping(appointment_id)
+        mapping = self._resolve_mapping(appointment_id, mapping_cache)
 
         # Change-only: if we already pushed this exact content to this calendar, do nothing. This is
         # what lets the reconcile/cron scale — steady-state cost is O(changes), not O(appointments),
@@ -54,13 +73,30 @@ class SyncService:
 
         client = self._client_factory(calendar_id)
         if mapping is None:
-            created = client.insert_event(calendar_id, body)
-            new_mapping: AppointmentEventMapping = AppointmentEventMapping.objects.create(
-                canvas_appointment_id=appointment_id,
-                google_calendar_id=calendar_id,
-                google_event_id=created["id"],
-                last_pushed_hash=new_hash,
+            # Idempotency (adopt, don't duplicate): we may have pushed this appointment before and
+            # lost the local mapping — an appointment hard-deleted-and-recreated, a dropped mapping
+            # row, or a first pass whose mapping write didn't persist. Blindly inserting would create
+            # a SECOND event on the provider's calendar. Look for an event we already stamped with
+            # this appointment id and patch it in place; only insert when Google truly has none. This
+            # is what makes the reconcile safe to re-run after mapping drift.
+            existing = client.find_event_by_private_property(
+                calendar_id, CANVAS_APPT_ID_KEY, appointment_id
             )
+            if existing is not None:
+                client.patch_event(calendar_id, existing["id"], body)
+                event_id = existing["id"]
+            else:
+                event_id = client.insert_event(calendar_id, body)["id"]
+            # update_or_create (not create) so a stale mapping_cache miss can't collide with an
+            # existing row on the unique canvas_appointment_id constraint.
+            new_mapping: AppointmentEventMapping = AppointmentEventMapping.objects.update_or_create(
+                canvas_appointment_id=appointment_id,
+                defaults={
+                    "google_calendar_id": calendar_id,
+                    "google_event_id": event_id,
+                    "last_pushed_hash": new_hash,
+                },
+            )[0]
             return new_mapping
 
         # If the calendar changed (provider re-mapped), delete from the old calendar first.
@@ -93,9 +129,80 @@ class SyncService:
         mapping.delete()
         return True
 
+    def sweep_calendar(
+        self,
+        calendar_id: str,
+        live_appointment_ids: set[str],
+        time_min: str,
+        time_max: str,
+        max_deletes: int,
+    ) -> int:
+        """Remove events we pushed that shouldn't be on the calendar; collapse duplicates.
+
+        ``live_appointment_ids`` is the authoritative set of appointment ids that SHOULD each have
+        exactly one event in this window (the caller computes it from Canvas: enrolled, non-terminal,
+        in-window, not Google-origin). Only events WE stamped (``canvasApptId``) are ever touched.
+        For each stamped appointment id found on the calendar:
+          - not in the live set  -> the appointment was cancelled/deleted/moved out of window; delete
+            every event for it and drop its mapping (orphan cleanup);
+          - in the live set with >1 event -> keep one (the mapped event when identifiable), delete the
+            rest (dedupe).
+        Bounded by ``max_deletes`` per call so the blast radius is small if the live set is wrong.
+        Returns the number of Google events deleted.
+        """
+        client = self._client_factory(calendar_id)
+        by_appt: dict[str, list[dict]] = defaultdict(list)
+        for event in client.list_all_events(calendar_id, time_min, time_max):
+            appt_id = extract_canvas_appt_id(event)
+            if appt_id:
+                by_appt[appt_id].append(event)
+
+        deletes = 0
+        for appt_id, events in by_appt.items():
+            if deletes >= max_deletes:
+                break
+            if appt_id not in live_appointment_ids:
+                # Orphan: no live in-window appointment backs these events -> remove them + the mapping.
+                for event in events:
+                    if deletes >= max_deletes:
+                        break
+                    client.delete_event(calendar_id, event["id"])
+                    deletes += 1
+                AppointmentEventMapping.objects.filter(
+                    canvas_appointment_id=appt_id, google_calendar_id=calendar_id
+                ).delete()
+            elif len(events) > 1:
+                # Duplicate: keep the mapped event if we can identify it, else the first; delete rest.
+                mapping = AppointmentEventMapping.objects.filter(
+                    canvas_appointment_id=appt_id, google_calendar_id=calendar_id
+                ).first()
+                ids = {e["id"] for e in events}
+                keep = mapping.google_event_id if mapping and mapping.google_event_id in ids else events[0]["id"]
+                for event in events:
+                    if deletes >= max_deletes:
+                        break
+                    if event["id"] != keep:
+                        client.delete_event(calendar_id, event["id"])
+                        deletes += 1
+        if deletes:
+            log.info("Sweep removed %s stale/duplicate event(s) from %s", deletes, calendar_id)
+        return deletes
+
     def _safe_delete(self, calendar_id: str, event_id: str) -> None:
         client = self._client_factory(calendar_id)
         client.delete_event(calendar_id, event_id)
+
+    def _resolve_mapping(
+        self, appointment_id: str, mapping_cache: dict[str, AppointmentEventMapping] | None
+    ) -> AppointmentEventMapping | None:
+        """Look the mapping up in a prefetched cache when the caller supplied one, else query it.
+
+        The cache is authoritative for the ids it was built from, so a miss means "no mapping" and
+        we do NOT fall back to a query (that would re-introduce the per-appointment N+1).
+        """
+        if mapping_cache is not None:
+            return mapping_cache.get(appointment_id)
+        return self._existing_mapping(appointment_id)
 
     @staticmethod
     def _existing_mapping(appointment_id: str) -> AppointmentEventMapping | None:

--- a/extensions/gcal_sync/gcal_sync/templates/google_admin.html
+++ b/extensions/gcal_sync/gcal_sync/templates/google_admin.html
@@ -138,6 +138,15 @@
         button.danger { background: var(--surface); color: var(--danger); border-color: #f1c9c7; }
         button.danger:hover:not(:disabled) { background: var(--danger-wash); border-color: var(--danger); transform: translateY(-1px); }
 
+        /* dry-run per-event preview: read-only, scrollable, monospace */
+        .dryrun-log {
+            display: block; width: 100%; margin: 8px 0 0; padding: 8px 10px;
+            max-height: 220px; overflow: auto; white-space: pre-wrap; word-break: break-word;
+            background: #0f1729; color: #d5deec; border-radius: 8px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 11px; line-height: 1.5;
+        }
+
         /* ---------- bulk import ---------- */
         details {
             background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-md);
@@ -154,9 +163,13 @@
             width: 20px; height: 20px; border-radius: 6px; font-size: 15px; font-weight: 700;
             background: var(--rm-blue-wash); color: var(--rm-blue-deep); transition: transform 0.2s ease;
         }
-        details[open] summary::before { content: "−"; transform: rotate(0deg); }
+        details[open] summary::before { content: "\u2212"; transform: rotate(0deg); }
         .import-body { padding: 0 0 14px; }
         .import-note { color: var(--muted); font-size: 12.5px; margin: 2px 0 10px; }
+        .action-defs { margin: 2px 0 0; }
+        .action-defs dt { font-weight: 600; color: var(--navy); font-size: 13px; margin-top: 12px; }
+        .action-defs dt:first-child { margin-top: 0; }
+        .action-defs dd { margin: 3px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.55; }
         .import-note code, code {
             font-family: var(--mono); font-size: 11.5px; background: var(--line-soft);
             padding: 1px 6px; border-radius: 5px; color: var(--navy);
@@ -238,6 +251,7 @@
 
         /* ---------- status messages ---------- */
         .row-actions { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+        .sync-detail { font-size: 11px; color: var(--muted); margin-top: 4px; }
         .status-msg { font-size: 12px; color: var(--muted); font-weight: 600; }
         .status-msg.ok { color: var(--success); }
         .status-msg.err { color: var(--danger); }
@@ -263,11 +277,33 @@
         </header>
 
         <div class="controls">
-            <button id="automap-btn" class="btn-primary">Auto-map schedulable providers</button>
-            <button id="reconcile-btn" class="secondary">Reconcile now</button>
+            <button id="automap-btn" class="btn-primary" title="Turn on sync for every provider by matching them to their own Google Workspace calendar (their staff email) and starting a live connection. Safe to run again; it updates, it never creates duplicates.">Auto-map schedulable providers</button>
+            <button id="reconcile-btn" class="secondary" title="Run a full two-way catch-up for all enabled providers: pull in changes from Google and re-push Canvas's current schedule. Safe to click repeatedly; it will not create duplicates.">Reconcile now</button>
+            <button id="reimport-all-btn" class="secondary" title="Queue EVERY enabled provider to have their holds rebuilt from their Google calendars. A background job rebuilds a few providers at a time over the next several minutes. Adopts existing holds and recreates missing/cancelled ones without duplicates. Safe to repeat.">Re-import all</button>
+            <button id="cancel-reimport-btn" class="secondary" title="Stop an in-progress 'Re-import all' by clearing its queue. No new providers are rebuilt after this (a batch already mid-run finishes). Holds already rebuilt are kept. Use if the re-import is straining the instance.">Cancel re-import</button>
             <span class="spacer"></span>
             <span id="reconcile-msg" class="status-msg msg-line"></span>
         </div>
+
+        <details class="actions-help">
+            <summary>What do these buttons do?</summary>
+            <div class="import-body">
+                <dl class="action-defs">
+                    <dt>Auto-map schedulable providers</dt>
+                    <dd>Turns on sync for every provider by matching them to their own Google Workspace calendar (their staff email) and starting a live connection. Safe to run again anytime; it updates existing entries and does not create duplicates. Use it at setup and whenever new providers join.</dd>
+                    <dt>Reconcile now</dt>
+                    <dd>Runs a full two-way catch-up for all enabled providers: pulls in changes from Google and re-pushes Canvas's current schedule. Safe to click repeatedly; it will not create duplicates. Use it after setup, after changes, or if something looks out of sync. (First-time imports bring in up to five providers' existing events per run and continue on later runs.)</dd>
+                    <dt>Reconcile (one provider)</dt>
+                    <dd>The same two-way catch-up, just for that one provider. Faster than the full run.</dd>
+                    <dt>Re-import (one provider)</dt>
+                    <dd>Rebuilds a provider from scratch: removes the holds we previously imported from their Google calendar, then pulls everything in fresh. Use it if a provider's imported events look wrong, or to bring in events that existed before sync was set up.</dd>
+                    <dt>Purge (one provider)</dt>
+                    <dd>Removes the holds we imported into Canvas for that provider and clears our sync bookkeeping. It does not rebuild, and it does not change anything on the provider's Google calendar. Use it to stop and clean up a provider's imported holds.</dd>
+                    <dt>Save</dt>
+                    <dd>Saves a provider's calendar address and their sync on/off switch.</dd>
+                </dl>
+            </div>
+        </details>
 
         <details>
             <summary>Bulk import from CSV</summary>
@@ -316,15 +352,18 @@
                                 {% else %}
                                     <span class="badge off">Off</span>
                                 {% endif %}
+                                <div class="sync-detail">{{ p.synced_count }} synced · last {{ p.last_synced_display }}</div>
                             </div>
                         </td>
                         <td>
                             <div class="row-actions">
-                                <button class="save-btn">Save</button>
-                                <button class="reconcile-row-btn secondary">Reconcile</button>
-                                <button class="reimport-row-btn secondary">Re-import</button>
-                                <button class="purge-row-btn danger" title="Cancel this provider's imported holds and clear their sync mappings (no rebuild)">Purge</button>
+                                <button class="save-btn" title="Save this provider's calendar address and sync on/off switch">Save</button>
+                                <button class="reconcile-row-btn secondary" title="Two-way catch-up for this provider only (safe to repeat; no duplicates)">Reconcile</button>
+                                <button class="dryrun-row-btn secondary" title="Preview what a Re-import WOULD do for this provider — per-event, without changing anything. Shows the outcome for each Google event below (also written to the plugin logs).">Dry-run</button>
+                                <button class="reimport-row-btn secondary" title="Rebuild this provider's holds from what's on their Google calendar now: adopts existing holds and recreates missing/cancelled ones. Does not remove holds up front; safe to repeat. Use Purge to actually remove holds.">Re-import</button>
+                                <button class="purge-row-btn danger" title="Remove the holds we imported into Canvas for this provider and clear our sync bookkeeping. Does not rebuild, and does not change the provider's Google calendar.">Purge</button>
                                 <span class="status-msg"></span>
+                                <pre class="dryrun-log" hidden></pre>
                             </div>
                         </td>
                     </tr>
@@ -358,7 +397,7 @@
                 postJSON("/plugin-io/api/gcal_sync/google/admin/mapping", payload).then(function (res) {
                     if (res.ok) {
                         var warn = res.body.warning;
-                        msg.textContent = warn ? warn : "Saved. Refreshing…";
+                        msg.textContent = warn ? warn : "Saved. Refreshing\u2026";
                         msg.className = warn ? "status-msg err" : "status-msg ok";
                         // Reload so the health badge (Watching / Off / No channel) reflects the new
                         // state — it's rendered server-side at page load, not updated by this POST.
@@ -386,19 +425,23 @@
                     var rowButtons = row.querySelectorAll("button");
                     rowButtons.forEach(function (b) { b.disabled = true; });
                     var originalLabel = button.textContent;
-                    button.textContent = verb + "…";
-                    msg.textContent = verb + " in progress… a full calendar can take up to a minute.";
+                    button.textContent = verb + "\u2026";
+                    msg.textContent = verb + " in progress\u2026 a full calendar can take up to a minute.";
                     msg.className = "status-msg";
                     postJSON(url, { staff_id: row.getAttribute("data-staff-id") }).then(function (res) {
                         if (res.ok) {
                             var b = res.body;
                             var parts = [];
-                            if (b.pushed !== undefined) parts.push(b.pushed + " appt");
+                            if (b.pushed !== undefined) parts.push(b.pushed + " appt(s) pushed");
                             if (b.holds_created) parts.push(b.holds_created + " hold(s) imported");
+                            if (b.holds_updated) parts.push(b.holds_updated + " updated");
+                            if (b.holds_unchanged) parts.push(b.holds_unchanged + " already current");
+                            if (b.holds_removed) parts.push(b.holds_removed + " removed");
+                            if (b.swept) parts.push(b.swept + " stale cleaned");
                             if (b.blocks_pushed) parts.push(b.blocks_pushed + " block(s)");
                             if (b.purged) parts.push(b.purged + " hold(s) purged");
                             msg.textContent = verb + " done" + (parts.length ? ": " + parts.join(", ") : ".")
-                                + " Refreshing…";
+                                + " Refreshing\u2026";
                             msg.className = "status-msg ok";
                             // Auto-refresh so the health badge (Watching / Resync pending) updates.
                             setTimeout(function () { location.reload(); }, 1500);
@@ -419,6 +462,55 @@
         }
         rowAction(".reconcile-row-btn", "/plugin-io/api/gcal_sync/google/admin/reconcile-provider", "Reconcile");
         rowAction(".reimport-row-btn", "/plugin-io/api/gcal_sync/google/admin/reimport-provider", "Re-import");
+
+        // Dry-run: read-only preview. Shows would-import/update counts inline and does NOT reload
+        // (nothing changed); full per-event detail is written to the plugin logs by the SDK logger.
+        document.querySelectorAll(".dryrun-row-btn").forEach(function (button) {
+            button.addEventListener("click", function () {
+                var row = button.closest("tr");
+                var msg = row.querySelector(".status-msg");
+                var out = row.querySelector(".dryrun-log");
+                var rowButtons = row.querySelectorAll("button");
+                rowButtons.forEach(function (b) { b.disabled = true; });
+                var originalLabel = button.textContent;
+                button.textContent = "Dry-run\u2026";
+                msg.textContent = "Dry-run in progress\u2026 (read-only; nothing will change).";
+                msg.className = "status-msg";
+                out.hidden = true;
+                out.textContent = "";
+                postJSON("/plugin-io/api/gcal_sync/google/admin/dryrun-provider", { staff_id: row.getAttribute("data-staff-id") }).then(function (res) {
+                    rowButtons.forEach(function (b) { b.disabled = false; });
+                    button.textContent = originalLabel;
+                    if (res.ok) {
+                        var b = res.body;
+                        var parts = [
+                            (b.holds_created || 0) + " would import",
+                            (b.holds_updated || 0) + " would update"
+                        ];
+                        if (b.holds_unchanged) parts.push(b.holds_unchanged + " already current");
+                        if (b.holds_removed) parts.push(b.holds_removed + " would remove");
+                        msg.textContent = "Dry-run (no changes): " + parts.join(", ") + ".";
+                        msg.className = "status-msg ok";
+                        var trace = b.trace || [];
+                        if (trace.length) {
+                            out.textContent = trace.join("\n");
+                            out.hidden = false;
+                        } else {
+                            out.textContent = "No events on this calendar in the import window.";
+                            out.hidden = false;
+                        }
+                    } else {
+                        msg.textContent = res.body.error || "Error";
+                        msg.className = "status-msg err";
+                    }
+                }).catch(function () {
+                    rowButtons.forEach(function (b) { b.disabled = false; });
+                    button.textContent = originalLabel;
+                    msg.textContent = "Network error";
+                    msg.className = "status-msg err";
+                });
+            });
+        });
         rowAction(".purge-row-btn", "/plugin-io/api/gcal_sync/google/admin/purge-provider", "Purge",
             "Purge ALL imported holds for this provider? This cancels their gcal-sync holds and clears their sync mappings. It does NOT rebuild (use Re-import for that), and cannot be undone.");
 
@@ -475,6 +567,84 @@
             }).catch(function () {
                 msg.textContent = "Network error";
                 msg.className = "status-msg err";
+            });
+        });
+
+        // Re-import all: queue every enabled provider for a rebuild. This request only enqueues (fast,
+        // synchronous DB writes), so it returns right away; a background cron then rebuilds a few
+        // providers every couple of minutes until the queue drains. Idempotent — clicking again while
+        // a drain is in flight won't double any provider's work.
+        document.getElementById("reimport-all-btn").addEventListener("click", function () {
+            if (!window.confirm(
+                "Queue ALL enabled providers for re-import from their Google calendars?\n\n"
+                + "Providers rebuild a few at a time over the next several minutes. It adopts existing "
+                + "holds and recreates missing/cancelled ones (no duplicates), and does not remove "
+                + "anything. Refresh this page as it progresses to see updated counts."
+            )) return;
+            var msg = document.getElementById("reconcile-msg");
+            var btn = this;
+            btn.disabled = true;
+            msg.textContent = "Queuing\u2026";
+            msg.className = "status-msg";
+            fetch("/plugin-io/api/gcal_sync/google/admin/reimport-all", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                credentials: "same-origin",
+                body: "{}"
+            }).then(function (r) {
+                return r.json().then(function (j) {
+                    if (r.ok) {
+                        msg.textContent = "Queued " + j.queued + " provider(s) for re-import ("
+                            + j.pending + " pending). They rebuild a few at a time over the next several "
+                            + "minutes \u2014 refresh to watch counts update. Safe to click again.";
+                        msg.className = "status-msg ok";
+                    } else {
+                        msg.textContent = (j && j.error) || "Could not queue re-import all";
+                        msg.className = "status-msg err";
+                        btn.disabled = false;
+                    }
+                });
+            }).catch(function () {
+                msg.textContent = "Network error queuing re-import all";
+                msg.className = "status-msg err";
+                btn.disabled = false;
+            });
+        });
+
+        // Cancel re-import: empty the queue so the drain cron stops. A batch already mid-run finishes
+        // (a few providers), but nothing new is picked up. Holds already rebuilt are kept.
+        document.getElementById("cancel-reimport-btn").addEventListener("click", function () {
+            if (!window.confirm(
+                "Cancel the in-progress re-import?\n\n"
+                + "This clears the queue so no further providers are rebuilt (a batch already running "
+                + "finishes). Holds already rebuilt are kept. You can start 'Re-import all' again later."
+            )) return;
+            var msg = document.getElementById("reconcile-msg");
+            var btn = this;
+            btn.disabled = true;
+            msg.textContent = "Cancelling\u2026";
+            msg.className = "status-msg";
+            fetch("/plugin-io/api/gcal_sync/google/admin/cancel-reimport-all", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                credentials: "same-origin",
+                body: "{}"
+            }).then(function (r) {
+                return r.json().then(function (j) {
+                    if (r.ok) {
+                        msg.textContent = "Re-import cancelled \u2014 cleared " + j.cleared + " queued "
+                            + "provider(s). A batch already running will finish; nothing new starts.";
+                        msg.className = "status-msg ok";
+                    } else {
+                        msg.textContent = (j && j.error) || "Could not cancel re-import";
+                        msg.className = "status-msg err";
+                    }
+                    btn.disabled = false;
+                });
+            }).catch(function () {
+                msg.textContent = "Network error cancelling re-import";
+                msg.className = "status-msg err";
+                btn.disabled = false;
             });
         });
     </script>

--- a/extensions/gcal_sync/tests/test_blocks.py
+++ b/extensions/gcal_sync/tests/test_blocks.py
@@ -74,7 +74,7 @@ def test_upsert_inserts_when_no_mapping(mocker):
     sync = _sync(mocker)
     fake = FakeClient()
     stats = {"pushed": 0, "deleted": 0}
-    sync._upsert(fake, "cal@x", "e1", _event(), stats)
+    sync._upsert(fake, "cal@x", "e1", _event(), stats, {})
     assert ("insert", "cal@x") in fake.calls
     model.objects.create.assert_called_once()
     assert stats["pushed"] == 1
@@ -84,20 +84,20 @@ def test_upsert_skips_when_unchanged(mocker):
     event = _event()
     unchanged_hash = content_hash(build_event_body(block_snapshot(event)))
     model = mocker.patch("gcal_sync.blocks.CalendarEventMapping")
-    model.objects.filter.return_value.first.return_value = SimpleNamespace(
+    existing = SimpleNamespace(
         google_calendar_id="cal@x", google_event_id="g-1", last_pushed_hash=unchanged_hash
     )
     sync = _sync(mocker)
     fake = FakeClient()
     stats = {"pushed": 0, "deleted": 0}
-    sync._upsert(fake, "cal@x", "e1", event, stats)
+    sync._upsert(fake, "cal@x", "e1", event, stats, {"e1": existing})
     assert fake.calls == []  # no Google call when nothing changed
     assert stats["pushed"] == 0
 
 
 def test_upsert_patches_when_changed(mocker):
     model = mocker.patch("gcal_sync.blocks.CalendarEventMapping")
-    model.objects.filter.return_value.first.return_value = SimpleNamespace(
+    existing = SimpleNamespace(
         google_calendar_id="cal@x",
         google_event_id="g-1",
         last_pushed_hash="stale",
@@ -106,7 +106,7 @@ def test_upsert_patches_when_changed(mocker):
     sync = _sync(mocker)
     fake = FakeClient()
     stats = {"pushed": 0, "deleted": 0}
-    sync._upsert(fake, "cal@x", "e1", _event(), stats)
+    sync._upsert(fake, "cal@x", "e1", _event(), stats, {"e1": existing})
     assert ("patch", "cal@x", "g-1") in fake.calls
     assert stats["pushed"] == 1
 

--- a/extensions/gcal_sync/tests/test_blocks_coverage.py
+++ b/extensions/gcal_sync/tests/test_blocks_coverage.py
@@ -1,0 +1,135 @@
+"""Tests for blocks.py: block_snapshot edge cases, _upsert self-heal, sync_all_blocks error handling."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from gcal_sync.blocks import BlockSync, block_snapshot, sync_all_blocks
+from gcal_sync.google.client import GoogleApiError
+
+
+SECRETS = {"GOOGLE_SERVICE_ACCOUNT_JSON": '{"client_email": "svc@x.iam", "private_key": "KEY"}'}
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def insert_event(self, calendar_id, body):
+        self.calls.append(("insert", calendar_id))
+        return {"id": "g-new"}
+
+    def patch_event(self, calendar_id, event_id, body):
+        self.calls.append(("patch", calendar_id, event_id))
+        return {"id": event_id}
+
+    def delete_event(self, calendar_id, event_id):
+        self.calls.append(("delete", calendar_id, event_id))
+
+
+def _event(event_id="e1", title="Lunch", ends_at=None):
+    return SimpleNamespace(
+        id=event_id,
+        title=title,
+        starts_at=datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc),
+        ends_at=ends_at or datetime(2026, 6, 10, 13, 0, tzinfo=timezone.utc),
+    )
+
+
+# --- block_snapshot edge case: None title ----------------------------------------------------------
+
+
+def test_block_snapshot_none_title():
+    event = SimpleNamespace(
+        id="e1",
+        title=None,
+        starts_at=datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 6, 10, 13, 0, tzinfo=timezone.utc),
+    )
+    snap = block_snapshot(event)
+    assert snap["visit_type"] == "Blocked"
+
+
+def test_block_snapshot_no_end_defaults_30():
+    event = SimpleNamespace(
+        id="e1",
+        title="PTO",
+        starts_at=datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc),
+        ends_at=None,
+    )
+    snap = block_snapshot(event)
+    assert snap["duration_minutes"] == 30
+
+
+# --- _upsert self-heal: patch 404 -> re-insert ---------------------------------------------------
+
+
+def test_upsert_self_heals_on_404(mocker):
+    model = mocker.patch("gcal_sync.blocks.CalendarEventMapping")
+    existing = SimpleNamespace(
+        google_calendar_id="cal@x",
+        google_event_id="g-1",
+        last_pushed_hash="stale",
+        save=mocker.Mock(),
+    )
+
+    class Client404(FakeClient):
+        def patch_event(self, calendar_id, event_id, body):
+            raise GoogleApiError(404, "not found")
+
+    sync = BlockSync(SECRETS, client_factory=lambda cal: FakeClient())
+    fake = Client404()
+    stats = {"pushed": 0, "deleted": 0}
+    sync._upsert(fake, "cal@x", "e1", _event(), stats, {"e1": existing})
+    # Re-insert after 404
+    assert ("insert", "cal@x") in fake.calls
+    assert existing.google_event_id == "g-new"
+    assert stats["pushed"] == 1
+
+
+def test_upsert_self_heals_on_410(mocker):
+    model = mocker.patch("gcal_sync.blocks.CalendarEventMapping")
+    existing = SimpleNamespace(
+        google_calendar_id="cal@x",
+        google_event_id="g-1",
+        last_pushed_hash="stale",
+        save=mocker.Mock(),
+    )
+
+    class Client410(FakeClient):
+        def patch_event(self, calendar_id, event_id, body):
+            raise GoogleApiError(410, "gone")
+
+    sync = BlockSync(SECRETS, client_factory=lambda cal: FakeClient())
+    fake = Client410()
+    stats = {"pushed": 0, "deleted": 0}
+    sync._upsert(fake, "cal@x", "e1", _event(), stats, {"e1": existing})
+    assert ("insert", "cal@x") in fake.calls
+    assert stats["pushed"] == 1
+
+
+# --- sync_all_blocks error handling ---------------------------------------------------------------
+
+
+def test_sync_all_blocks_catches_per_provider_error(mocker):
+    mocker.patch("gcal_sync.blocks.GoogleAuth")
+    mocker.patch("gcal_sync.blocks.GoogleCalendarClient")
+    block_sync = mocker.patch("gcal_sync.blocks.BlockSync")
+    block_sync.return_value.sync_provider.side_effect = GoogleApiError(500, "boom")
+    mapping = SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1")
+    totals = sync_all_blocks({}, [mapping])
+    assert totals["pushed"] == 0
+    assert totals["deleted"] == 0
+
+
+def test_sync_all_blocks_aggregates_stats(mocker):
+    mocker.patch("gcal_sync.blocks.GoogleAuth")
+    mocker.patch("gcal_sync.blocks.GoogleCalendarClient")
+    block_sync = mocker.patch("gcal_sync.blocks.BlockSync")
+    block_sync.return_value.sync_provider.return_value = {"pushed": 2, "deleted": 1}
+    mappings = [
+        SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1"),
+        SimpleNamespace(canvas_staff_id="15", google_calendar_id="c2"),
+    ]
+    totals = sync_all_blocks({}, mappings)
+    assert totals["pushed"] == 4
+    assert totals["deleted"] == 2

--- a/extensions/gcal_sync/tests/test_blocks_sync.py
+++ b/extensions/gcal_sync/tests/test_blocks_sync.py
@@ -66,7 +66,7 @@ def test_upsert_inserts_new_block(mocker):
         ends_at=datetime(2026, 6, 22, 12, 30, tzinfo=timezone.utc),
     )
     stats = {"pushed": 0, "deleted": 0}
-    bs._upsert(client, "cal", "ev1", event, stats)
+    bs._upsert(client, "cal", "ev1", event, stats, {})
     client.insert_event.assert_called_once()
     cem.objects.create.assert_called_once()
     assert stats["pushed"] == 1
@@ -75,7 +75,7 @@ def test_upsert_inserts_new_block(mocker):
 def test_upsert_skips_unchanged(mocker):
     bs = _bs()
     cem = mocker.patch("gcal_sync.blocks.CalendarEventMapping")
-    cem.objects.filter.return_value.first.return_value = SimpleNamespace(
+    existing = SimpleNamespace(
         last_pushed_hash="h1", google_calendar_id="cal", google_event_id="g1"
     )
     mocker.patch("gcal_sync.blocks.build_event_body", return_value={})
@@ -87,7 +87,7 @@ def test_upsert_skips_unchanged(mocker):
         ends_at=datetime(2026, 6, 22, 12, 30, tzinfo=timezone.utc),
     )
     stats = {"pushed": 0, "deleted": 0}
-    bs._upsert(client, "cal", "ev1", event, stats)
+    bs._upsert(client, "cal", "ev1", event, stats, {"ev1": existing})
     client.patch_event.assert_not_called()  # unchanged -> no Google call
     assert stats["pushed"] == 0
 
@@ -108,6 +108,7 @@ def test_delete_removed_drops_orphans(mocker):
 def test_sync_provider_upserts_then_deletes(mocker):
     bs = _bs()
     mocker.patch.object(bs, "_current_blocks", return_value={"ev1": SimpleNamespace(id="ev1")})
+    mocker.patch("gcal_sync.blocks.CalendarEventMapping").objects.filter.return_value = []
     up = mocker.patch.object(bs, "_upsert")
     rm = mocker.patch.object(bs, "_delete_removed")
     bs.sync_provider("14", "cal")

--- a/extensions/gcal_sync/tests/test_client_coverage.py
+++ b/extensions/gcal_sync/tests/test_client_coverage.py
@@ -1,0 +1,201 @@
+"""Tests for google/client.py: GoogleRateLimitError, _error_for, find_event_by_private_property,
+list_all_events.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gcal_sync.google.client import (
+    GoogleApiError,
+    GoogleCalendarClient,
+    GoogleRateLimitError,
+    _error_for,
+)
+
+
+def _client(mocker):
+    http = mocker.patch("gcal_sync.google.client.Http").return_value
+    return GoogleCalendarClient("tok"), http
+
+
+def _resp(status, body=None, text="err"):
+    return SimpleNamespace(status_code=status, json=lambda: (body or {}), text=text)
+
+
+# --- _error_for -----------------------------------------------------------------------------------
+
+
+def test_error_for_rate_limit_403_usage_limits():
+    exc = _error_for(403, '{"error": {"errors": [{"domain": "usageLimits"}]}}')
+    assert isinstance(exc, GoogleRateLimitError)
+    assert exc.status_code == 403
+
+
+def test_error_for_rate_limit_429():
+    exc = _error_for(429, "rateLimitExceeded")
+    assert isinstance(exc, GoogleRateLimitError)
+    assert exc.status_code == 429
+
+
+def test_error_for_rate_limit_user_rate():
+    exc = _error_for(403, "userRateLimitExceeded")
+    assert isinstance(exc, GoogleRateLimitError)
+
+
+def test_error_for_quota_exceeded():
+    exc = _error_for(403, "quotaExceeded")
+    assert isinstance(exc, GoogleRateLimitError)
+
+
+def test_error_for_daily_limit():
+    exc = _error_for(429, "dailyLimitExceeded")
+    assert isinstance(exc, GoogleRateLimitError)
+
+
+def test_error_for_plain_403_is_not_rate_limit():
+    exc = _error_for(403, "forbidden: not shared")
+    assert isinstance(exc, GoogleApiError)
+    assert not isinstance(exc, GoogleRateLimitError)
+
+
+def test_error_for_500_is_plain_error():
+    exc = _error_for(500, "server error")
+    assert isinstance(exc, GoogleApiError)
+    assert not isinstance(exc, GoogleRateLimitError)
+
+
+# --- GoogleRateLimitError is a subclass of GoogleApiError -----------------------------------------
+
+
+def test_rate_limit_error_is_api_error():
+    exc = GoogleRateLimitError(429, "too many")
+    assert isinstance(exc, GoogleApiError)
+    assert exc.status_code == 429
+    assert "429" in str(exc)
+
+
+# --- find_event_by_private_property ---------------------------------------------------------------
+
+
+def test_find_event_returns_first_match(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(200, {"items": [{"id": "g1"}]})
+    result = client.find_event_by_private_property("cal@x", "canvasApptId", "appt-1")
+    assert result["id"] == "g1"
+    # URL should contain the privateExtendedProperty param
+    url = http.get.call_args.args[0]
+    assert "privateExtendedProperty" in url
+
+
+def test_find_event_returns_none_when_empty(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(200, {"items": []})
+    result = client.find_event_by_private_property("cal@x", "canvasApptId", "appt-1")
+    assert result is None
+
+
+def test_find_event_raises_on_error(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(500, text="server error")
+    with pytest.raises(GoogleApiError):
+        client.find_event_by_private_property("cal@x", "canvasApptId", "appt-1")
+
+
+def test_find_event_raises_rate_limit_on_403(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(403, text="usageLimits")
+    with pytest.raises(GoogleRateLimitError):
+        client.find_event_by_private_property("cal@x", "canvasApptId", "appt-1")
+
+
+# --- list_all_events ------------------------------------------------------------------------------
+
+
+def test_list_all_events_single_page(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(200, {"items": [{"id": "a"}, {"id": "b"}]})
+    events = client.list_all_events("cal@x", "2026-01-01T00:00:00Z", "2027-01-01T00:00:00Z")
+    assert len(events) == 2
+    assert events[0]["id"] == "a"
+
+
+def test_list_all_events_follows_pagination(mocker):
+    client, http = _client(mocker)
+    http.get.side_effect = [
+        _resp(200, {"items": [{"id": "a"}], "nextPageToken": "p2"}),
+        _resp(200, {"items": [{"id": "b"}]}),
+    ]
+    events = client.list_all_events("cal@x", "2026-01-01T00:00:00Z", "2027-01-01T00:00:00Z")
+    assert [e["id"] for e in events] == ["a", "b"]
+    assert http.get.call_count == 2
+    # Second call should carry the page token
+    second_url = http.get.call_args_list[1].args[0]
+    assert "pageToken=p2" in second_url
+
+
+def test_list_all_events_raises_on_error(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(500, text="boom")
+    with pytest.raises(GoogleApiError):
+        client.list_all_events("cal@x", "2026-01-01T00:00:00Z", "2027-01-01T00:00:00Z")
+
+
+def test_list_all_events_uses_single_events_true(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(200, {"items": []})
+    client.list_all_events("cal@x", "2026-01-01T00:00:00Z", "2027-01-01T00:00:00Z")
+    url = http.get.call_args.args[0]
+    assert "singleEvents=true" in url
+    assert "timeMin=" in url
+    assert "timeMax=" in url
+
+
+# --- list_event_deltas uses full pull time params when no sync token -----
+
+
+def test_list_event_deltas_full_pull_params(mocker):
+    client, http = _client(mocker)
+    http.get.return_value = _resp(200, {"items": [], "nextSyncToken": "tok"})
+    events, token = client.list_event_deltas(
+        "cal@x", sync_token="", time_min="2026-01-01T00:00:00Z", time_max="2027-01-01T00:00:00Z"
+    )
+    url = http.get.call_args.args[0]
+    assert "timeMin=" in url
+    assert "timeMax=" in url
+    assert "syncToken" not in url
+    assert token == "tok"
+
+
+# --- insert_event 201 is success ---
+
+
+def test_insert_event_accepts_201(mocker):
+    client, http = _client(mocker)
+    http.post.return_value = _resp(201, {"id": "g-1"})
+    result = client.insert_event("cal@x", {})
+    assert result["id"] == "g-1"
+
+
+# --- insert/patch/delete raise rate limit on 429 ---
+
+
+def test_insert_event_raises_rate_limit_on_429(mocker):
+    client, http = _client(mocker)
+    http.post.return_value = _resp(429, text="rateLimitExceeded")
+    with pytest.raises(GoogleRateLimitError):
+        client.insert_event("cal@x", {})
+
+
+def test_patch_event_raises_rate_limit_on_429(mocker):
+    client, http = _client(mocker)
+    http.patch.return_value = _resp(429, text="rateLimitExceeded")
+    with pytest.raises(GoogleRateLimitError):
+        client.patch_event("cal@x", "e1", {})
+
+
+def test_delete_event_raises_rate_limit_on_429(mocker):
+    client, http = _client(mocker)
+    http.delete.return_value = _resp(429, text="rateLimitExceeded")
+    with pytest.raises(GoogleRateLimitError):
+        client.delete_event("cal@x", "e1")

--- a/extensions/gcal_sync/tests/test_google_admin.py
+++ b/extensions/gcal_sync/tests/test_google_admin.py
@@ -119,6 +119,8 @@ def test_reconcile_one_runs_for_enrolled_provider(mocker):
         "gcal_sync.routes.google_admin.reconcile_provider",
         return_value=({"pushed": 1, "blocks_pushed": 0, "blocks_deleted": 0}, ["E"]),
     )
+    mocker.patch("gcal_sync.routes.google_admin.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.routes.google_admin.release_provider_lock")
     api = _api({"ADMIN_STAFF_IDS": "id1"}, staff_id="id1", body={"staff_id": "14"})
     resp = api.reconcile_one()
     # effects are applied alongside the JSON summary.

--- a/extensions/gcal_sync/tests/test_google_admin_coverage.py
+++ b/extensions/gcal_sync/tests/test_google_admin_coverage.py
@@ -1,0 +1,179 @@
+"""Tests for remaining uncovered google_admin routes: dryrun-provider, reimport-all,
+cancel-reimport-all, purge with chunked mode, provider_action lock conflict, and
+provider_action error handling.
+"""
+
+from http import HTTPStatus
+from types import SimpleNamespace
+
+from gcal_sync.google.auth import GoogleAuthError
+from gcal_sync.google.client import GoogleApiError
+from gcal_sync.routes.google_admin import GoogleCalendarAdminAPI, parse_provider_emails
+
+
+def _api(secrets=None, staff_id="", body=None):
+    api = GoogleCalendarAdminAPI.__new__(GoogleCalendarAdminAPI)
+    api.secrets = secrets or {}
+    api.request = SimpleNamespace(
+        headers={"canvas-logged-in-user-id": staff_id}, json=lambda: (body or {})
+    )
+    return api
+
+
+# --- parse_provider_emails -----------------------------------------------------------------------
+
+
+def test_parse_provider_emails_basic():
+    csv = "Email,First,Last\njoe@x.com,Joe,Ryan\n\nbad-line\njane@x.com,Jane,Smith"
+    result = parse_provider_emails(csv)
+    assert result == ["joe@x.com", "jane@x.com"]
+
+
+def test_parse_provider_emails_skips_header_row():
+    csv = "email\njo@x.com"
+    result = parse_provider_emails(csv)
+    assert result == ["jo@x.com"]
+
+
+# --- dryrun_one -----------------------------------------------------------------------------------
+
+
+def test_dryrun_forbidden_for_non_admin():
+    resp = _api({"ADMIN_STAFF_IDS": ""}, body={"staff_id": "14"}).dryrun_one()
+    assert resp[0].status_code == HTTPStatus.FORBIDDEN
+
+
+def test_dryrun_rejects_unenrolled(mocker):
+    scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = None
+    resp = _api(
+        {"ADMIN_STAFF_IDS": "id1"}, staff_id="id1", body={"staff_id": "99"}
+    ).dryrun_one()
+    assert resp[0].status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_dryrun_returns_stats_without_effects(mocker):
+    scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="j@r.com", active=True
+    )
+    mocker.patch(
+        "gcal_sync.routes.google_admin.reimport_provider",
+        return_value=({"holds_created": 3, "holds_updated": 1}, ["WOULD_BE_EFFECT"]),
+    )
+    resp = _api(
+        {"ADMIN_STAFF_IDS": "id1"}, staff_id="id1", body={"staff_id": "14"}
+    ).dryrun_one()
+    # Effects are discarded in dry_run; only JSON summary returned
+    assert len(resp) == 1
+    assert resp[0].status_code == HTTPStatus.OK
+
+
+def test_dryrun_handles_error(mocker):
+    scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="j@r.com", active=True
+    )
+    mocker.patch(
+        "gcal_sync.routes.google_admin.reimport_provider",
+        side_effect=GoogleApiError(500, "fail"),
+    )
+    resp = _api(
+        {"ADMIN_STAFF_IDS": "id1"}, staff_id="id1", body={"staff_id": "14"}
+    ).dryrun_one()
+    assert resp[0].status_code == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+# --- reimport_all ----------------------------------------------------------------------------------
+
+
+def test_reimport_all_forbidden_for_non_admin():
+    resp = _api({"ADMIN_STAFF_IDS": ""}).reimport_all()
+    assert resp[0].status_code == HTTPStatus.FORBIDDEN
+
+
+def test_reimport_all_queues_and_returns_stats(mocker):
+    mocker.patch("gcal_sync.routes.google_admin.enqueue_fleet_reimport", return_value=5)
+    mocker.patch("gcal_sync.routes.google_admin.reimport_queue_depth", return_value=5)
+    resp = _api({"ADMIN_STAFF_IDS": "id1"}, staff_id="id1").reimport_all()
+    assert resp[0].status_code == HTTPStatus.OK
+
+
+# --- cancel_reimport_all --------------------------------------------------------------------------
+
+
+def test_cancel_reimport_all_forbidden_for_non_admin():
+    resp = _api({"ADMIN_STAFF_IDS": ""}).cancel_reimport_all()
+    assert resp[0].status_code == HTTPStatus.FORBIDDEN
+
+
+def test_cancel_reimport_all_clears_queue(mocker):
+    mocker.patch("gcal_sync.routes.google_admin.cancel_fleet_reimport", return_value=3)
+    mocker.patch("gcal_sync.routes.google_admin.reimport_queue_depth", return_value=0)
+    resp = _api({"ADMIN_STAFF_IDS": "id1"}, staff_id="id1").cancel_reimport_all()
+    assert resp[0].status_code == HTTPStatus.OK
+
+
+# --- purge with chunked mode ----------------------------------------------------------------------
+
+
+def test_purge_chunked_mode(mocker):
+    scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="j@r.com"
+    )
+    mocker.patch(
+        "gcal_sync.routes.google_admin.purge_holds_chunk",
+        return_value=(["C1"], "last-id", False),
+    )
+    resp = _api(
+        {"ADMIN_STAFF_IDS": "id1"},
+        staff_id="id1",
+        body={"staff_id": "14", "limit": 50, "after_id": ""},
+    ).purge_one()
+    # Effects + JSON
+    assert "C1" in resp
+    assert resp[-1].status_code == HTTPStatus.OK
+
+
+# --- provider_action lock conflict ----------------------------------------------------------------
+
+
+def test_provider_action_lock_conflict_returns_409(mocker):
+    scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="j@r.com"
+    )
+    mocker.patch("gcal_sync.routes.google_admin.acquire_provider_lock", return_value=False)
+    resp = _api(
+        {"ADMIN_STAFF_IDS": "id1"}, staff_id="id1", body={"staff_id": "14"}
+    ).reconcile_one()
+    assert resp[0].status_code == HTTPStatus.CONFLICT
+
+
+# --- provider_action error handling ---------------------------------------------------------------
+
+
+def test_provider_action_error_returns_503(mocker):
+    scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="j@r.com"
+    )
+    mocker.patch("gcal_sync.routes.google_admin.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.routes.google_admin.release_provider_lock")
+    mocker.patch(
+        "gcal_sync.routes.google_admin.reconcile_provider",
+        side_effect=GoogleAuthError("auth fail"),
+    )
+    resp = _api(
+        {"ADMIN_STAFF_IDS": "id1"}, staff_id="id1", body={"staff_id": "14"}
+    ).reconcile_one()
+    assert resp[0].status_code == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+# --- auto_map forbidden ---------------------------------------------------------------------------
+
+
+def test_auto_map_forbidden_for_non_admin():
+    resp = _api({"ADMIN_STAFF_IDS": ""}).auto_map()
+    assert resp[0].status_code == HTTPStatus.FORBIDDEN

--- a/extensions/gcal_sync/tests/test_google_admin_more.py
+++ b/extensions/gcal_sync/tests/test_google_admin_more.py
@@ -137,10 +137,13 @@ def test_latest_channel_by_calendar_keeps_newest(mocker):
 def test_page_context_builds_rows(mocker):
     scm = mocker.patch("gcal_sync.routes.google_admin.StaffCalendarMapping")
     scm.objects.all.return_value = [
-        SimpleNamespace(canvas_staff_id="14", google_calendar_id="j@r.com", active=True)
+        SimpleNamespace(canvas_staff_id="14", google_calendar_id="j@r.com", active=True,
+                        last_outbound_synced_at=None)
     ]
     css = mocker.patch("gcal_sync.routes.google_admin.CalendarSyncState")
     css.objects.all.return_value = []
+    aem = mocker.patch("gcal_sync.routes.google_admin.AppointmentEventMapping")
+    aem.objects.values.return_value.annotate.return_value = []
     staff = mocker.patch("gcal_sync.routes.google_admin.Staff")
     staff.objects.filter.return_value.values.return_value.order_by.return_value = [
         {"id": 14, "first_name": "Joe", "last_name": "Ryan", "user__email": "j@r.com"}

--- a/extensions/gcal_sync/tests/test_handlers_coverage.py
+++ b/extensions/gcal_sync/tests/test_handlers_coverage.py
@@ -1,0 +1,52 @@
+"""Tests for the two new CronTask handlers: OutboundBackfillDrainCron and ReimportDrainCron."""
+
+from gcal_sync.handlers.outbound_backfill import OutboundBackfillDrainCron
+from gcal_sync.handlers.reimport_drain import ReimportDrainCron
+
+
+def _cron(cls, secrets=None):
+    handler = cls.__new__(cls)
+    handler.secrets = secrets or {}
+    return handler
+
+
+# --- OutboundBackfillDrainCron --------------------------------------------------------------------
+
+
+def test_outbound_backfill_cron_delegates_to_drain(mocker):
+    drain = mocker.patch(
+        "gcal_sync.handlers.outbound_backfill.drain_outbound_backfill",
+        return_value={"providers": 1, "pushed": 10, "skipped": 0},
+    )
+    result = _cron(OutboundBackfillDrainCron, {"KEY": "val"}).execute()
+    assert result == []
+    drain.assert_called_once_with({"KEY": "val"})
+
+
+def test_outbound_backfill_cron_schedule():
+    assert OutboundBackfillDrainCron.SCHEDULE == "*/2 * * * *"
+
+
+# --- ReimportDrainCron ---------------------------------------------------------------------------
+
+
+def test_reimport_drain_cron_returns_effects(mocker):
+    mocker.patch(
+        "gcal_sync.handlers.reimport_drain.drain_reimport_queue",
+        return_value=({"processed": 1}, ["EFFECT_1", "EFFECT_2"]),
+    )
+    result = _cron(ReimportDrainCron, {"KEY": "val"}).execute()
+    assert result == ["EFFECT_1", "EFFECT_2"]
+
+
+def test_reimport_drain_cron_returns_empty_when_queue_empty(mocker):
+    mocker.patch(
+        "gcal_sync.handlers.reimport_drain.drain_reimport_queue",
+        return_value=({"processed": 0}, []),
+    )
+    result = _cron(ReimportDrainCron).execute()
+    assert result == []
+
+
+def test_reimport_drain_cron_schedule():
+    assert ReimportDrainCron.SCHEDULE == "*/2 * * * *"

--- a/extensions/gcal_sync/tests/test_inbound_coverage.py
+++ b/extensions/gcal_sync/tests/test_inbound_coverage.py
@@ -1,0 +1,557 @@
+"""Tests for inbound.py: dry-run mode, force_rebuild, convergence guard, import window guard,
+provider-scoped lookups, event_line, dry_trace, and process_calendar dry_run mode.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import arrow
+import pytest
+
+from gcal_sync.google.client import GoogleApiError
+from gcal_sync.google.event_builder import CANVAS_APPT_ID_KEY, build_event_body, content_hash
+from gcal_sync.inbound import InboundSync, _dry_trace, _event_line, _event_log, _MAX_TRACE
+
+SECRETS = {"GOOGLE_SERVICE_ACCOUNT_JSON": '{"client_email": "svc@x.iam", "private_key": "KEY"}'}
+
+
+def _inbound(mocker):
+    inbound = InboundSync(SECRETS, client_factory=lambda cal: object())
+    mocker.patch.object(inbound._sync, "push")
+    mocker.patch.object(inbound._sync, "remove")
+    return inbound
+
+
+def _stats(dry_run=False):
+    s = {
+        "processed": 0,
+        "echoes": 0,
+        "reverted": 0,
+        "holds_created": 0,
+        "holds_updated": 0,
+        "holds_unchanged": 0,
+        "holds_removed": 0,
+        "ignored": 0,
+        "full_resync": False,
+    }
+    if dry_run:
+        s["trace"] = []
+    return s
+
+
+# --- _event_line ---------------------------------------------------------------------------------
+
+
+def test_event_line_masks_private_title():
+    event = {
+        "start": {"dateTime": "2026-06-10T15:00:00Z"},
+        "end": {"dateTime": "2026-06-10T15:30:00Z"},
+        "visibility": "private",
+        "summary": "Secret stuff",
+    }
+    line = _event_line(event)
+    assert "Secret" not in line
+    assert "Busy" in line
+
+
+def test_event_line_shows_public_title():
+    event = {
+        "start": {"dateTime": "2026-06-10T15:00:00Z"},
+        "end": {"dateTime": "2026-06-10T15:30:00Z"},
+        "summary": "Team standup",
+    }
+    line = _event_line(event)
+    assert "Team standup" in line
+
+
+def test_event_line_no_start():
+    line = _event_line({"summary": "No time"})
+    assert "(no start)" in line
+
+
+def test_event_line_no_summary():
+    event = {
+        "start": {"dateTime": "2026-06-10T15:00:00Z"},
+        "end": {"dateTime": "2026-06-10T15:30:00Z"},
+    }
+    line = _event_line(event)
+    assert "Busy" in line
+
+
+# --- _dry_trace ----------------------------------------------------------------------------------
+
+
+def test_dry_trace_appends_when_trace_present():
+    stats = {"trace": []}
+    event = {"start": {"dateTime": "2026-06-10T15:00:00Z"}, "summary": "Test"}
+    _dry_trace(stats, "would import", event)
+    assert len(stats["trace"]) == 1
+    assert "would import" in stats["trace"][0]
+
+
+def test_dry_trace_noop_without_trace_key():
+    stats = {}
+    _dry_trace(stats, "would import", {"summary": "Test"})
+    assert "trace" not in stats
+
+
+def test_dry_trace_caps_at_max():
+    stats = {"trace": ["x"] * _MAX_TRACE}
+    _dry_trace(stats, "overflow", {"summary": "Test"})
+    assert len(stats["trace"]) == _MAX_TRACE + 1
+    assert "capped" in stats["trace"][-1]
+    # One more after cap -> no growth
+    _dry_trace(stats, "overflow again", {"summary": "Test"})
+    assert len(stats["trace"]) == _MAX_TRACE + 1
+
+
+# --- _event_log -----------------------------------------------------------------------------------
+
+
+def test_event_log_emits_when_verbose(mocker):
+    log = mocker.patch("gcal_sync.inbound.log")
+    _event_log(True, "create", "cal", "p1", "g1")
+    log.info.assert_called_once()
+
+
+def test_event_log_silent_when_not_verbose(mocker):
+    log = mocker.patch("gcal_sync.inbound.log")
+    _event_log(False, "create", "cal", "p1", "g1")
+    log.info.assert_not_called()
+
+
+# --- _within_import_window ------------------------------------------------------------------------
+
+
+def test_within_import_window_true_for_current_events(mocker):
+    inbound = _inbound(mocker)
+    event = {
+        "start": {"dateTime": arrow.utcnow().format("YYYY-MM-DD[T]HH:mm:ss[Z]")},
+    }
+    assert inbound._within_import_window(event) is True
+
+
+def test_within_import_window_false_for_far_future(mocker):
+    inbound = _inbound(mocker)
+    event = {
+        "start": {"dateTime": arrow.utcnow().shift(years=2).format("YYYY-MM-DD[T]HH:mm:ss[Z]")},
+    }
+    assert inbound._within_import_window(event) is False
+
+
+def test_within_import_window_false_for_far_past(mocker):
+    inbound = _inbound(mocker)
+    event = {
+        "start": {"dateTime": arrow.utcnow().shift(years=-2).format("YYYY-MM-DD[T]HH:mm:ss[Z]")},
+    }
+    assert inbound._within_import_window(event) is False
+
+
+def test_within_import_window_true_when_no_start(mocker):
+    inbound = _inbound(mocker)
+    assert inbound._within_import_window({}) is True
+
+
+# --- _canvas_id_for_google_event ------------------------------------------------------------------
+
+
+def test_canvas_id_for_google_event_returns_id(mocker):
+    aei = mocker.patch("gcal_sync.inbound.AppointmentExternalIdentifier")
+    aei.objects.filter.return_value.exclude.return_value.values_list.return_value.first.return_value = 42
+    result = InboundSync._canvas_id_for_google_event("g1", "p1")
+    assert result == "42"
+
+
+def test_canvas_id_for_google_event_returns_none(mocker):
+    aei = mocker.patch("gcal_sync.inbound.AppointmentExternalIdentifier")
+    aei.objects.filter.return_value.exclude.return_value.values_list.return_value.first.return_value = None
+    result = InboundSync._canvas_id_for_google_event("g1", "p1")
+    assert result is None
+
+
+# --- _external_hold_exists ------------------------------------------------------------------------
+
+
+def test_external_hold_exists_true(mocker):
+    aei = mocker.patch("gcal_sync.inbound.AppointmentExternalIdentifier")
+    aei.objects.filter.return_value.exists.return_value = True
+    assert InboundSync._external_hold_exists("g1", "p1") is True
+
+
+def test_external_hold_exists_false(mocker):
+    aei = mocker.patch("gcal_sync.inbound.AppointmentExternalIdentifier")
+    aei.objects.filter.return_value.exists.return_value = False
+    assert InboundSync._external_hold_exists("g1", "p1") is False
+
+
+# --- _hold_delete_effect --------------------------------------------------------------------------
+
+
+def test_hold_delete_effect_returns_none_when_no_canvas_id(mocker):
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    assert inbound._hold_delete_effect("g1", "p1") is None
+
+
+def test_hold_delete_effect_returns_effect_when_found(mocker):
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-1")
+    se = mocker.patch("gcal_sync.inbound.ScheduleEvent")
+    result = inbound._hold_delete_effect("g1", "p1")
+    se.assert_called_once_with(instance_id="appt-1")
+    assert result is not None
+
+
+# --- _hold_update_effect --------------------------------------------------------------------------
+
+
+def test_hold_update_effect_returns_none_when_no_canvas_id(mocker):
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    assert inbound._hold_update_effect("g1", {}, "p1") is None
+
+
+def test_hold_update_effect_returns_none_when_no_window(mocker):
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-1")
+    mocker.patch("gcal_sync.inbound.parse_event_window", return_value=None)
+    assert inbound._hold_update_effect("g1", {}, "p1") is None
+
+
+# --- process_calendar dry_run mode ----------------------------------------------------------------
+
+
+def test_process_calendar_dry_run_does_not_save_token(mocker):
+    state = SimpleNamespace(sync_token="", needs_full_resync=True, save=mocker.Mock())
+    css = mocker.patch("gcal_sync.inbound.CalendarSyncState")
+    css.objects.get_or_create.return_value = (state, False)
+    client = SimpleNamespace(
+        list_event_deltas=lambda *a, **kw: ([], "newtok"),
+    )
+    inbound = InboundSync(SECRETS, client_factory=lambda c: client)
+    stats, effects = inbound.process_calendar("c1", dry_run=True)
+    assert "trace" in stats  # dry run populates trace
+    # Token and state NOT saved in dry_run mode
+    state.save.assert_not_called()
+
+
+def test_process_calendar_dry_run_410_does_not_save(mocker):
+    state = SimpleNamespace(sync_token="tok", needs_full_resync=False, save=mocker.Mock())
+    css = mocker.patch("gcal_sync.inbound.CalendarSyncState")
+    css.objects.get_or_create.return_value = (state, False)
+    client = SimpleNamespace(
+        list_event_deltas=lambda *a, **kw: (_ for _ in ()).throw(GoogleApiError(410, "gone")),
+    )
+    inbound = InboundSync(SECRETS, client_factory=lambda c: client)
+    stats, effects = inbound.process_calendar("c1", dry_run=True)
+    assert stats["full_resync"] is True
+    state.save.assert_not_called()
+
+
+# --- unmarked event: convergence guard blocks recreate unless force_rebuild --------------------
+
+
+def test_convergence_guard_blocks_recreate(mocker):
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=True)
+    stats = _stats()
+    effects = inbound._apply("cal", {"id": "g1", "status": "confirmed"}, stats)
+    assert effects == []
+    assert stats["ignored"] == 1
+
+
+def test_force_rebuild_bypasses_convergence_guard(mocker):
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    mocker.patch("gcal_sync.inbound.build_hold_effect", return_value="HOLD")
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=True)
+    stats = _stats()
+    effects = inbound._apply("cal", {"id": "g1", "status": "confirmed"}, stats, force_rebuild=True)
+    assert effects == ["HOLD"]
+    assert stats["holds_created"] == 1
+
+
+# --- unmarked event: all-day and private filter ---------------------------------------------------
+
+
+def test_all_day_event_skipped_when_not_ingesting(mocker):
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    inbound._ingest_all_day = False
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=False)
+    stats = _stats()
+    event = {"id": "g1", "status": "confirmed", "start": {"date": "2026-06-10"}}
+    effects = inbound._apply("cal", event, stats)
+    assert effects == []
+    assert stats["ignored"] == 1
+
+
+def test_private_event_skipped_when_not_ingesting(mocker):
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    inbound._ingest_private = False
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=False)
+    stats = _stats()
+    event = {"id": "g1", "status": "confirmed", "visibility": "private"}
+    effects = inbound._apply("cal", event, stats)
+    assert effects == []
+    assert stats["ignored"] == 1
+
+
+# --- unmarked event: cancelled deletes pending marker + mapping in non-dry mode -------------------
+
+
+def test_cancelled_event_clears_pending_marker(mocker):
+    existing = SimpleNamespace(google_event_id="g-1", delete=mocker.Mock())
+    mocker.patch(
+        "gcal_sync.inbound.InboundEventMapping"
+    ).objects.filter.return_value.first.return_value = existing
+    pending = SimpleNamespace(delete=mocker.Mock())
+    mocker.patch(
+        "gcal_sync.inbound.PendingHoldCreate"
+    ).objects.filter.return_value.first.return_value = pending
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_hold_delete_effect", return_value="DEL")
+    stats = _stats()
+    effects = inbound._apply("cal", {"id": "g-1", "status": "cancelled"}, stats)
+    assert effects == ["DEL"]
+    existing.delete.assert_called_once()
+    pending.delete.assert_called_once()
+
+
+def test_cancelled_event_no_effect_when_no_hold(mocker):
+    mocker.patch(
+        "gcal_sync.inbound.InboundEventMapping"
+    ).objects.filter.return_value.first.return_value = None
+    mocker.patch(
+        "gcal_sync.inbound.PendingHoldCreate"
+    ).objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_hold_delete_effect", return_value=None)
+    stats = _stats()
+    effects = inbound._apply("cal", {"id": "g-1", "status": "cancelled"}, stats)
+    assert effects == []
+    assert stats["ignored"] == 1
+
+
+# --- unmarked event: outside import window is skipped ---
+
+
+def test_event_outside_window_is_skipped(mocker):
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    stats = _stats()
+    event = {
+        "id": "g1",
+        "status": "confirmed",
+        "start": {"dateTime": arrow.utcnow().shift(years=2).format("YYYY-MM-DD[T]HH:mm:ss[Z]")},
+    }
+    effects = inbound._apply("cal", event, stats)
+    assert effects == []
+    assert stats["ignored"] == 1
+
+
+# --- unmarked event: no-op guard (unchanged hash) ------------------------------------------------
+
+
+def test_unchanged_hash_skips_update(mocker):
+    from gcal_sync.google.event_builder import google_event_content_hash
+
+    # Use a date within the import window (relative to now)
+    now_str = arrow.utcnow().shift(days=1).format("YYYY-MM-DD[T]HH:mm:ss[Z]")
+    end_str = arrow.utcnow().shift(days=1, minutes=30).format("YYYY-MM-DD[T]HH:mm:ss[Z]")
+    event = {
+        "id": "g1",
+        "status": "confirmed",
+        "summary": "Meeting",
+        "start": {"dateTime": now_str},
+        "end": {"dateTime": end_str},
+    }
+    event_hash = google_event_content_hash(event)
+    existing = SimpleNamespace(google_event_id="g1", last_applied_hash=event_hash)
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = existing
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-1")
+    stats = _stats()
+    effects = inbound._apply("cal", event, stats)
+    assert effects == []
+    assert stats["holds_unchanged"] == 1
+
+
+# --- marked event: no mapping found => ignored ---
+
+
+def test_marked_event_no_mapping_is_ignored(mocker):
+    mocker.patch(
+        "gcal_sync.inbound.AppointmentEventMapping"
+    ).objects.filter.return_value.first.return_value = None
+    inbound = _inbound(mocker)
+    event = build_event_body({
+        "appointment_id": "appt-1",
+        "visit_type": "Visit",
+        "start_time": datetime(2026, 6, 10, 15, 0, tzinfo=timezone.utc),
+        "duration_minutes": 30,
+        "location": "Clinic",
+        "meeting_link": None,
+        "status": "confirmed",
+    })
+    event["id"] = "g1"
+    stats = _stats()
+    effects = inbound._apply("cal", event, stats)
+    assert effects == []
+    assert stats["ignored"] == 1
+
+
+# --- marked event: dry_run reverts without actually pushing ---
+
+
+def test_marked_event_dry_run_does_not_push(mocker):
+    body = build_event_body({
+        "appointment_id": "appt-1",
+        "visit_type": "Visit",
+        "start_time": datetime(2026, 6, 10, 15, 0, tzinfo=timezone.utc),
+        "duration_minutes": 30,
+        "location": "Clinic",
+        "meeting_link": None,
+        "status": "confirmed",
+    })
+    event = dict(body)
+    event["id"] = "g-1"
+    event["summary"] = "Changed by provider"
+    mapping = SimpleNamespace(last_pushed_hash=content_hash(body))
+    mocker.patch(
+        "gcal_sync.inbound.AppointmentEventMapping"
+    ).objects.filter.return_value.first.return_value = mapping
+    inbound = _inbound(mocker)
+    stats = _stats(dry_run=True)
+    effects = inbound._apply("cal", event, stats, dry_run=True)
+    assert effects == []
+    assert stats["reverted"] == 1
+    inbound._sync.push.assert_not_called()
+
+
+# --- marked event: reverts to None => removes event ---
+
+
+def test_marked_revert_removes_when_snapshot_none(mocker):
+    body = build_event_body({
+        "appointment_id": "appt-1",
+        "visit_type": "Visit",
+        "start_time": datetime(2026, 6, 10, 15, 0, tzinfo=timezone.utc),
+        "duration_minutes": 30,
+        "location": "Clinic",
+        "meeting_link": None,
+        "status": "confirmed",
+    })
+    event = dict(body)
+    event["id"] = "g-1"
+    event["summary"] = "Changed"
+    mapping = SimpleNamespace(last_pushed_hash=content_hash(body))
+    mocker.patch(
+        "gcal_sync.inbound.AppointmentEventMapping"
+    ).objects.filter.return_value.first.return_value = mapping
+    mocker.patch("gcal_sync.inbound.build_snapshot", return_value=None)
+    inbound = _inbound(mocker)
+    stats = _stats()
+    inbound._apply("cal", event, stats)
+    assert stats["reverted"] == 1
+    inbound._sync.remove.assert_called_once_with("appt-1")
+
+
+# --- update writes mapping on non-dry run ---
+
+
+def test_update_writes_mapping_on_non_dry(mocker):
+    existing = SimpleNamespace(google_event_id="g1", last_applied_hash="")
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = existing
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-1")
+    mocker.patch.object(inbound, "_hold_update_effect", return_value="UPD")
+    stats = _stats()
+    event = {"id": "g1", "status": "confirmed", "summary": "New title"}
+    effects = inbound._apply("cal", event, stats)
+    assert effects == ["UPD"]
+    iem.objects.update_or_create.assert_called_once()
+
+
+def test_update_skips_mapping_write_on_dry_run(mocker):
+    existing = SimpleNamespace(google_event_id="g1", last_applied_hash="")
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = existing
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-1")
+    mocker.patch.object(inbound, "_hold_update_effect", return_value="UPD")
+    stats = _stats(dry_run=True)
+    event = {"id": "g1", "status": "confirmed", "summary": "New title"}
+    effects = inbound._apply("cal", event, stats, dry_run=True)
+    assert effects == ["UPD"]
+    iem.objects.update_or_create.assert_not_called()
+
+
+# --- update returns None -> ignored ---
+
+
+def test_update_returns_none_is_ignored(mocker):
+    existing = SimpleNamespace(google_event_id="g1", last_applied_hash="")
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = existing
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
+    inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-1")
+    mocker.patch.object(inbound, "_hold_update_effect", return_value=None)
+    stats = _stats()
+    event = {"id": "g1", "status": "confirmed", "summary": "New"}
+    effects = inbound._apply("cal", event, stats)
+    assert effects == []
+    assert stats["ignored"] == 1

--- a/extensions/gcal_sync/tests/test_inbound_decisions.py
+++ b/extensions/gcal_sync/tests/test_inbound_decisions.py
@@ -88,25 +88,33 @@ def test_marked_provider_edit_reverts_to_canvas(mocker):
 def test_unmarked_new_event_creates_hold(mocker):
     iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
     iem.objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
     # Import context (note-type + provider/location) is resolved once per calendar; mock the resolvers.
     mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
     mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
     mocker.patch("gcal_sync.inbound.build_hold_effect", return_value="HOLD_EFFECT")
     inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=False)
     stats = _stats()
     effects = inbound._apply("cal", {"id": "g-new", "status": "confirmed", "summary": "Hold"}, stats)
     assert effects == ["HOLD_EFFECT"]
     assert stats["holds_created"] == 1
-    iem.objects.update_or_create.assert_called_once()
+    phc.objects.update_or_create.assert_called_once()
 
 
 def test_unmarked_unresolvable_hold_is_ignored(mocker):
     mocker.patch("gcal_sync.inbound.InboundEventMapping").objects.filter.return_value.first.return_value = None
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
     mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
     mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
     # build_hold_effect returns None (e.g. event time unparseable) -> skip, no create.
     mocker.patch("gcal_sync.inbound.build_hold_effect", return_value=None)
     inbound = _inbound(mocker)
+    mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=False)
     stats = _stats()
     effects = inbound._apply("cal", {"id": "g-new", "status": "confirmed"}, stats)
     assert effects == []
@@ -114,9 +122,14 @@ def test_unmarked_unresolvable_hold_is_ignored(mocker):
 
 
 def test_unmarked_known_event_updates_hold(mocker):
-    mocker.patch(
-        "gcal_sync.inbound.InboundEventMapping"
-    ).objects.filter.return_value.first.return_value = SimpleNamespace(google_event_id="g-1")
+    iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
+    iem.objects.filter.return_value.first.return_value = SimpleNamespace(
+        google_event_id="g-1", last_applied_hash=""
+    )
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
     inbound = _inbound(mocker)
     # A live Canvas hold exists for this mapping -> take the update path.
     mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value="appt-99")
@@ -128,10 +141,14 @@ def test_unmarked_known_event_updates_hold(mocker):
 
 
 def test_unmarked_orphaned_mapping_recreates_hold(mocker):
-    # Mapping row exists but no live Canvas hold AND it predates the pending-create grace window (a
-    # prior run was interrupted/capped before the create applied). RE-CREATE it, don't skip (#4).
+    # Mapping row exists but no live Canvas hold AND the pending-create marker predates the grace
+    # window (a prior run was interrupted/capped before the create applied). RE-CREATE it (#4).
     iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
     iem.objects.filter.return_value.first.return_value = SimpleNamespace(
+        google_event_id="g-1", last_applied_hash=""
+    )
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = SimpleNamespace(
         google_event_id="g-1", created_at=datetime.now(timezone.utc) - timedelta(hours=1)
     )
     mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
@@ -139,33 +156,41 @@ def test_unmarked_orphaned_mapping_recreates_hold(mocker):
     mocker.patch("gcal_sync.inbound.build_hold_effect", return_value="HOLD_EFFECT")
     inbound = _inbound(mocker)
     mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)  # orphaned
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=False)
     update_spy = mocker.patch.object(inbound, "_hold_update_effect")
     stats = _stats()
     effects = inbound._apply("cal", {"id": "g-1", "status": "confirmed", "summary": "Hold"}, stats)
     assert effects == ["HOLD_EFFECT"]
     assert stats["holds_created"] == 1
     update_spy.assert_not_called()
-    iem.objects.update_or_create.assert_called_once()
+    phc.objects.update_or_create.assert_called_once()
 
 
 def test_unmarked_pending_create_is_not_duplicated(mocker):
-    # Mapping was written moments ago but the async create hasn't applied yet (no live hold). A
-    # re-delivered webhook must NOT re-issue the create — re-creating in-flight holds is what
-    # produced the duplicate-hold storm under load.
+    # PendingHoldCreate was written moments ago but the async create hasn't applied yet (no live
+    # hold). A re-delivered webhook must NOT re-issue the create — re-creating in-flight holds is
+    # what produced the duplicate-hold storm under load.
     iem = mocker.patch("gcal_sync.inbound.InboundEventMapping")
     iem.objects.filter.return_value.first.return_value = SimpleNamespace(
+        google_event_id="g-1", last_applied_hash=""
+    )
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = SimpleNamespace(
         google_event_id="g-1", created_at=datetime.now(timezone.utc)
     )
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
     build = mocker.patch("gcal_sync.inbound.build_hold_effect", return_value="HOLD_EFFECT")
     inbound = _inbound(mocker)
     mocker.patch.object(inbound, "_canvas_id_for_google_event", return_value=None)  # not applied yet
+    mocker.patch.object(inbound, "_external_hold_exists", return_value=False)
     stats = _stats()
     effects = inbound._apply("cal", {"id": "g-1", "status": "confirmed", "summary": "Hold"}, stats)
     assert effects == []
     assert stats["holds_created"] == 0
     assert stats["ignored"] == 1
     build.assert_not_called()
-    iem.objects.update_or_create.assert_not_called()
+    phc.objects.update_or_create.assert_not_called()
 
 
 def test_unmarked_cancelled_known_event_removes_hold(mocker):
@@ -173,6 +198,10 @@ def test_unmarked_cancelled_known_event_removes_hold(mocker):
     mocker.patch(
         "gcal_sync.inbound.InboundEventMapping"
     ).objects.filter.return_value.first.return_value = existing
+    phc = mocker.patch("gcal_sync.inbound.PendingHoldCreate")
+    phc.objects.filter.return_value.first.return_value = None
+    mocker.patch("gcal_sync.inbound.schedule_event_note_type_id", return_value="nt-1")
+    mocker.patch("gcal_sync.inbound.provider_and_location", return_value=("14", "loc-1"))
     inbound = _inbound(mocker)
     mocker.patch.object(inbound, "_hold_delete_effect", return_value="DELETE_EFFECT")
     stats = _stats()
@@ -199,7 +228,7 @@ def test_update_masks_private_event_title(mocker):
     )
     se = mocker.patch("gcal_sync.inbound.ScheduleEvent").return_value
     inbound._hold_update_effect(
-        "g-1", {"id": "g-1", "visibility": "private", "summary": "Dad - Dr. Appt"}
+        "g-1", {"id": "g-1", "visibility": "private", "summary": "Dad - Dr. Appt"}, "14"
     )
     assert se.description == "Busy"
 
@@ -212,5 +241,5 @@ def test_update_keeps_public_event_title(mocker):
         return_value=(datetime(2026, 6, 10, 15, 0, tzinfo=timezone.utc), 30),
     )
     se = mocker.patch("gcal_sync.inbound.ScheduleEvent").return_value
-    inbound._hold_update_effect("g-1", {"id": "g-1", "summary": "Standup"})
+    inbound._hold_update_effect("g-1", {"id": "g-1", "summary": "Standup"}, "14")
     assert se.description == "Standup"

--- a/extensions/gcal_sync/tests/test_inbound_process.py
+++ b/extensions/gcal_sync/tests/test_inbound_process.py
@@ -74,7 +74,7 @@ def test_safety_cap_aborts_without_advancing_cursor(mocker):
     )
     inbound = _inbound(client)
 
-    def over_cap(_cal, _event, stats):
+    def over_cap(_cal, _event, stats, force_rebuild=False, dry_run=False, verbose=False):
         stats["holds_created"] = inbound._MAX_HOLDS_PER_RUN
         return []
 

--- a/extensions/gcal_sync/tests/test_reconcile.py
+++ b/extensions/gcal_sync/tests/test_reconcile.py
@@ -21,6 +21,7 @@ def test_reset_cancels_existing_holds_and_clears_mappings(mocker):
         102,
     ]
     iem = mocker.patch("gcal_sync.reconcile.InboundEventMapping")
+    phc = mocker.patch("gcal_sync.reconcile.PendingHoldCreate")
     schedule_event = mocker.patch("gcal_sync.reconcile.ScheduleEvent")
 
     effects = reset_inbound_for_provider(_mapping())
@@ -31,10 +32,12 @@ def test_reset_cancels_existing_holds_and_clears_mappings(mocker):
     # Inbound mappings for THIS calendar are dropped so the pull recreates fresh.
     iem.objects.filter.assert_called_once_with(google_calendar_id="joe@x")
     iem.objects.filter.return_value.delete.assert_called_once()
+    # PendingHoldCreate markers for THIS calendar are also cleared.
+    phc.objects.filter.assert_called_once_with(google_calendar_id="joe@x")
+    phc.objects.filter.return_value.delete.assert_called_once()
 
 
 def test_reimport_resets_then_full_pulls(mocker):
-    mocker.patch("gcal_sync.reconcile.reset_inbound_for_provider", return_value=["CANCEL"])
     state = SimpleNamespace(sync_token="stale-token", needs_full_resync=False, save=mocker.Mock())
     css = mocker.patch("gcal_sync.reconcile.CalendarSyncState")
     css.objects.get_or_create.return_value = (state, False)
@@ -47,6 +50,6 @@ def test_reimport_resets_then_full_pulls(mocker):
     assert state.sync_token == ""
     assert state.needs_full_resync is True
     state.save.assert_called_once()
-    # Reset (cancel) effects are applied before the freshly-imported holds.
-    assert effects == ["CANCEL", "HOLD"]
+    # Re-import now does a force_rebuild pull (no separate reset step).
+    assert effects == ["HOLD"]
     assert stats["holds_created"] == 5

--- a/extensions/gcal_sync/tests/test_reconcile_coverage.py
+++ b/extensions/gcal_sync/tests/test_reconcile_coverage.py
@@ -1,0 +1,645 @@
+"""Tests for reconcile.py: provider locking, bounded outbound, sweep, reimport drain,
+outbound backfill drain, purge chunks, fleet reimport queue, and helper functions.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gcal_sync.channels import ChannelConfigError
+from gcal_sync.google.auth import GoogleAuthError
+from gcal_sync.google.client import GoogleApiError, GoogleRateLimitError
+from gcal_sync.reconcile import (
+    _full_pull_priority,
+    _needs_full_pull,
+    _outbound_priority,
+    _outbound_window,
+    _pushable_appointments,
+    _rfc3339,
+    acquire_provider_lock,
+    cancel_fleet_reimport,
+    drain_outbound_backfill,
+    drain_reimport_queue,
+    enqueue_fleet_reimport,
+    outbound_truth,
+    purge_holds_chunk,
+    reimport_queue_depth,
+    release_provider_lock,
+    sweep_outbound,
+)
+
+
+# --- provider locking -----------------------------------------------------------------------------
+
+
+def test_acquire_lock_succeeds_on_fresh_insert(mocker):
+    psl = mocker.patch("gcal_sync.reconcile.ProviderSyncLock")
+    psl.objects.filter.return_value.delete.return_value = None
+    psl.objects.create.return_value = SimpleNamespace()
+    assert acquire_provider_lock("cal@x") is True
+    psl.objects.create.assert_called_once_with(google_calendar_id="cal@x")
+
+
+def test_acquire_lock_returns_false_on_integrity_error(mocker):
+    from django.db import IntegrityError
+
+    psl = mocker.patch("gcal_sync.reconcile.ProviderSyncLock")
+    psl.objects.filter.return_value.delete.return_value = None
+    psl.objects.create.side_effect = IntegrityError("dup")
+    assert acquire_provider_lock("cal@x") is False
+
+
+def test_acquire_lock_reclaims_stale_lock(mocker):
+    from django.db import IntegrityError
+
+    psl = mocker.patch("gcal_sync.reconcile.ProviderSyncLock")
+    # delete returns something (stale lock cleaned up)
+    psl.objects.filter.return_value.delete.return_value = 1
+    psl.objects.create.return_value = SimpleNamespace()
+    assert acquire_provider_lock("cal@x") is True
+
+
+def test_release_lock_deletes_row(mocker):
+    psl = mocker.patch("gcal_sync.reconcile.ProviderSyncLock")
+    release_provider_lock("cal@x")
+    psl.objects.filter.assert_called_once_with(google_calendar_id="cal@x")
+    psl.objects.filter.return_value.delete.assert_called_once()
+
+
+# --- helper functions -----------------------------------------------------------------------------
+
+
+def test_outbound_window_returns_arrow_range():
+    start, end = _outbound_window()
+    # start is ~1 month ago, end is ~1 year from now
+    assert start < end
+
+
+def test_rfc3339_format():
+    import arrow
+    when = arrow.get("2026-06-10T15:30:00Z")
+    assert _rfc3339(when) == "2026-06-10T15:30:00Z"
+
+
+def test_needs_full_pull_true_when_no_state():
+    assert _needs_full_pull(None) is True
+
+
+def test_needs_full_pull_true_when_no_token():
+    assert _needs_full_pull(SimpleNamespace(sync_token="", needs_full_resync=False)) is True
+
+
+def test_needs_full_pull_true_when_flagged():
+    assert _needs_full_pull(SimpleNamespace(sync_token="tok", needs_full_resync=True)) is True
+
+
+def test_needs_full_pull_false_when_healthy():
+    assert _needs_full_pull(SimpleNamespace(sync_token="tok", needs_full_resync=False)) is False
+
+
+def test_full_pull_priority_none_state():
+    assert _full_pull_priority(None) == (0, "")
+
+
+def test_full_pull_priority_with_state():
+    from datetime import datetime, timezone
+
+    state = SimpleNamespace(updated_at=datetime(2026, 6, 10, tzinfo=timezone.utc))
+    p = _full_pull_priority(state)
+    assert p[0] == 1
+    assert "2026" in p[1]
+
+
+def test_full_pull_priority_with_no_updated_at():
+    state = SimpleNamespace(updated_at=None)
+    assert _full_pull_priority(state) == (1, "")
+
+
+def test_outbound_priority_none_timestamp():
+    m = SimpleNamespace()
+    assert _outbound_priority(m) == (0, 0.0)
+
+
+def test_outbound_priority_with_timestamp():
+    from datetime import datetime, timezone
+
+    m = SimpleNamespace(last_outbound_synced_at=datetime(2026, 6, 10, tzinfo=timezone.utc))
+    p = _outbound_priority(m)
+    assert p[0] == 1
+    assert p[1] > 0
+
+
+# --- pushable_appointments -----------------------------------------------------------------------
+
+
+def test_pushable_skips_terminal_and_google_origin(mocker):
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+        {"id": 2, "status": "cancelled"},
+        {"id": 3, "status": "noshowed"},
+        {"id": 4, "status": "confirmed"},
+    ]
+    m = SimpleNamespace(canvas_staff_id="14")
+    result = _pushable_appointments(m, None, None, {4})
+    # id=1 passes, id=2 cancelled, id=3 noshowed, id=4 google-origin
+    assert len(result) == 1
+    assert result[0]["id"] == 1
+
+
+# --- outbound_truth bounded pushes ---------------------------------------------------------------
+
+
+def test_outbound_truth_respects_max_pushes(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    aem.objects.filter.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+        {"id": 2, "status": "confirmed"},
+        {"id": 3, "status": "confirmed"},
+    ]
+    mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
+    pushed = outbound_truth(
+        {},
+        [SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1")],
+        max_pushes=2,
+    )
+    assert pushed == 2
+    assert sync.push.call_count == 2
+
+
+def test_outbound_truth_skip_mapped_drops_already_mapped(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    # appt "1" already has a mapping
+    existing_mapping = SimpleNamespace(canvas_appointment_id="1", google_event_id="g-1")
+    aem.objects.filter.return_value = [existing_mapping]
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+        {"id": 2, "status": "confirmed"},
+    ]
+    mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
+    pushed = outbound_truth(
+        {},
+        [SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1")],
+        skip_mapped=True,
+    )
+    # Only appt 2 is pushed (appt 1 is already mapped and skip_mapped=True)
+    assert pushed == 1
+    sync.push.assert_called_once()
+
+
+def test_outbound_truth_handles_rate_limit(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    sync.push.side_effect = GoogleRateLimitError(429, "rate limit")
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    aem.objects.filter.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+        {"id": 2, "status": "confirmed"},
+    ]
+    mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        last_outbound_synced_at=None,
+    )
+    pushed = outbound_truth({}, [mapping])
+    # Rate-limited -> stops and does NOT stamp last_outbound_synced_at
+    assert pushed == 0
+
+
+def test_outbound_truth_handles_api_error(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    sync.push.side_effect = GoogleApiError(500, "server error")
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    aem.objects.filter.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+    ]
+    mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        last_outbound_synced_at=None,
+    )
+    # Errors are logged, not raised; run completes
+    pushed = outbound_truth({}, [mapping])
+    assert pushed == 0
+
+
+def test_outbound_truth_stamps_synced_at_when_completed(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    aem.objects.filter.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+    ]
+    mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        last_outbound_synced_at=None,
+        save=mocker.Mock(),
+    )
+    outbound_truth({}, [mapping])
+    assert mapping.last_outbound_synced_at is not None
+    mapping.save.assert_called_once()
+
+
+def test_outbound_truth_save_failure_doesnt_abort(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    aem.objects.filter.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = [
+        {"id": 1, "status": "confirmed"},
+    ]
+    mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        last_outbound_synced_at=None,
+        save=mocker.Mock(side_effect=Exception("db boom")),
+    )
+    # Should not raise — the save failure is swallowed
+    pushed = outbound_truth({}, [mapping])
+    assert pushed == 1
+
+
+# --- sweep_outbound -------------------------------------------------------------------------------
+
+
+def test_sweep_outbound_delegates_to_sync_service(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    sync.sweep_calendar.return_value = 3
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = []
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        last_outbound_synced_at=None,
+    )
+    deleted = sweep_outbound({}, [mapping])
+    assert deleted == 3
+    sync.sweep_calendar.assert_called_once()
+
+
+def test_sweep_outbound_caps_calendars(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    sync.sweep_calendar.return_value = 0
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = []
+    mappings = [
+        SimpleNamespace(canvas_staff_id=str(i), google_calendar_id=f"c{i}")
+        for i in range(5)
+    ]
+    sweep_outbound({}, mappings, max_calendars=2)
+    assert sync.sweep_calendar.call_count == 2
+
+
+def test_sweep_outbound_handles_error(mocker):
+    sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
+    sync.sweep_calendar.side_effect = GoogleApiError(500, "boom")
+    ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    ext.objects.filter.return_value.values_list.return_value = []
+    appt = mocker.patch("gcal_sync.reconcile.Appointment")
+    appt.objects.filter.return_value.values.return_value = []
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        last_outbound_synced_at=None,
+    )
+    deleted = sweep_outbound({}, [mapping])
+    assert deleted == 0
+
+
+# --- inbound_recovery error handling --------------------------------------------------------------
+
+
+def test_inbound_recovery_catches_errors_per_calendar(mocker):
+    inbound = mocker.patch("gcal_sync.reconcile.InboundSync").return_value
+    inbound.process_calendar.side_effect = GoogleApiError(500, "boom")
+    mocker.patch("gcal_sync.reconcile.CalendarSyncState").objects.filter.return_value = []
+    effects = __import__("gcal_sync.reconcile", fromlist=["inbound_recovery"]).inbound_recovery(
+        {}, [SimpleNamespace(google_calendar_id="c1")]
+    )
+    assert effects == []
+
+
+# --- purge_holds_chunk ----------------------------------------------------------------------------
+
+
+def test_purge_holds_chunk_partial(mocker):
+    aei = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    qs = aei.objects.filter.return_value.exclude.return_value
+    qs.filter.return_value.order_by.return_value.values_list.return_value.distinct.return_value.__getitem__ = (
+        lambda self, key: [101, 102, 103]
+    )
+    se = mocker.patch("gcal_sync.reconcile.ScheduleEvent")
+    iem = mocker.patch("gcal_sync.reconcile.InboundEventMapping")
+    phc = mocker.patch("gcal_sync.reconcile.PendingHoldCreate")
+    mapping = SimpleNamespace(canvas_staff_id="14", google_calendar_id="cal@x")
+    effects, last_id, done = purge_holds_chunk(mapping, limit=5, after_id="100")
+    assert len(effects) == 3
+    assert done is True  # 3 < 5 = done
+    # When done, mappings and pending markers are cleared
+    iem.objects.filter.assert_called_once_with(google_calendar_id="cal@x")
+    phc.objects.filter.assert_called_once_with(google_calendar_id="cal@x")
+
+
+def test_purge_holds_chunk_not_done_when_full(mocker):
+    aei = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    qs = aei.objects.filter.return_value.exclude.return_value
+    # When after_id is empty, the code goes straight to .order_by() (no .filter())
+    qs.order_by.return_value.values_list.return_value.distinct.return_value.__getitem__ = (
+        lambda self, key: [101, 102]
+    )
+    se = mocker.patch("gcal_sync.reconcile.ScheduleEvent")
+    iem = mocker.patch("gcal_sync.reconcile.InboundEventMapping")
+    phc = mocker.patch("gcal_sync.reconcile.PendingHoldCreate")
+    mapping = SimpleNamespace(canvas_staff_id="14", google_calendar_id="cal@x")
+    effects, last_id, done = purge_holds_chunk(mapping, limit=2, after_id="")
+    assert len(effects) == 2
+    assert done is False  # 2 == 2 -> not done
+    # Mappings NOT cleared when not done
+    iem.objects.filter.assert_not_called()
+    phc.objects.filter.assert_not_called()
+
+
+def test_purge_holds_chunk_empty_result(mocker):
+    aei = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
+    qs = aei.objects.filter.return_value.exclude.return_value
+    qs.order_by.return_value.values_list.return_value.distinct.return_value.__getitem__ = (
+        lambda self, key: []
+    )
+    se = mocker.patch("gcal_sync.reconcile.ScheduleEvent")
+    iem = mocker.patch("gcal_sync.reconcile.InboundEventMapping")
+    phc = mocker.patch("gcal_sync.reconcile.PendingHoldCreate")
+    mapping = SimpleNamespace(canvas_staff_id="14", google_calendar_id="cal@x")
+    effects, last_id, done = purge_holds_chunk(mapping, limit=10, after_id="prev")
+    assert effects == []
+    assert done is True
+    assert last_id == "prev"
+
+
+# --- fleet reimport queue -------------------------------------------------------------------------
+
+
+def test_enqueue_fleet_reimport_creates_rows(mocker):
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    scm.objects.filter.return_value.order_by.return_value = [
+        SimpleNamespace(google_calendar_id="c1"),
+        SimpleNamespace(google_calendar_id="c2"),
+    ]
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    rq.objects.get_or_create.side_effect = [
+        (SimpleNamespace(), True),
+        (SimpleNamespace(), False),  # already exists
+    ]
+    queued = enqueue_fleet_reimport()
+    assert queued == 1  # one newly created
+
+
+def test_enqueue_fleet_reimport_with_limit(mocker):
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    scm.objects.filter.return_value.order_by.return_value.__getitem__ = lambda self, key: [
+        SimpleNamespace(google_calendar_id="c1"),
+    ]
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    rq.objects.get_or_create.return_value = (SimpleNamespace(), True)
+    queued = enqueue_fleet_reimport(limit=1)
+    assert queued == 1
+
+
+def test_reimport_queue_depth(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    rq.objects.count.return_value = 7
+    assert reimport_queue_depth() == 7
+
+
+def test_cancel_fleet_reimport_empties_queue(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    rq.objects.count.return_value = 3
+    rq.objects.all.return_value.delete.return_value = None
+    cleared = cancel_fleet_reimport()
+    assert cleared == 3
+    rq.objects.all.return_value.delete.assert_called_once()
+
+
+# --- drain_reimport_queue -------------------------------------------------------------------------
+
+
+def test_drain_reimport_queue_processes_entries(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    entry = SimpleNamespace(
+        google_calendar_id="c1", attempts=0, save=mocker.Mock(), delete=mocker.Mock()
+    )
+    rq.objects.order_by.return_value.__getitem__ = lambda self, key: [entry]
+    rq.objects.count.return_value = 0
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    mapping = SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1", active=True)
+    scm.objects.filter.return_value.first.return_value = mapping
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.reconcile.release_provider_lock")
+    mocker.patch(
+        "gcal_sync.reconcile.reimport_provider",
+        return_value=({"holds_created": 5, "holds_updated": 0, "holds_unchanged": 0, "holds_removed": 0}, ["E"]),
+    )
+    totals, effects = drain_reimport_queue({}, batch_size=4)
+    assert totals["processed"] == 1
+    assert totals["holds_created"] == 5
+    assert effects == ["E"]
+    entry.delete.assert_called_once()
+
+
+def test_drain_reimport_queue_drops_deactivated_mapping(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    entry = SimpleNamespace(
+        google_calendar_id="c1", attempts=0, save=mocker.Mock(), delete=mocker.Mock()
+    )
+    rq.objects.order_by.return_value.__getitem__ = lambda self, key: [entry]
+    rq.objects.count.return_value = 0
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = None  # mapping gone
+    totals, effects = drain_reimport_queue({}, batch_size=4)
+    assert totals["dropped"] == 1
+    entry.delete.assert_called_once()
+
+
+def test_drain_reimport_queue_skips_locked_provider(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    entry = SimpleNamespace(
+        google_calendar_id="c1", attempts=0, save=mocker.Mock(), delete=mocker.Mock()
+    )
+    rq.objects.order_by.return_value.__getitem__ = lambda self, key: [entry]
+    rq.objects.count.return_value = 1
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="c1", active=True
+    )
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=False)
+    totals, effects = drain_reimport_queue({}, batch_size=4)
+    assert totals["skipped"] == 1
+    entry.delete.assert_not_called()
+
+
+def test_drain_reimport_queue_retries_on_error(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    entry = SimpleNamespace(
+        google_calendar_id="c1", attempts=0, save=mocker.Mock(), delete=mocker.Mock()
+    )
+    rq.objects.order_by.return_value.__getitem__ = lambda self, key: [entry]
+    rq.objects.count.return_value = 1
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="c1", active=True
+    )
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.reconcile.release_provider_lock")
+    mocker.patch(
+        "gcal_sync.reconcile.reimport_provider",
+        side_effect=GoogleApiError(500, "boom"),
+    )
+    totals, effects = drain_reimport_queue({}, batch_size=4)
+    assert totals["failed"] == 1
+    assert entry.attempts == 1
+    entry.save.assert_called_once()  # saved for retry
+    entry.delete.assert_not_called()
+
+
+def test_drain_reimport_queue_drops_after_max_attempts(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    entry = SimpleNamespace(
+        google_calendar_id="c1", attempts=2, save=mocker.Mock(), delete=mocker.Mock()
+    )
+    rq.objects.order_by.return_value.__getitem__ = lambda self, key: [entry]
+    rq.objects.count.return_value = 0
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    scm.objects.filter.return_value.first.return_value = SimpleNamespace(
+        canvas_staff_id="14", google_calendar_id="c1", active=True
+    )
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.reconcile.release_provider_lock")
+    mocker.patch(
+        "gcal_sync.reconcile.reimport_provider",
+        side_effect=GoogleAuthError("auth fail"),
+    )
+    totals, effects = drain_reimport_queue({}, batch_size=4)
+    assert totals["dropped"] == 1
+    entry.delete.assert_called_once()
+
+
+def test_drain_reimport_queue_noop_when_empty(mocker):
+    rq = mocker.patch("gcal_sync.reconcile.ReimportQueue")
+    rq.objects.order_by.return_value.__getitem__ = lambda self, key: []
+    rq.objects.count.return_value = 0
+    totals, effects = drain_reimport_queue({}, batch_size=4)
+    assert totals["processed"] == 0
+    assert effects == []
+
+
+# --- drain_outbound_backfill ----------------------------------------------------------------------
+
+
+def _mock_scm_for_drain(mocker, mappings):
+    """Mock StaffCalendarMapping so the first filter(active=True) returns mappings and
+    subsequent filter() calls return a countable mock (for the `remaining` count).
+    """
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    remaining_qs = MagicMock()
+    remaining_qs.count.return_value = 0
+    scm.objects.filter.side_effect = [mappings, remaining_qs]
+    return scm
+
+
+def test_drain_outbound_backfill_processes_providers(mocker):
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        active=True,
+        last_outbound_synced_at=None,
+    )
+    _mock_scm_for_drain(mocker, [mapping])
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.reconcile.release_provider_lock")
+    mocker.patch("gcal_sync.reconcile.outbound_truth", return_value=10)
+    totals = drain_outbound_backfill({}, providers_per_tick=1, pushes_per_provider=40)
+    assert totals["providers"] == 1
+    assert totals["pushed"] == 10
+
+
+def test_drain_outbound_backfill_skips_locked(mocker):
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        active=True,
+        last_outbound_synced_at=None,
+    )
+    _mock_scm_for_drain(mocker, [mapping])
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=False)
+    totals = drain_outbound_backfill({}, providers_per_tick=1, pushes_per_provider=40)
+    assert totals["skipped"] == 1
+    assert totals["pushed"] == 0
+
+
+def test_drain_outbound_backfill_reports_remaining(mocker):
+    mapping = SimpleNamespace(
+        canvas_staff_id="14",
+        google_calendar_id="c1",
+        active=True,
+        last_outbound_synced_at=None,
+    )
+    scm = mocker.patch("gcal_sync.reconcile.StaffCalendarMapping")
+    remaining_qs = MagicMock()
+    remaining_qs.count.return_value = 5
+    scm.objects.filter.side_effect = [[mapping], remaining_qs]
+    mocker.patch("gcal_sync.reconcile.acquire_provider_lock", return_value=True)
+    mocker.patch("gcal_sync.reconcile.release_provider_lock")
+    mocker.patch("gcal_sync.reconcile.outbound_truth", return_value=0)
+    totals = drain_outbound_backfill({}, providers_per_tick=1, pushes_per_provider=40)
+    assert totals["providers"] == 1
+
+
+# --- reconcile_provider error handling ------------------------------------------------------------
+
+
+def test_reconcile_provider_handles_inbound_error(mocker):
+    inbound = mocker.patch("gcal_sync.reconcile.InboundSync").return_value
+    inbound.process_calendar.side_effect = GoogleApiError(500, "fail")
+    mocker.patch("gcal_sync.reconcile.outbound_truth", return_value=0)
+    mocker.patch("gcal_sync.reconcile.sweep_outbound", return_value=0)
+    mocker.patch(
+        "gcal_sync.reconcile.sync_all_blocks", return_value={"pushed": 0, "deleted": 0}
+    )
+    from gcal_sync.reconcile import reconcile_provider
+
+    stats, effects = reconcile_provider(
+        {}, SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1")
+    )
+    # Inbound error is caught; outbound/blocks still run
+    assert stats["pushed"] == 0
+    assert effects == []

--- a/extensions/gcal_sync/tests/test_reconcile_flows.py
+++ b/extensions/gcal_sync/tests/test_reconcile_flows.py
@@ -42,6 +42,8 @@ def test_outbound_truth_pushes_only_live_non_origin(mocker):
     sync = mocker.patch("gcal_sync.reconcile.SyncService").return_value
     ext = mocker.patch("gcal_sync.reconcile.AppointmentExternalIdentifier")
     ext.objects.filter.return_value.values_list.return_value = []  # no google-origin records
+    aem = mocker.patch("gcal_sync.reconcile.AppointmentEventMapping")
+    aem.objects.filter.return_value = []
     appt = mocker.patch("gcal_sync.reconcile.Appointment")
     appt.objects.filter.return_value.values.return_value = [
         {"id": 1, "status": "confirmed"},
@@ -50,7 +52,7 @@ def test_outbound_truth_pushes_only_live_non_origin(mocker):
     mocker.patch("gcal_sync.reconcile.snapshot_from_values", return_value="SNAP")
     pushed = outbound_truth({}, [SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1")])
     assert pushed == 1
-    sync.push.assert_called_once_with("c1", "SNAP")
+    sync.push.assert_called_once_with("c1", "SNAP", {})
 
 
 def test_outbound_truth_skips_google_origin(mocker):
@@ -68,6 +70,7 @@ def test_reconcile_provider_combines_inbound_outbound_blocks(mocker):
     inbound = mocker.patch("gcal_sync.reconcile.InboundSync").return_value
     inbound.process_calendar.return_value = ({}, ["HOLD"])
     mocker.patch("gcal_sync.reconcile.outbound_truth", return_value=3)
+    mocker.patch("gcal_sync.reconcile.sweep_outbound", return_value=0)
     mocker.patch(
         "gcal_sync.reconcile.sync_all_blocks", return_value={"pushed": 2, "deleted": 1}
     )
@@ -75,7 +78,7 @@ def test_reconcile_provider_combines_inbound_outbound_blocks(mocker):
         {}, SimpleNamespace(canvas_staff_id="14", google_calendar_id="c1")
     )
     assert effects == ["HOLD"]
-    assert stats == {"pushed": 3, "blocks_pushed": 2, "blocks_deleted": 1}
+    assert stats == {"pushed": 3, "swept": 0, "blocks_pushed": 2, "blocks_deleted": 1}
 
 
 def test_reconcile_all_noop_without_mappings(mocker):
@@ -91,6 +94,7 @@ def test_reconcile_all_runs_full_pass(mocker):
     scm.objects.filter.return_value = [SimpleNamespace(google_calendar_id="c1")]
     mocker.patch("gcal_sync.reconcile.inbound_recovery", return_value=["E"])
     mocker.patch("gcal_sync.reconcile.outbound_truth", return_value=5)
+    mocker.patch("gcal_sync.reconcile.sweep_outbound", return_value=0)
     mocker.patch(
         "gcal_sync.reconcile.sync_all_blocks", return_value={"pushed": 1, "deleted": 0}
     )

--- a/extensions/gcal_sync/tests/test_sync_service.py
+++ b/extensions/gcal_sync/tests/test_sync_service.py
@@ -42,6 +42,9 @@ class FakeClient:
     def delete_event(self, calendar_id, event_id):
         self.calls.append(("delete", calendar_id, event_id))
 
+    def find_event_by_private_property(self, calendar_id, key, value):
+        return None
+
 
 def _mock_model(mocker, existing):
     """Patch AppointmentEventMapping so .get returns ``existing`` (or raises DoesNotExist if None)."""
@@ -52,6 +55,10 @@ def _mock_model(mocker, existing):
     else:
         model.objects.get.return_value = existing
     model.objects.create.side_effect = lambda **kw: SimpleNamespace(**kw)
+    model.objects.update_or_create.side_effect = lambda **kw: (
+        SimpleNamespace(**kw.get("defaults", {}), **{k: v for k, v in kw.items() if k != "defaults"}),
+        True,
+    )
     return model
 
 
@@ -63,8 +70,8 @@ def test_push_inserts_when_no_existing_mapping(mocker):
     service.push("cal@example.com", _snapshot())
 
     assert ("insert", "cal@example.com") in fake.calls
-    model.objects.create.assert_called_once()
-    assert model.objects.create.call_args.kwargs["google_event_id"] == "g-new"
+    model.objects.update_or_create.assert_called_once()
+    assert model.objects.update_or_create.call_args.kwargs["defaults"]["google_event_id"] == "g-new"
 
 
 def test_push_skips_when_content_unchanged(mocker):

--- a/extensions/gcal_sync/tests/test_sync_service_coverage.py
+++ b/extensions/gcal_sync/tests/test_sync_service_coverage.py
@@ -1,0 +1,315 @@
+"""Tests for sync_service.py: adopt-don't-duplicate, sweep_calendar, mapping cache."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from gcal_sync.google.client import GoogleApiError
+from gcal_sync.sync_service import SyncService
+
+VALID_SA = '{"client_email": "svc@x.iam", "private_key": "KEY"}'
+
+
+def _snapshot(appt_id="appt-1"):
+    return {
+        "appointment_id": appt_id,
+        "visit_type": "Visit",
+        "start_time": datetime(2026, 6, 10, 15, 0, tzinfo=timezone.utc),
+        "duration_minutes": 30,
+        "location": "Clinic",
+        "meeting_link": None,
+        "status": "confirmed",
+    }
+
+
+def _mock_model(mocker, existing=None):
+    model = mocker.patch("gcal_sync.sync_service.AppointmentEventMapping")
+    model.DoesNotExist = type("DoesNotExist", (Exception,), {})
+    if existing is None:
+        model.objects.get.side_effect = model.DoesNotExist
+    else:
+        model.objects.get.return_value = existing
+    model.objects.create.side_effect = lambda **kw: SimpleNamespace(**kw)
+    model.objects.update_or_create.side_effect = lambda **kw: (
+        SimpleNamespace(**kw.get("defaults", {}), **{k: v for k, v in kw.items() if k != "defaults"}),
+        True,
+    )
+    return model
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = []
+        self._find_result = None
+
+    def insert_event(self, calendar_id, body):
+        self.calls.append(("insert", calendar_id))
+        return {"id": "g-new"}
+
+    def patch_event(self, calendar_id, event_id, body):
+        self.calls.append(("patch", calendar_id, event_id))
+        return {"id": event_id}
+
+    def delete_event(self, calendar_id, event_id):
+        self.calls.append(("delete", calendar_id, event_id))
+
+    def find_event_by_private_property(self, calendar_id, key, value):
+        self.calls.append(("find", calendar_id, key, value))
+        return self._find_result
+
+    def list_all_events(self, calendar_id, time_min, time_max):
+        return self._all_events
+
+
+# --- adopt-don't-duplicate (find_event_by_private_property) ----------------------------------------
+
+
+def test_push_adopts_existing_google_event_when_mapping_lost(mocker):
+    """When local mapping is missing but Google has an event with the appt ID, adopt it."""
+    _mock_model(mocker, existing=None)
+    fake = FakeClient()
+    fake._find_result = {"id": "g-existing"}
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    mapping = service.push("cal@x", _snapshot())
+
+    # Should patch the existing event, not insert a new one
+    assert ("find", "cal@x", "canvasApptId", "appt-1") in fake.calls
+    assert ("patch", "cal@x", "g-existing") in fake.calls
+    assert ("insert", "cal@x") not in fake.calls
+
+
+def test_push_inserts_when_no_google_event_found(mocker):
+    """When mapping is missing AND Google has no matching event, insert fresh."""
+    _mock_model(mocker, existing=None)
+    fake = FakeClient()
+    fake._find_result = None
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    service.push("cal@x", _snapshot())
+
+    assert ("find", "cal@x", "canvasApptId", "appt-1") in fake.calls
+    assert ("insert", "cal@x") in fake.calls
+
+
+# --- mapping cache -------------------------------------------------------------------------------
+
+
+def test_push_uses_mapping_cache_hit(mocker):
+    """When mapping_cache is provided and has the key, skip the DB lookup entirely."""
+    model = _mock_model(mocker, existing=None)
+    existing = SimpleNamespace(
+        google_calendar_id="cal@x",
+        google_event_id="g-1",
+        last_pushed_hash="old",
+        save=mocker.Mock(),
+    )
+    cache = {"appt-1": existing}
+    fake = FakeClient()
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    service.push("cal@x", _snapshot(), mapping_cache=cache)
+
+    # Should NOT call .get on the model (cache used instead)
+    model.objects.get.assert_not_called()
+    assert ("patch", "cal@x", "g-1") in fake.calls
+
+
+def test_push_uses_mapping_cache_miss(mocker):
+    """When mapping_cache is provided but key is absent, treat as no mapping (authoritative)."""
+    model = _mock_model(mocker, existing=None)
+    cache = {}  # empty cache = authoritative miss
+    fake = FakeClient()
+    fake._find_result = None
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    service.push("cal@x", _snapshot(), mapping_cache=cache)
+
+    # Should NOT call .get — the cache miss is authoritative
+    model.objects.get.assert_not_called()
+    assert ("insert", "cal@x") in fake.calls
+
+
+def test_resolve_mapping_without_cache_queries_db(mocker):
+    existing = SimpleNamespace(
+        google_calendar_id="cal@x",
+        google_event_id="g-1",
+        last_pushed_hash="old",
+        save=mocker.Mock(),
+    )
+    model = _mock_model(mocker, existing=existing)
+    fake = FakeClient()
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    service.push("cal@x", _snapshot())
+
+    model.objects.get.assert_called_once_with(canvas_appointment_id="appt-1")
+
+
+# --- sweep_calendar -------------------------------------------------------------------------------
+
+
+def test_sweep_calendar_removes_orphans(mocker):
+    _mock_model(mocker)
+    model = mocker.patch("gcal_sync.sync_service.AppointmentEventMapping")
+    model.objects.filter.return_value.delete.return_value = None
+
+    fake = FakeClient()
+    fake._all_events = [
+        {"id": "g1", "extendedProperties": {"private": {"canvasApptId": "orphan-1"}}},
+        {"id": "g2", "extendedProperties": {"private": {"canvasApptId": "live-1"}}},
+    ]
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    deleted = service.sweep_calendar(
+        "cal@x",
+        live_appointment_ids={"live-1"},
+        time_min="2026-01-01T00:00:00Z",
+        time_max="2027-01-01T00:00:00Z",
+        max_deletes=100,
+    )
+
+    assert deleted == 1
+    assert ("delete", "cal@x", "g1") in fake.calls
+    # live-1 is in the live set, so g2 is not deleted
+    assert ("delete", "cal@x", "g2") not in fake.calls
+
+
+def test_sweep_calendar_deduplicates(mocker):
+    model = mocker.patch("gcal_sync.sync_service.AppointmentEventMapping")
+    model.objects.filter.return_value.first.return_value = SimpleNamespace(
+        google_event_id="g1"  # g1 is the mapped event
+    )
+
+    fake = FakeClient()
+    fake._all_events = [
+        {"id": "g1", "extendedProperties": {"private": {"canvasApptId": "live-1"}}},
+        {"id": "g2", "extendedProperties": {"private": {"canvasApptId": "live-1"}}},
+    ]
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    deleted = service.sweep_calendar(
+        "cal@x",
+        live_appointment_ids={"live-1"},
+        time_min="2026-01-01T00:00:00Z",
+        time_max="2027-01-01T00:00:00Z",
+        max_deletes=100,
+    )
+
+    assert deleted == 1
+    # g1 is kept (the mapped event), g2 is deleted (the duplicate)
+    assert ("delete", "cal@x", "g2") in fake.calls
+    assert ("delete", "cal@x", "g1") not in fake.calls
+
+
+def test_sweep_calendar_dedup_no_mapping_keeps_first(mocker):
+    model = mocker.patch("gcal_sync.sync_service.AppointmentEventMapping")
+    model.objects.filter.return_value.first.return_value = None  # no mapping
+
+    fake = FakeClient()
+    fake._all_events = [
+        {"id": "g1", "extendedProperties": {"private": {"canvasApptId": "live-1"}}},
+        {"id": "g2", "extendedProperties": {"private": {"canvasApptId": "live-1"}}},
+    ]
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    deleted = service.sweep_calendar(
+        "cal@x",
+        live_appointment_ids={"live-1"},
+        time_min="2026-01-01T00:00:00Z",
+        time_max="2027-01-01T00:00:00Z",
+        max_deletes=100,
+    )
+
+    # First event kept, second deleted
+    assert deleted == 1
+    assert ("delete", "cal@x", "g2") in fake.calls
+
+
+def test_sweep_calendar_respects_max_deletes(mocker):
+    mocker.patch("gcal_sync.sync_service.AppointmentEventMapping")
+
+    fake = FakeClient()
+    fake._all_events = [
+        {"id": f"g{i}", "extendedProperties": {"private": {"canvasApptId": f"orphan-{i}"}}}
+        for i in range(10)
+    ]
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    deleted = service.sweep_calendar(
+        "cal@x",
+        live_appointment_ids=set(),  # all are orphans
+        time_min="2026-01-01T00:00:00Z",
+        time_max="2027-01-01T00:00:00Z",
+        max_deletes=3,
+    )
+
+    assert deleted == 3
+
+
+def test_sweep_calendar_skips_unstamped_events(mocker):
+    mocker.patch("gcal_sync.sync_service.AppointmentEventMapping")
+
+    fake = FakeClient()
+    fake._all_events = [
+        {"id": "g1"},  # no canvasApptId -> not ours
+        {"id": "g2", "extendedProperties": {"private": {}}},  # no canvasApptId
+    ]
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+
+    deleted = service.sweep_calendar(
+        "cal@x",
+        live_appointment_ids=set(),
+        time_min="2026-01-01T00:00:00Z",
+        time_max="2027-01-01T00:00:00Z",
+        max_deletes=100,
+    )
+
+    assert deleted == 0
+
+
+# --- push self-heal 410 --------------------------------------------------------------------------
+
+
+def test_push_self_heals_on_410(mocker):
+    existing = SimpleNamespace(
+        google_calendar_id="cal@x",
+        google_event_id="g-1",
+        last_pushed_hash="old",
+        save=mocker.Mock(),
+    )
+    _mock_model(mocker, existing=existing)
+
+    class GoneClient(FakeClient):
+        def patch_event(self, calendar_id, event_id, body):
+            raise GoogleApiError(410, "gone")
+
+    fake = GoneClient()
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+    service.push("cal@x", _snapshot())
+
+    assert ("insert", "cal@x") in fake.calls
+    assert existing.google_event_id == "g-new"
+
+
+# --- push re-raises non-404/410 errors ---
+
+
+def test_push_reraises_500(mocker):
+    existing = SimpleNamespace(
+        google_calendar_id="cal@x",
+        google_event_id="g-1",
+        last_pushed_hash="old",
+        save=mocker.Mock(),
+    )
+    _mock_model(mocker, existing=existing)
+
+    class ErrorClient(FakeClient):
+        def patch_event(self, calendar_id, event_id, body):
+            raise GoogleApiError(500, "server error")
+
+    fake = ErrorClient()
+    service = SyncService(VALID_SA, client_factory=lambda cal: fake)
+    with pytest.raises(GoogleApiError):
+        service.push("cal@x", _snapshot())


### PR DESCRIPTION
## Summary

Ports all production-hardened improvements from `gcal_sync` (v0.6.1) back to the MSF reference (was v0.4.5).

### Critical bug fixes
- **Idempotent outbound push** — adopts existing Google events by private property instead of inserting duplicates when local mapping drifts
- **Multi-attendee scoping** — provider-scoped lookups prevent shared Google events from being skipped or duplicated across calendars
- **Convergence guard** — prevents create→cancel→re-create hold loops (previously minted 260k cancelled duplicates)
- **PendingHoldCreate dedup** — per-(calendar, event) marker prevents duplicate hold creation under concurrent load
- **Non-destructive reimport** — adopts existing holds instead of cancel-then-recreate

### Performance
- Prefetch mapping caches in blocks, sync, and reconcile (N+1 elimination)
- Inbound content hash skips unchanged re-deliveries
- Bounded outbound push with `GoogleRateLimitError` handling and rate-limit deferral

### New features
- **ReimportDrainCron** — paced fleet re-import across many short cron ticks
- **OutboundBackfillDrainCron** — paced Canvas→Google backfill with rate-limit defer
- **sweep_outbound / sweep_calendar** — orphan and duplicate event cleanup
- **Provider locking** (`ProviderSyncLock`) for concurrent admin action safety
- **Dry-run re-import** preview in admin UI
- **Bounded purge** with cursor for gateway-timeout-safe hold cleanup
- **Admin UI** — re-import all, cancel, dry-run buttons with collapsible help section

### Files changed (11)
- 9 modified: manifest, models, client, inbound, reconcile, sync_service, blocks, admin routes, admin template
- 2 new: `handlers/reimport_drain.py`, `handlers/outbound_backfill.py`

### Notes
- MSF namespace (`msf__gcal_sync`) preserved — no Rivia-specific references
- MSF's early `parse_service_account()` validation retained (appointment_sync.py untouched)
- MSF's resilient try/except in `_delete_removed` (blocks.py) kept over Rivia's bare version

## Test plan
- [ ] Review with Cerberus for code quality and security
- [ ] Deploy to `thelanby-dev` and verify two-way sync
- [ ] Test admin UI: dry-run, re-import all, cancel, purge
- [ ] Verify idempotent push doesn't create duplicate Google events
- [ ] Verify multi-attendee shared events sync correctly per-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)