### PR TITLE
Fix CSS unicode escape in gcal_sync admin UI

### DIFF
--- a/extensions/gcal_sync/gcal_sync/templates/google_admin.html
+++ b/extensions/gcal_sync/gcal_sync/templates/google_admin.html
@@ -163,7 +163,7 @@
             width: 20px; height: 20px; border-radius: 6px; font-size: 15px; font-weight: 700;
             background: var(--rm-blue-wash); color: var(--rm-blue-deep); transition: transform 0.2s ease;
         }
-        details[open] summary::before { content: "\u2212"; transform: rotate(0deg); }
+        details[open] summary::before { content: "\2212"; transform: rotate(0deg); }
         .import-body { padding: 0 0 14px; }
         .import-note { color: var(--muted); font-size: 12.5px; margin: 2px 0 10px; }
         .action-defs { margin: 2px 0 0; }


### PR DESCRIPTION
## Summary

- Fix CSS `content` property using `\u2212` (JavaScript unicode) instead of `\2212` (CSS unicode escape) for the minus sign in the collapsible help section toggle
- Browser was rendering literal text "u221" instead of the − character

One-line fix in `google_admin.html`.

## Test plan
- [ ] Open Google Calendar Sync admin app
- [ ] Expand "What do these buttons do?" section
- [ ] Verify the toggle icon shows − (minus) not "u221"

🤖 Generated with [Claude Code](https://claude.com/claude-code)