### PR TITLE
fix(external-calendar-busy-blocks): reconcile Busy blocks on the live calendar so orphans clean up

### DIFF
--- a/extensions/external-calendar-busy-blocks/README.md
+++ b/extensions/external-calendar-busy-blocks/README.md
@@ -20,9 +20,17 @@ Each provider opens the **Calendar Busy Blocks** application from the Canvas glo
 
 1. Fetches each provider's ICS feed (sending `If-None-Match` / `If-Modified-Since` so unchanged feeds return `304 Not Modified` and skip work).
 2. Parses the feed, filters to confirmed busy events, expands recurring events within a 90-day window, and converts everything to UTC.
-3. Diffs the parsed events against the events the plugin previously imported and emits `Event.create`, `Event.update`, or `Event.delete` effects.
+3. Reconciles the provider's live Admin calendar against the parsed feed, matching blocks on their `(starts_at, ends_at)` window. Blocks the feed no longer wants are deleted, blocks it wants that aren't present yet are created (`Event.create` / `Event.delete`).
 
 Canvas users see only "Busy" — the original event titles never leave the personal calendar.
+
+### Why it reconciles on the live calendar (KOALA-6372)
+
+The plugin used to track each block's Canvas event id in an `ImportedEvent` table and update/delete by that id. Canvas's calendar-event **create** interpreter discards the id supplied on the effect and assigns its own uuid (KOALA-6372), so every stored id was a phantom: updates raised "Event does not exist" and deletes silently no-op'd. The plugin could add blocks but never clean them up, and orphaned "Busy" events piled up until they made providers unbookable.
+
+As of **0.4.0** the reconcile no longer trusts any stored id. It reads the live "Busy" events straight off the Admin calendar (with their real uuids), matches them to the feed by start/end time, and deletes by the real uuid. This both stops accruing orphans and cleans up ones already stranded — the next few ticks after upgrading will delete existing orphaned blocks (bounded by `MAX_DELETES_PER_SYNC` per feed per tick). A feed that parses to zero events while blocks still exist is treated as a transient glitch and skips deletions, so an upstream hiccup can't wipe a calendar. The `ImportedEvent` table is now unused and inert; it can be dropped in a later release.
+
+Note: cleanup runs whenever a feed's contents change (any `Event.create`/`Event.delete` tick). A feed that returns `304 Not Modified` is skipped, so a completely static feed's historical orphans clear on its next real change rather than immediately.
 
 ## Admin: connect feeds on behalf of providers
 
@@ -40,6 +48,7 @@ feeds, and the stored URL is never shown back in the UI.
 | Plugin secret | Default | Notes |
 |---|---|---|
 | `LOOKAHEAD_DAYS` | `90` | How far in advance to expand recurring events. |
+| `MAX_DELETES_PER_SYNC` | `500` | Cap on block deletions emitted per feed per tick. A safety valve: bounds the blast radius of a partial parse and spreads the one-time cleanup of historical orphans across ticks. Anything over the cap clears on the next run. |
 | `ADMIN_STAFF_IDS` | _(unset)_ | Comma-separated Canvas staff IDs allowed to manage other providers' feeds from the admin section. Unset means no one has admin access (the admin section is hidden). |
 
 ## Privacy & security

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.1.4",
-    "plugin_version": "0.3.3",
+    "plugin_version": "0.4.0",
     "name": "external_calendar_busy_blocks",
     "description": "Subscribe Canvas to a provider's personal calendar via ICS and mirror busy times as Admin events.",
     "components": {
@@ -8,17 +8,17 @@
             {
                 "class": "external_calendar_busy_blocks.routes.feeds:FeedsAPI",
                 "description": "POST /feeds to connect; POST /feeds/delete to disconnect.",
-                "data_access": {"event": "", "read": ["Staff"], "write": ["Event", "Calendar"]}
+                "data_access": {"event": "", "read": ["Staff", "Calendar", "Event"], "write": ["Event", "Calendar"]}
             },
             {
                 "class": "external_calendar_busy_blocks.ui.pages:ConfigPage",
                 "description": "GET /pages/config — renders the connect/disconnect HTML page.",
-                "data_access": {"event": "", "read": ["Staff"], "write": []}
+                "data_access": {"event": "", "read": ["Staff", "Calendar", "Event"], "write": []}
             },
             {
                 "class": "external_calendar_busy_blocks.sync.cron:SyncCron",
-                "description": "Every 15 minutes: fetch each active feed, parse, diff, and emit Event effects.",
-                "data_access": {"event": "", "read": ["Staff", "Calendar"], "write": ["Event", "Calendar"]}
+                "description": "Every 15 minutes: fetch each active feed, parse, and reconcile the live Admin calendar to the feed.",
+                "data_access": {"event": "", "read": ["Staff", "Calendar", "Event"], "write": ["Event", "Calendar"]}
             }
         ],
         "applications": [
@@ -35,7 +35,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["LOOKAHEAD_DAYS", "ADMIN_STAFF_IDS", "namespace_read_write_access_key"],
+    "secrets": ["LOOKAHEAD_DAYS", "MAX_DELETES_PER_SYNC", "ADMIN_STAFF_IDS", "namespace_read_write_access_key"],
     "tags": {},
     "references": [],
     "license": "MIT",

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/calendars/admin_lookup.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/calendars/admin_lookup.py
@@ -16,6 +16,39 @@ from canvas_sdk.v1.data.staff import Staff
 from logger import log
 
 
+def _provider_name(provider_id: str) -> str | None:
+    """Resolve a staff member's display name, or ``None`` if it can't be found."""
+    try:
+        staff = Staff.objects.get(id=provider_id)
+    except Staff.DoesNotExist:
+        return None
+    return staff.full_name or None
+
+
+def _existing_admin_calendar_id(provider_name: str) -> str:
+    existing = CalendarModel.objects.for_calendar_name(
+        provider_name=provider_name,
+        calendar_type=CalendarType.Administrative,
+        location=None,
+    ).first()
+    # `id` is a UUID. The Event effect json-serializes calendar_id as-is, so a
+    # UUID object raises "Object of type UUID is not JSON serializable".
+    return str(existing.id) if existing else ""
+
+
+def find_admin_calendar_id(provider_id: str) -> str:
+    """Return the provider's existing Admin calendar id, or ``""`` if none.
+
+    Look-up only. Unlike :func:`get_admin_calendar_id` this never provisions a
+    calendar, so callers that only read or clean up existing blocks (disconnect,
+    status) don't create an empty calendar as a side effect.
+    """
+    provider_name = _provider_name(provider_id)
+    if not provider_name:
+        return ""
+    return _existing_admin_calendar_id(provider_name)
+
+
 def get_admin_calendar_id(provider_id: str) -> tuple[str, list[Effect]]:
     """Find or create the provider's Administrative calendar.
 
@@ -23,24 +56,13 @@ def get_admin_calendar_id(provider_id: str) -> tuple[str, list[Effect]]:
     already has an Admin calendar the effects list is empty. When the staff or
     their name cannot be resolved, returns ``("", [])``.
     """
-    try:
-        staff = Staff.objects.get(id=provider_id)
-        provider_name = staff.full_name
-    except Staff.DoesNotExist:
-        return "", []
-
+    provider_name = _provider_name(provider_id)
     if not provider_name:
         return "", []
 
-    existing = CalendarModel.objects.for_calendar_name(
-        provider_name=provider_name,
-        calendar_type=CalendarType.Administrative,
-        location=None,
-    ).first()
-    if existing:
-        # `id` is a UUID. The Event effect json-serializes calendar_id as-is, so
-        # a UUID object raises "Object of type UUID is not JSON serializable".
-        return str(existing.id), []
+    existing_id = _existing_admin_calendar_id(provider_name)
+    if existing_id:
+        return existing_id, []
 
     new_id = str(uuid.uuid4())
     cal_effect = CalendarEffect(

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/calendars/live_events.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/calendars/live_events.py
@@ -1,0 +1,80 @@
+"""Read a provider's live "Busy" Admin-calendar events by their real UUIDs.
+
+The cron writes each block with ``Event(...).create()``, but Canvas's
+calendar-event create interpreter discards the supplied ``event_id`` and assigns
+a fresh uuid (KOALA-6372). The id the plugin stored therefore never matches the
+live event, so update/delete by that id fail: update raises "Event does not
+exist" and delete silently no-ops. That is why orphaned blocks accumulate and
+can never be cleaned up.
+
+The fix is to stop trusting the stored id. Read each block's *real* uuid back
+from the calendar data model and reconcile on the live calendar, matching blocks
+by their ``(starts_at, ends_at)`` window. Nothing here depends on the phantom id.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+
+from canvas_sdk.v1.data.calendar import Event as CalendarEvent
+
+BUSY_TITLE = "Busy"
+
+
+def live_busy_events(
+    calendar_id: str, now: datetime, window_end: datetime | None = None
+):
+    """Future, non-cancelled "Busy" events on one Admin calendar.
+
+    Mirrors the ICS parser's window so a reconcile compares like for like: an
+    event counts as live when it has not ended (``ends_at > now``) and, when
+    ``window_end`` is given, starts before the look-ahead horizon
+    (``starts_at < window_end``). Omit ``window_end`` to select every not-yet-
+    ended block, which disconnect uses to remove all of a provider's blocks.
+    """
+    qs = CalendarEvent.objects.filter(
+        calendar__id=calendar_id,
+        title=BUSY_TITLE,
+        is_cancelled=False,
+        ends_at__gt=now,
+    )
+    if window_end is not None:
+        qs = qs.filter(starts_at__lt=window_end)
+    return qs
+
+
+def busy_ids_by_time(
+    calendar_id: str, now: datetime, window_end: datetime
+) -> dict[tuple[datetime, datetime], list[str]]:
+    """Map each live block's ``(starts_at, ends_at)`` to the real uuids there.
+
+    A slot can hold more than one uuid when duplicate blocks exist (e.g. a
+    triplicated import). The reconcile uses each list's length to decide how many
+    blocks to keep versus delete at that time.
+    """
+    by_time: dict[tuple[datetime, datetime], list[str]] = defaultdict(list)
+    for event in live_busy_events(calendar_id, now, window_end):
+        by_time[(event.starts_at, event.ends_at)].append(str(event.id))
+    return by_time
+
+
+def live_busy_counts(calendar_ids: list[str], now: datetime) -> dict[str, int]:
+    """Count future, non-cancelled "Busy" events per calendar in one query.
+
+    Returns ``{calendar_uuid_str: count}`` so the admin config page can show each
+    provider's real block count without an N+1 over calendars.
+    """
+    counts: dict[str, int] = {}
+    if not calendar_ids:
+        return counts
+    rows = CalendarEvent.objects.filter(
+        calendar__id__in=calendar_ids,
+        title=BUSY_TITLE,
+        is_cancelled=False,
+        ends_at__gt=now,
+    ).values_list("calendar__id", flat=True)
+    for cal_id in rows:
+        key = str(cal_id)
+        counts[key] = counts.get(key, 0) + 1
+    return counts

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/models/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/models/feeds.py
@@ -39,7 +39,18 @@ class StaffCalendarFeed(CustomModel):
 
 
 class ImportedEvent(CustomModel):
-    """One row per (ICS UID, recurrence-id) -> Canvas Event id mapping."""
+    """DEPRECATED as of 0.4.0. No longer read or written at runtime.
+
+    This table stored each block's `canvas_event_id`, but Canvas's create
+    interpreter discards the supplied id and assigns its own (KOALA-6372), so
+    every stored id was a phantom and update/delete by it failed. The plugin now
+    reconciles against the live calendar by `(starts_at, ends_at)` and reads real
+    uuids back from the calendar data model, so this mapping is obsolete. The
+    class is retained only so the table isn't dropped; existing rows are inert
+    and it can be removed in a follow-up once the drop migration is vetted.
+
+    Historically: one row per (ICS UID, recurrence-id) -> Canvas Event id mapping.
+    """
 
     class Meta:
         constraints = [

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/routes/feeds.py
@@ -1,5 +1,6 @@
 import json
 import re
+from datetime import datetime, timezone
 
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.calendar import Event
@@ -7,11 +8,12 @@ from canvas_sdk.effects.simple_api import JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 
 from external_calendar_busy_blocks.auth import canonical_staff_id, canonicalize_staff_id, is_admin
-from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
-from external_calendar_busy_blocks.data.models import (
-    ImportedEvent,
-    StaffCalendarFeed,
+from external_calendar_busy_blocks.calendars.admin_lookup import (
+    find_admin_calendar_id,
+    get_admin_calendar_id,
 )
+from external_calendar_busy_blocks.calendars.live_events import live_busy_events
+from external_calendar_busy_blocks.data.models import StaffCalendarFeed
 from external_calendar_busy_blocks.http.fetcher import FetchOk, fetch_feed
 
 
@@ -99,10 +101,16 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         if feed is None:
             return [JSONResponse({"status": "no feed"}, status_code=200)]
 
+        # Remove every block this feed put on the provider's Admin calendar,
+        # deleting each by its real uuid read from the live calendar. Look up the
+        # calendar without provisioning one — if none exists there is nothing to
+        # clean up.
         effects: list[Effect] = []
-        for row in ImportedEvent.objects.filter(staff_id=target_id):
-            effects.append(Event(event_id=row.canvas_event_id).delete())
-            row.delete()
+        calendar_id = find_admin_calendar_id(target_id)
+        if calendar_id:
+            now = datetime.now(timezone.utc)
+            for event in live_busy_events(calendar_id, now):
+                effects.append(Event(event_id=str(event.id)).delete())
 
         feed.delete()
         return [*effects, JSONResponse({"status": "disconnected"}, status_code=200)]
@@ -119,7 +127,12 @@ class FeedsAPI(StaffSessionAuthMixin, SimpleAPI):
         if not target_id:
             return [JSONResponse({"error": "Missing staff_id"}, status_code=400)]
 
-        event_count = ImportedEvent.objects.filter(staff_id=target_id).count()
+        calendar_id = find_admin_calendar_id(target_id)
+        event_count = (
+            live_busy_events(calendar_id, datetime.now(timezone.utc)).count()
+            if calendar_id
+            else 0
+        )
 
         feed = StaffCalendarFeed.objects.filter(staff_id=target_id).first()
         if feed is None:

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/sync/cron.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/sync/cron.py
@@ -1,6 +1,5 @@
-import uuid
-from datetime import datetime, timezone
-from typing import Any
+from collections import Counter
+from datetime import datetime, timedelta, timezone
 
 from logger import log
 
@@ -9,10 +8,8 @@ from canvas_sdk.effects.calendar import Event
 from canvas_sdk.handlers.cron_task import CronTask
 
 from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
-from external_calendar_busy_blocks.data.models import (
-    ImportedEvent,
-    StaffCalendarFeed,
-)
+from external_calendar_busy_blocks.calendars.live_events import busy_ids_by_time
+from external_calendar_busy_blocks.data.models import StaffCalendarFeed
 from external_calendar_busy_blocks.http.fetcher import (
     FetchOk,
     NotFound,
@@ -27,6 +24,13 @@ from external_calendar_busy_blocks.ics.types import IcsParseError, ParsedEvent
 
 LOOKAHEAD_DAYS_DEFAULT = 90
 
+# Safety valve: the most block deletions a single feed may emit in one tick.
+# A healthy feed deletes only what genuinely dropped out; this bounds the blast
+# radius if a feed ever parses partially, and it spreads the one-time cleanup of
+# historical orphans over a few ticks rather than firing hundreds of deletes at
+# once. Anything left over clears on the next run.
+MAX_DELETES_PER_SYNC_DEFAULT = 500
+
 
 class SyncCron(CronTask):
     """Polls every 15 minutes and reconciles ICS feeds to Canvas Admin events."""
@@ -36,11 +40,12 @@ class SyncCron(CronTask):
     def execute(self) -> list[Effect]:
         now = datetime.now(timezone.utc)
         lookahead = self._lookahead_days()
+        max_deletes = self._max_deletes_per_sync()
         effects: list[Effect] = []
 
         for feed in StaffCalendarFeed.objects.filter(is_active=True):
             try:
-                effects.extend(self._sync_feed(feed, now, lookahead))
+                effects.extend(self._sync_feed(feed, now, lookahead, max_deletes))
             except Exception as exc:  # noqa: BLE001 — isolate per-feed failures
                 # One provider's feed must never abort the whole tick or skip
                 # the remaining feeds. Log with traceback (Sentry-visible) and
@@ -60,11 +65,24 @@ class SyncCron(CronTask):
             log.warning("LOOKAHEAD_DAYS not parseable; using default %d", LOOKAHEAD_DAYS_DEFAULT)
             return LOOKAHEAD_DAYS_DEFAULT
 
+    def _max_deletes_per_sync(self) -> int:
+        try:
+            return int(
+                self.secrets.get("MAX_DELETES_PER_SYNC", str(MAX_DELETES_PER_SYNC_DEFAULT))
+            )
+        except (TypeError, ValueError):
+            log.warning(
+                "MAX_DELETES_PER_SYNC not parseable; using default %d",
+                MAX_DELETES_PER_SYNC_DEFAULT,
+            )
+            return MAX_DELETES_PER_SYNC_DEFAULT
+
     def _sync_feed(
         self,
         feed: StaffCalendarFeed,
         now: datetime,
         lookahead_days: int,
+        max_deletes: int,
     ) -> list[Effect]:
         calendar_id, cal_effects = get_admin_calendar_id(feed.staff_id)
         if not calendar_id:
@@ -110,21 +128,22 @@ class SyncCron(CronTask):
             feed.save()
             return []
 
-        # Only reconcile events that haven't ended yet. The parser never yields
-        # past occurrences, so including past ImportedEvent rows here would make
-        # the diff treat them as "removed from the feed" and delete them within
-        # ~15 min of the meeting ending. Per the spec, past events age out
-        # naturally on the source calendar rather than being deleted by the cron.
-        existing = list(
-            ImportedEvent.objects.filter(staff_id=feed.staff_id, ends_at__gte=now)
-        )
+        # The live calendar is the source of truth for what exists; the feed is
+        # the source of truth for what should. Read live blocks (by their real
+        # uuids) within the same window the parser covers so the two sets line up.
+        window_end = now + timedelta(days=lookahead_days)
+        live_by_time = busy_ids_by_time(calendar_id, now, window_end)
 
-        if not parsed and existing:
+        # Safety guard: a feed that parses to zero events while the calendar still
+        # holds blocks is almost always a transient upstream glitch, not the
+        # provider clearing their calendar. Skip deletions rather than wipe every
+        # block; a genuinely emptied feed clears on a later tick once confirmed.
+        if not parsed and live_by_time:
             feed.last_error = "feed parsed but empty; deletions skipped"
             feed.save()
             return cal_effects
 
-        effects = self._diff_and_emit(feed, calendar_id, parsed, existing, now)
+        effects = self._reconcile(calendar_id, parsed, live_by_time, max_deletes)
 
         feed.last_sync_at = now
         feed.last_etag = result.etag
@@ -133,74 +152,64 @@ class SyncCron(CronTask):
         feed.save()
         return [*cal_effects, *effects]
 
-    def _diff_and_emit(
+    def _reconcile(
         self,
-        feed: StaffCalendarFeed,
         calendar_id: str,
         parsed: list[ParsedEvent],
-        existing: list[Any],
-        now: datetime,
+        live_by_time: dict[tuple[datetime, datetime], list[str]],
+        max_deletes: int,
     ) -> list[Effect]:
-        by_key_existing = {(e.ics_uid, e.recurrence_id): e for e in existing}
-        seen_keys: set[tuple[str, str | None]] = set()
+        """Reconcile the live Admin calendar to the parsed feed by time window.
+
+        Every block is matched on its ``(starts_at, ends_at)`` pair, never on the
+        stored id. A live block the feed no longer wants is deleted by its *real*
+        uuid; a block the feed wants that isn't live yet is created. Because it
+        reconciles against the live calendar rather than a tracking table, it both
+        stops accruing orphans and cleans up ones already stranded by KOALA-6372.
+        """
+        desired: Counter[tuple[datetime, datetime]] = Counter(
+            (ev.starts_at, ev.ends_at) for ev in parsed
+        )
         effects: list[Effect] = []
 
-        for ev in parsed:
-            key = (ev.uid, ev.recurrence_id)
-            seen_keys.add(key)
-            prior = by_key_existing.get(key)
+        # Delete surplus: any block present more times than the feed wants at that
+        # time. A feed count of zero deletes them all — that is the orphan
+        # cleanup. Bounded by max_deletes so a partial parse can't mass-delete;
+        # the remainder clears on subsequent ticks.
+        deletes = 0
+        hit_cap = False
+        for key, real_ids in live_by_time.items():
+            keep = desired.get(key, 0)
+            for real_id in real_ids[keep:]:
+                if deletes >= max_deletes:
+                    hit_cap = True
+                    break
+                effects.append(Event(event_id=real_id).delete())
+                deletes += 1
+            if hit_cap:
+                break
+        if hit_cap:
+            log.warning(
+                "external_calendar_busy_blocks: hit delete cap of %d on calendar %s; "
+                "remaining orphaned blocks will clear on subsequent ticks",
+                max_deletes,
+                calendar_id,
+            )
 
-            if prior is None:
-                new_event_id = str(uuid.uuid4())
+        # Create shortfall: the feed wants more blocks at this time than are live.
+        for (starts_at, ends_at), want in desired.items():
+            have = len(live_by_time.get((starts_at, ends_at), ()))
+            for _ in range(want - have):
+                # event_id is intentionally omitted: the create interpreter
+                # ignores any supplied id and assigns its own (KOALA-6372). The
+                # real id is read back from the calendar on later ticks.
                 effects.append(
                     Event(
-                        event_id=new_event_id,
                         calendar_id=calendar_id,
                         title="Busy",
-                        starts_at=ev.starts_at,
-                        ends_at=ev.ends_at,
+                        starts_at=starts_at,
+                        ends_at=ends_at,
                     ).create()
                 )
-                ImportedEvent(
-                    staff_id=feed.staff_id,
-                    ics_uid=ev.uid,
-                    recurrence_id=ev.recurrence_id,
-                    canvas_event_id=new_event_id,
-                    sequence=ev.sequence,
-                    starts_at=ev.starts_at,
-                    ends_at=ev.ends_at,
-                    is_all_day=ev.is_all_day,
-                    last_seen=now,
-                ).save()
-                continue
-
-            if (
-                prior.starts_at == ev.starts_at
-                and prior.ends_at == ev.ends_at
-                and prior.sequence == ev.sequence
-            ):
-                prior.last_seen = now
-                prior.save()
-                continue
-
-            effects.append(
-                Event(
-                    event_id=prior.canvas_event_id,
-                    title="Busy",
-                    starts_at=ev.starts_at,
-                    ends_at=ev.ends_at,
-                ).update()
-            )
-            prior.starts_at = ev.starts_at
-            prior.ends_at = ev.ends_at
-            prior.sequence = ev.sequence
-            prior.last_seen = now
-            prior.save()
-
-        for key, row in by_key_existing.items():
-            if key in seen_keys:
-                continue
-            effects.append(Event(event_id=row.canvas_event_id).delete())
-            row.delete()
 
         return effects

--- a/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
+++ b/extensions/external-calendar-busy-blocks/external_calendar_busy_blocks/ui/pages.py
@@ -1,12 +1,16 @@
+from datetime import datetime, timezone
 from http import HTTPStatus
 
+from canvas_sdk.effects.calendar import CalendarType
 from canvas_sdk.effects.simple_api import HTMLResponse, PlainTextResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 from canvas_sdk.templates import render_to_string
+from canvas_sdk.v1.data.calendar import Calendar as CalendarModel
 from canvas_sdk.v1.data.staff import Staff
 
 from external_calendar_busy_blocks.auth import canonical_staff_id, is_admin
-from external_calendar_busy_blocks.data.models import ImportedEvent, StaffCalendarFeed
+from external_calendar_busy_blocks.calendars.live_events import live_busy_counts
+from external_calendar_busy_blocks.data.models import StaffCalendarFeed
 
 
 class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
@@ -31,13 +35,25 @@ class ConfigPage(StaffSessionAuthMixin, SimpleAPI):
                 f.staff_id: f
                 for f in StaffCalendarFeed.objects.filter(staff_id__in=staff_ids)
             }
-            # One bulk query for imported-event counts per provider. values_list
-            # avoids pulling full rows; tally in Python (no Count/Counter import).
-            event_counts: dict[str, int] = {}
-            for sid in ImportedEvent.objects.filter(staff_id__in=staff_ids).values_list(
-                "staff_id", flat=True
-            ):
-                event_counts[sid] = event_counts.get(sid, 0) + 1
+            # Live block count per provider, read from the calendar (its real
+            # state), in two bulk queries and no per-provider N+1: map each
+            # provider to their Admin calendar by title, then count in one pass.
+            admin_title_by_staff = {
+                s.id: f"{s.full_name}: {CalendarType.Administrative}" for s in active_staff
+            }
+            cal_id_by_title = {
+                c.title: str(c.id)
+                for c in CalendarModel.objects.filter(
+                    title__in=list(admin_title_by_staff.values())
+                )
+            }
+            counts_by_cal = live_busy_counts(
+                list(cal_id_by_title.values()), datetime.now(timezone.utc)
+            )
+            event_counts = {
+                staff_id: counts_by_cal.get(cal_id_by_title.get(title, ""), 0)
+                for staff_id, title in admin_title_by_staff.items()
+            }
             for s in active_staff:
                 f = feeds_by_staff.get(s.id)
                 staff_options.append(

--- a/extensions/external-calendar-busy-blocks/tests/calendars/test_admin_lookup.py
+++ b/extensions/external-calendar-busy-blocks/tests/calendars/test_admin_lookup.py
@@ -2,7 +2,10 @@ from unittest.mock import MagicMock, call, patch
 
 from canvas_sdk.v1.data.staff import Staff
 
-from external_calendar_busy_blocks.calendars.admin_lookup import get_admin_calendar_id
+from external_calendar_busy_blocks.calendars.admin_lookup import (
+    find_admin_calendar_id,
+    get_admin_calendar_id,
+)
 
 MODULE = "external_calendar_busy_blocks.calendars.admin_lookup"
 
@@ -93,3 +96,42 @@ def test_returns_empty_when_name_blank() -> None:
     assert cal_id == ""
     assert effects == []
     MockCalEffect.assert_not_called()
+
+
+def test_find_returns_existing_id_without_provisioning() -> None:
+    mock_staff = MagicMock(full_name="Jane Doe")
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarModel.objects") as mock_cal_objects,
+        patch(f"{MODULE}.CalendarEffect") as MockCalEffect,
+    ):
+        mock_staff_objects.get.return_value = mock_staff
+        mock_cal_objects.for_calendar_name.return_value.first.return_value = MagicMock(
+            id="cal-uuid-123"
+        )
+        cal_id = find_admin_calendar_id("p1")
+
+    assert cal_id == "cal-uuid-123"
+    # Look-up only: it must never emit a create effect as a side effect.
+    MockCalEffect.assert_not_called()
+
+
+def test_find_returns_empty_when_no_calendar() -> None:
+    mock_staff = MagicMock(full_name="Jane Doe")
+    with (
+        patch(f"{MODULE}.Staff.objects") as mock_staff_objects,
+        patch(f"{MODULE}.CalendarModel.objects") as mock_cal_objects,
+        patch(f"{MODULE}.CalendarEffect") as MockCalEffect,
+    ):
+        mock_staff_objects.get.return_value = mock_staff
+        mock_cal_objects.for_calendar_name.return_value.first.return_value = None
+        cal_id = find_admin_calendar_id("p1")
+
+    assert cal_id == ""
+    MockCalEffect.assert_not_called()
+
+
+def test_find_returns_empty_when_staff_missing() -> None:
+    with patch(f"{MODULE}.Staff.objects") as mock_staff_objects:
+        mock_staff_objects.get.side_effect = Staff.DoesNotExist
+        assert find_admin_calendar_id("nope") == ""

--- a/extensions/external-calendar-busy-blocks/tests/calendars/test_live_events.py
+++ b/extensions/external-calendar-busy-blocks/tests/calendars/test_live_events.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from external_calendar_busy_blocks.calendars import live_events
+
+MODULE = "external_calendar_busy_blocks.calendars.live_events"
+NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 8, 30, tzinfo=timezone.utc)
+
+
+def test_live_busy_events_windowed_filter() -> None:
+    with patch(f"{MODULE}.CalendarEvent") as MockEvent:
+        base_qs = MockEvent.objects.filter.return_value
+        result = live_events.live_busy_events("cal-1", NOW, WINDOW_END)
+
+    _, kwargs = MockEvent.objects.filter.call_args
+    assert kwargs == {
+        "calendar__id": "cal-1",
+        "title": "Busy",
+        "is_cancelled": False,
+        "ends_at__gt": NOW,
+    }
+    # A window_end adds the upper bound so the read mirrors the parser's window.
+    base_qs.filter.assert_called_once_with(starts_at__lt=WINDOW_END)
+    assert result is base_qs.filter.return_value
+
+
+def test_live_busy_events_without_window_skips_upper_bound() -> None:
+    with patch(f"{MODULE}.CalendarEvent") as MockEvent:
+        base_qs = MockEvent.objects.filter.return_value
+        result = live_events.live_busy_events("cal-1", NOW)
+
+    base_qs.filter.assert_not_called()
+    assert result is base_qs
+
+
+def test_busy_ids_by_time_groups_real_uuids_by_time() -> None:
+    s1, e1 = datetime(2026, 6, 2, 9, tzinfo=timezone.utc), datetime(2026, 6, 2, 10, tzinfo=timezone.utc)
+    s2, e2 = datetime(2026, 6, 3, 9, tzinfo=timezone.utc), datetime(2026, 6, 3, 10, tzinfo=timezone.utc)
+    events = [
+        MagicMock(id="u1", starts_at=s1, ends_at=e1),
+        MagicMock(id="u2", starts_at=s1, ends_at=e1),  # duplicate slot
+        MagicMock(id="u3", starts_at=s2, ends_at=e2),
+    ]
+    with patch(f"{MODULE}.live_busy_events", return_value=events):
+        by_time = live_events.busy_ids_by_time("cal-1", NOW, WINDOW_END)
+
+    assert by_time[(s1, e1)] == ["u1", "u2"]
+    assert by_time[(s2, e2)] == ["u3"]
+
+
+def test_live_busy_counts_tallies_per_calendar() -> None:
+    with patch(f"{MODULE}.CalendarEvent") as MockEvent:
+        MockEvent.objects.filter.return_value.values_list.return_value = [
+            "cal-a",
+            "cal-a",
+            "cal-b",
+        ]
+        counts = live_events.live_busy_counts(["cal-a", "cal-b"], NOW)
+
+    assert counts == {"cal-a": 2, "cal-b": 1}
+    _, kwargs = MockEvent.objects.filter.call_args
+    assert kwargs["calendar__id__in"] == ["cal-a", "cal-b"]
+    assert kwargs["title"] == "Busy"
+    assert kwargs["is_cancelled"] is False
+
+
+def test_live_busy_counts_empty_input_makes_no_query() -> None:
+    with patch(f"{MODULE}.CalendarEvent") as MockEvent:
+        counts = live_events.live_busy_counts([], NOW)
+
+    assert counts == {}
+    MockEvent.objects.filter.assert_not_called()

--- a/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
+++ b/extensions/external-calendar-busy-blocks/tests/routes/test_feeds.py
@@ -196,10 +196,12 @@ def test_delete_admin_targets_other_staff() -> None:
     feed = MagicMock(staff_id="00000000000000000000000000000099")
     with (
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+        patch(
+            "external_calendar_busy_blocks.routes.feeds.find_admin_calendar_id",
+            return_value="",
+        ) as mock_find,
     ):
         MockFeed.objects.filter.return_value.first.return_value = feed
-        MockImported.objects.filter.return_value = []
         api = _api_with_request(
             "POST",
             b'{"staff_id":"00000000-0000-0000-0000-000000000099"}',
@@ -207,8 +209,9 @@ def test_delete_admin_targets_other_staff() -> None:
             secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
         )
         responses = api.delete_feed()
-    # Feed and imported-event lookups were scoped to the target staff id.
+    # Feed lookup and calendar cleanup were scoped to the target staff id.
     assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert mock_find.call_args.args[0] == "00000000000000000000000000000099"
     assert responses[-1].status_code == 200
     feed.delete.assert_called_once()
 
@@ -218,10 +221,12 @@ def test_delete_non_admin_ignores_staff_id() -> None:
     feed = MagicMock(staff_id="00000000000000000000000000000002")
     with (
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+        patch(
+            "external_calendar_busy_blocks.routes.feeds.find_admin_calendar_id",
+            return_value="",
+        ),
     ):
         MockFeed.objects.filter.return_value.first.return_value = feed
-        MockImported.objects.filter.return_value = []
         api = _api_with_request(
             "POST",
             b'{"staff_id":"00000000000000000000000000000099"}',
@@ -245,21 +250,30 @@ def test_delete_idempotent_when_no_feed() -> None:
 
 def test_delete_removes_feed_and_emits_delete_effects() -> None:
     feed = MagicMock(staff_id="staff-abc")
-    imported = [
-        MagicMock(canvas_event_id="evt-1"),
-        MagicMock(canvas_event_id="evt-2"),
-    ]
+    # Live blocks are deleted by their REAL uuids read off the calendar, not by
+    # any stored id (which KOALA-6372 makes a phantom).
+    live = [MagicMock(id="real-uuid-1"), MagicMock(id="real-uuid-2")]
     with (
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+        patch(
+            "external_calendar_busy_blocks.routes.feeds.find_admin_calendar_id",
+            return_value="cal-1",
+        ),
+        patch(
+            "external_calendar_busy_blocks.routes.feeds.live_busy_events",
+            return_value=live,
+        ) as mock_live,
     ):
         MockFeed.objects.filter.return_value.first.return_value = feed
-        MockImported.objects.filter.return_value = imported
         api = _api_with_request("POST", b"{}", logged_in_staff="staff-abc")
         responses = api.delete_feed()
     # Expect 2 Event.delete effects + 1 JSONResponse
     effects_emitted = [r for r in responses if hasattr(r, "type")]
     assert len(effects_emitted) == 2
+    # Deletes carried the real uuids.
+    payloads = [json.loads(e.payload)["data"]["event_id"] for e in effects_emitted]
+    assert set(payloads) == {"real-uuid-1", "real-uuid-2"}
+    assert mock_live.call_args.args[0] == "cal-1"
     feed.delete.assert_called_once()
 
 
@@ -428,10 +442,14 @@ def test_status_reports_connected_feed_without_url() -> None:
     feed = MagicMock(is_active=True, last_sync_at="2026-07-11T00:00:00Z", last_error=None)
     with (
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+        patch(
+            "external_calendar_busy_blocks.routes.feeds.find_admin_calendar_id",
+            return_value="cal-1",
+        ) as mock_find,
+        patch("external_calendar_busy_blocks.routes.feeds.live_busy_events") as mock_live,
     ):
         MockFeed.objects.filter.return_value.first.return_value = feed
-        MockImported.objects.filter.return_value.count.return_value = 5
+        mock_live.return_value.count.return_value = 5
         api = _api_with_request(
             "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
             secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},
@@ -441,20 +459,25 @@ def test_status_reports_connected_feed_without_url() -> None:
     assert responses[0].status_code == 200
     body = json.loads(responses[0].content)
     assert body["connected"] is True
+    # event_count now reflects live blocks on the calendar, not stale tracking rows.
     assert body["event_count"] == 5
     assert "ics_url" not in body
-    # Both the feed lookup and the event count were scoped to the canonical id.
+    # Both the feed lookup and the calendar lookup were scoped to the canonical id.
     assert MockFeed.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
-    assert MockImported.objects.filter.call_args.kwargs["staff_id"] == "00000000000000000000000000000099"
+    assert mock_find.call_args.args[0] == "00000000000000000000000000000099"
 
 
 def test_status_reports_no_feed() -> None:
     with (
         patch("external_calendar_busy_blocks.routes.feeds.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.routes.feeds.ImportedEvent") as MockImported,
+        patch(
+            "external_calendar_busy_blocks.routes.feeds.find_admin_calendar_id",
+            return_value="cal-1",
+        ),
+        patch("external_calendar_busy_blocks.routes.feeds.live_busy_events") as mock_live,
     ):
         MockFeed.objects.filter.return_value.first.return_value = None
-        MockImported.objects.filter.return_value.count.return_value = 0
+        mock_live.return_value.count.return_value = 0
         api = _api_with_request(
             "GET", b"", logged_in_staff="00000000-0000-0000-0000-000000000001",
             secrets={"ADMIN_STAFF_IDS": "00000000000000000000000000000001"},

--- a/extensions/external-calendar-busy-blocks/tests/sync/test_cron.py
+++ b/extensions/external-calendar-busy-blocks/tests/sync/test_cron.py
@@ -30,11 +30,11 @@ def _z(dt: datetime) -> str:
     return dt.strftime("%Y%m%dT%H%M%SZ")
 
 
-def _new_cron(timestamp: datetime) -> SyncCron:
+def _new_cron(timestamp: datetime, secrets: dict | None = None) -> SyncCron:
     """Construct SyncCron with a CRON event keyed to `timestamp`."""
     event = MagicMock()
     event.target.id = timestamp.isoformat()
-    cron = SyncCron(event=event)
+    cron = SyncCron(event=event, secrets=secrets or {})
     cron.SCHEDULE = "*/15 * * * *"
     return cron
 
@@ -75,19 +75,25 @@ def _ok_body(uid: str, start_z: str, end_z: str) -> bytes:
 
 @pytest.fixture
 def patch_sync_deps():
-    """Patch SyncCron's external dependencies in a single place."""
+    """Patch SyncCron's external dependencies in a single place.
+
+    `busy_ids_by_time` stands in for the live Admin calendar: tests set its
+    return value to `{(starts_at, ends_at): [real_uuid, ...]}` to describe the
+    blocks currently on the calendar. It defaults to an empty calendar.
+    """
     with (
         patch("external_calendar_busy_blocks.sync.cron.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.sync.cron.ImportedEvent") as MockImported,
+        patch("external_calendar_busy_blocks.sync.cron.busy_ids_by_time") as mock_busy,
         patch("external_calendar_busy_blocks.sync.cron.fetch_feed") as mock_fetch,
         patch(
             "external_calendar_busy_blocks.sync.cron.get_admin_calendar_id"
         ) as mock_get_cal,
     ):
         mock_get_cal.return_value = ("cal-1", [])
+        mock_busy.return_value = {}
         yield {
             "feed_model": MockFeed,
-            "imported_model": MockImported,
+            "busy": mock_busy,
             "fetch": mock_fetch,
             "get_cal": mock_get_cal,
         }
@@ -98,7 +104,6 @@ def test_new_event_emits_create_effect(patch_sync_deps) -> None:
 
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = FetchOk(
         body=_ok_body("ev-1@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
         etag='"abc"',
@@ -111,6 +116,9 @@ def test_new_event_emits_create_effect(patch_sync_deps) -> None:
     payload = json.loads(create_effects[0].payload)["data"]
     assert payload["title"] == "Busy"
     assert payload["calendar_id"] == "cal-1"
+    # The create no longer supplies an event_id: the interpreter assigns its own
+    # (KOALA-6372), so we stop pretending to control it.
+    assert payload["event_id"] is None
 
 
 def test_unchanged_event_emits_no_effect(patch_sync_deps) -> None:
@@ -119,16 +127,9 @@ def test_unchanged_event_emits_no_effect(patch_sync_deps) -> None:
     feed = _stub_feed()
     start = _future_dt(10, 14)
     end = _future_dt(10, 15)
-    existing = MagicMock(
-        ics_uid="ev-1@x",
-        recurrence_id=None,
-        canvas_event_id="canvas-1",
-        sequence=0,
-        starts_at=start,
-        ends_at=end,
-    )
+    # The block is already live at this exact time; the feed wants the same.
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
+    patch_sync_deps["busy"].return_value = {(start, end): ["real-1"]}
     patch_sync_deps["fetch"].return_value = FetchOk(
         body=_ok_body("ev-1@x", _z(start), _z(end)),
         etag='"abc"',
@@ -140,20 +141,17 @@ def test_unchanged_event_emits_no_effect(patch_sync_deps) -> None:
     assert calendar_effects == []
 
 
-def test_time_changed_emits_update_effect(patch_sync_deps) -> None:
+def test_time_changed_emits_delete_old_and_create_new(patch_sync_deps) -> None:
+    # A moved meeting is a delete of the old block plus a create of the new one.
+    # (The old id-based in-place UPDATE never worked — update by the stored id
+    # raised "Event does not exist" under KOALA-6372.)
     from external_calendar_busy_blocks.http.fetcher import FetchOk
 
     feed = _stub_feed()
-    existing = MagicMock(
-        ics_uid="ev-1@x",
-        recurrence_id=None,
-        canvas_event_id="canvas-1",
-        sequence=0,
-        starts_at=datetime(2026, 6, 15, 14, 0, tzinfo=timezone.utc),
-        ends_at=datetime(2026, 6, 15, 15, 0, tzinfo=timezone.utc),
-    )
+    old_start = _future_dt(10, 14)
+    old_end = _future_dt(10, 15)
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
+    patch_sync_deps["busy"].return_value = {(old_start, old_end): ["real-old"]}
     patch_sync_deps["fetch"].return_value = FetchOk(
         body=_ok_body("ev-1@x", _z(_future_dt(10, 16)), _z(_future_dt(10, 17))),
         etag=None,
@@ -161,28 +159,31 @@ def test_time_changed_emits_update_effect(patch_sync_deps) -> None:
     )
 
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
+    delete_effects = [e for e in effects if e.type == _DELETE]
+    create_effects = [e for e in effects if e.type == _CREATE]
     update_effects = [e for e in effects if e.type == _UPDATE]
-    assert len(update_effects) == 1
-    payload = json.loads(update_effects[0].payload)["data"]
-    assert payload["event_id"] == "canvas-1"
+    assert len(delete_effects) == 1
+    assert len(create_effects) == 1
+    assert update_effects == []
+    # The delete carried the REAL uuid read off the calendar, not a stored id.
+    assert json.loads(delete_effects[0].payload)["data"]["event_id"] == "real-old"
 
 
-def test_removed_event_emits_delete_effect(patch_sync_deps) -> None:
+def test_orphan_block_deleted_by_real_uuid(patch_sync_deps) -> None:
+    # The self-heal: a live block the feed no longer contains is deleted by its
+    # real uuid, while the block the feed still wants is left untouched.
     from external_calendar_busy_blocks.http.fetcher import FetchOk
 
     feed = _stub_feed()
-    existing = MagicMock(
-        ics_uid="ev-old@x",
-        recurrence_id=None,
-        canvas_event_id="canvas-old",
-        sequence=0,
-        starts_at=datetime(2026, 6, 15, 14, 0, tzinfo=timezone.utc),
-        ends_at=datetime(2026, 6, 15, 15, 0, tzinfo=timezone.utc),
-    )
+    keep_start, keep_end = _future_dt(10, 14), _future_dt(10, 15)
+    orphan_start, orphan_end = _future_dt(20, 9), _future_dt(20, 21)
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
+    patch_sync_deps["busy"].return_value = {
+        (keep_start, keep_end): ["real-keep"],
+        (orphan_start, orphan_end): ["real-orphan"],
+    }
     patch_sync_deps["fetch"].return_value = FetchOk(
-        body=_ok_body("ev-new@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
+        body=_ok_body("ev-keep@x", _z(keep_start), _z(keep_end)),
         etag=None,
         last_modified=None,
     )
@@ -190,26 +191,79 @@ def test_removed_event_emits_delete_effect(patch_sync_deps) -> None:
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
     delete_effects = [e for e in effects if e.type == _DELETE]
     create_effects = [e for e in effects if e.type == _CREATE]
+    assert create_effects == []
     assert len(delete_effects) == 1
-    assert len(create_effects) == 1
-    delete_payload = json.loads(delete_effects[0].payload)["data"]
-    assert delete_payload["event_id"] == "canvas-old"
+    assert json.loads(delete_effects[0].payload)["data"]["event_id"] == "real-orphan"
 
 
-def test_safety_guard_skips_deletes_on_empty_feed(patch_sync_deps) -> None:
+def test_duplicate_blocks_pruned_to_feed_count(patch_sync_deps) -> None:
+    # The triplicate case: the feed wants one block at a time, three are live;
+    # two are deleted and one is kept. No creates.
     from external_calendar_busy_blocks.http.fetcher import FetchOk
 
     feed = _stub_feed()
-    existing = MagicMock(
-        ics_uid="ev-1@x",
-        recurrence_id=None,
-        canvas_event_id="canvas-1",
-        sequence=0,
-        starts_at=datetime(2026, 6, 15, 14, 0, tzinfo=timezone.utc),
-        ends_at=datetime(2026, 6, 15, 15, 0, tzinfo=timezone.utc),
-    )
+    start, end = _future_dt(15, 10), _future_dt(15, 11)
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = [existing]
+    patch_sync_deps["busy"].return_value = {(start, end): ["dup-1", "dup-2", "dup-3"]}
+    patch_sync_deps["fetch"].return_value = FetchOk(
+        body=_ok_body("ev-1@x", _z(start), _z(end)),
+        etag=None,
+        last_modified=None,
+    )
+
+    effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
+    delete_effects = [e for e in effects if e.type == _DELETE]
+    create_effects = [e for e in effects if e.type == _CREATE]
+    assert create_effects == []
+    assert len(delete_effects) == 2
+    deleted_ids = {json.loads(e.payload)["data"]["event_id"] for e in delete_effects}
+    # Exactly one of the three real uuids is kept.
+    assert deleted_ids.issubset({"dup-1", "dup-2", "dup-3"})
+    assert len(deleted_ids) == 2
+
+
+def test_delete_cap_limits_deletes_per_tick(patch_sync_deps) -> None:
+    # The safety valve: with a cap of 2, only two of several orphans are deleted
+    # this tick; the rest clear on later ticks. The feed's own block still needs
+    # creating (creates are not capped).
+    from external_calendar_busy_blocks.http.fetcher import FetchOk
+
+    feed = _stub_feed()
+    wanted_start, wanted_end = _future_dt(5, 8), _future_dt(5, 9)
+    orphans = {
+        (_future_dt(6, 9), _future_dt(6, 10)): ["orph-1"],
+        (_future_dt(7, 9), _future_dt(7, 10)): ["orph-2"],
+        (_future_dt(8, 9), _future_dt(8, 10)): ["orph-3"],
+        (_future_dt(9, 9), _future_dt(9, 10)): ["orph-4"],
+    }
+    patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
+    patch_sync_deps["busy"].return_value = orphans
+    patch_sync_deps["fetch"].return_value = FetchOk(
+        body=_ok_body("ev-want@x", _z(wanted_start), _z(wanted_end)),
+        etag=None,
+        last_modified=None,
+    )
+
+    cron = _new_cron(
+        datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc),
+        secrets={"MAX_DELETES_PER_SYNC": "2"},
+    )
+    effects = cron.execute()
+    delete_effects = [e for e in effects if e.type == _DELETE]
+    create_effects = [e for e in effects if e.type == _CREATE]
+    assert len(delete_effects) == 2  # capped
+    assert len(create_effects) == 1  # the wanted block is created regardless
+
+
+def test_safety_guard_skips_deletes_on_empty_feed(patch_sync_deps) -> None:
+    # A feed that parses to zero events while blocks are still live is treated as
+    # a transient glitch: deletions are skipped rather than wiping the calendar.
+    from external_calendar_busy_blocks.http.fetcher import FetchOk
+
+    feed = _stub_feed()
+    start, end = _future_dt(15, 14), _future_dt(15, 15)
+    patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
+    patch_sync_deps["busy"].return_value = {(start, end): ["real-1"]}
     patch_sync_deps["fetch"].return_value = FetchOk(
         body=b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n",
         etag=None,
@@ -219,6 +273,7 @@ def test_safety_guard_skips_deletes_on_empty_feed(patch_sync_deps) -> None:
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
     delete_effects = [e for e in effects if e.type == _DELETE]
     assert delete_effects == []
+    assert feed.last_error and "empty" in feed.last_error.lower()
 
 
 def test_304_emits_no_effects(patch_sync_deps) -> None:
@@ -226,12 +281,13 @@ def test_304_emits_no_effects(patch_sync_deps) -> None:
 
     feed = _stub_feed(last_etag='"abc"')
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = NotModified()
 
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
     calendar_effects = [e for e in effects if e.type in _CALENDAR_TYPES]
     assert calendar_effects == []
+    # A 304 never reads the live calendar (nothing to reconcile against).
+    patch_sync_deps["busy"].assert_not_called()
 
 
 def test_401_deactivates_feed(patch_sync_deps) -> None:
@@ -239,7 +295,6 @@ def test_401_deactivates_feed(patch_sync_deps) -> None:
 
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = Unauthorized()
 
     _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
@@ -252,7 +307,6 @@ def test_5xx_keeps_feed_active(patch_sync_deps) -> None:
 
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = TransientError(reason="HTTP 503")
 
     _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
@@ -263,7 +317,6 @@ def test_5xx_keeps_feed_active(patch_sync_deps) -> None:
 def test_no_admin_calendar_records_error_and_skips(patch_sync_deps) -> None:
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["get_cal"].return_value = ("", [])
 
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()
@@ -271,32 +324,31 @@ def test_no_admin_calendar_records_error_and_skips(patch_sync_deps) -> None:
     assert feed.last_error and "unable to provision" in feed.last_error.lower()
 
 
-def test_existing_query_excludes_past_events(patch_sync_deps) -> None:
-    # Regression: the reconciliation must only consider events that haven't
-    # ended yet. Past ImportedEvent rows must NOT be loaded, otherwise the diff
-    # treats them as removed-from-feed and deletes them every tick.
+def test_live_calendar_read_within_lookahead_window(patch_sync_deps) -> None:
+    # Regression: the live-calendar read must be bounded to the same window the
+    # parser covers ([now, now + lookahead]), so far-future blocks the feed has
+    # not yielded yet are never treated as orphans and deleted.
     from external_calendar_busy_blocks.http.fetcher import FetchOk
 
     now = datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = FetchOk(
-        body=_ok_body("ev-1@x", "20260615T140000Z", "20260615T150000Z"),
+        body=_ok_body("ev-1@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
         etag=None,
         last_modified=None,
     )
 
     _new_cron(now).execute()
 
-    # The ImportedEvent query must be scoped to ends_at >= now. (The cron uses
-    # its own wall-clock now internally, so assert the kwarg is present and is
-    # a tz-aware datetime rather than equal to a fabricated timestamp.)
-    _, kwargs = patch_sync_deps["imported_model"].objects.filter.call_args
-    assert kwargs.get("staff_id") == "staff-abc"
-    ends_at_gte = kwargs.get("ends_at__gte")
-    assert isinstance(ends_at_gte, datetime)
-    assert ends_at_gte.tzinfo is not None
+    # busy_ids_by_time(calendar_id, now, window_end) with a tz-aware window_end
+    # ~90 days out. The cron uses its own wall-clock now, so assert relative.
+    args, _ = patch_sync_deps["busy"].call_args
+    calendar_id, call_now, window_end = args
+    assert calendar_id == "cal-1"
+    assert call_now.tzinfo is not None
+    assert window_end.tzinfo is not None
+    assert timedelta(days=89) < (window_end - call_now) < timedelta(days=91)
 
 
 def test_one_feed_failure_does_not_abort_other_feeds(patch_sync_deps) -> None:
@@ -308,7 +360,6 @@ def test_one_feed_failure_does_not_abort_other_feeds(patch_sync_deps) -> None:
     feed_a = _stub_feed(staff_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ics_url="https://a/x.ics")
     feed_b = _stub_feed(staff_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", ics_url="https://b/x.ics")
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed_a, feed_b]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
 
     # Feed A blows up unexpectedly; Feed B returns a valid single event.
     def fetch_side_effect(url, etag, last_modified):
@@ -341,7 +392,6 @@ def test_new_calendar_effect_is_prepended_before_events(patch_sync_deps) -> None
 
     feed = _stub_feed()
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = FetchOk(
         body=_ok_body("ev-1@x", _z(_future_dt(10, 14)), _z(_future_dt(10, 15))),
         etag=None,
@@ -366,7 +416,6 @@ def test_not_modified_still_provisions_missing_calendar(patch_sync_deps) -> None
 
     feed = _stub_feed(last_etag='"abc"')
     patch_sync_deps["feed_model"].objects.filter.return_value = [feed]
-    patch_sync_deps["imported_model"].objects.filter.return_value = []
     patch_sync_deps["fetch"].return_value = NotModified()
 
     effects = _new_cron(datetime(2026, 6, 1, 14, 15, tzinfo=timezone.utc)).execute()

--- a/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
+++ b/extensions/external-calendar-busy-blocks/tests/ui/test_pages.py
@@ -52,17 +52,22 @@ def test_render_admin_lists_active_staff_with_per_row_status() -> None:
         self_lookup.first.return_value = None
         return self_lookup
 
-    # Bea has 7 imported events; Cy has none. Returned as values_list rows.
-    imported_staff_ids = ["00000000000000000000000000000010"] * 7
+    # Bea's Admin calendar holds 7 live Busy blocks; Cy has no calendar/blocks.
+    # Counts come from the live calendar (real state), matched by Admin title.
+    cal_a = MagicMock(title="Bea Adams: Admin", id="cal-a")
 
     with (
         patch("external_calendar_busy_blocks.ui.pages.render_to_string", return_value="<html></html>") as mock_render,
         patch("external_calendar_busy_blocks.ui.pages.StaffCalendarFeed") as MockFeed,
-        patch("external_calendar_busy_blocks.ui.pages.ImportedEvent") as MockImported,
+        patch("external_calendar_busy_blocks.ui.pages.CalendarModel") as MockCal,
+        patch(
+            "external_calendar_busy_blocks.ui.pages.live_busy_counts",
+            return_value={"cal-a": 7},
+        ) as mock_counts,
         patch("external_calendar_busy_blocks.ui.pages.Staff") as MockStaff,
     ):
         MockFeed.objects.filter.side_effect = filter_side_effect
-        MockImported.objects.filter.return_value.values_list.return_value = imported_staff_ids
+        MockCal.objects.filter.return_value = [cal_a]
         MockStaff.objects.filter.return_value.order_by.return_value = [staff_a, staff_b, staff_nameless]
         _page(
             "00000000-0000-0000-0000-000000000001",
@@ -90,10 +95,13 @@ def test_render_admin_lists_active_staff_with_per_row_status() -> None:
     ]
     assert all(opt["id"] != "00000000000000000000000000000012" for opt in context["staff_options"])
     MockStaff.objects.filter.assert_called_once_with(active=True)
-    # Exactly one bulk feed query and one bulk event-count query (no N+1).
+    # Exactly one bulk feed query, one bulk calendar lookup, one bulk count (no N+1).
     bulk_feed_calls = [c for c in MockFeed.objects.filter.call_args_list if "staff_id__in" in c.kwargs]
     assert len(bulk_feed_calls) == 1
-    assert set(MockImported.objects.filter.call_args.kwargs["staff_id__in"]) == {
-        "00000000000000000000000000000010",
-        "00000000000000000000000000000011",
+    MockCal.objects.filter.assert_called_once()
+    assert set(MockCal.objects.filter.call_args.kwargs["title__in"]) == {
+        "Bea Adams: Admin",
+        "Cy Brown: Admin",
     }
+    mock_counts.assert_called_once()
+    assert mock_counts.call_args.args[0] == ["cal-a"]


### PR DESCRIPTION
## What

The busy-blocks plugin mirrors a provider's external (ICS) busy times onto their Canvas Admin calendar. It tracked each block's Canvas event id in an `ImportedEvent` table and used that id to update or delete blocks when the feed changed.

## The bug

The calendar-event **create** interpreter discards the `event_id` supplied on the effect and assigns its own uuid. So every id the plugin stored was a phantom: `Event(event_id=...).update()` raised "Event does not exist" and `.delete()` silently no-op'd. The plugin could add blocks but never remove them, so orphaned "Busy" events accumulated on Admin calendars and eventually consumed a provider's bookable time.

## The fix

Stop trusting the stored id. Reconcile against the **live** Admin calendar: read each block's real uuid from `canvas_sdk.v1.data.calendar.Event` and match blocks to the parsed feed by `(starts_at, ends_at)`. Deletes carry the real uuid, so they take effect - this both stops accruing orphans and cleans up ones already stranded, **including blocks that no longer have a tracking row** (which the earlier adopt-the-real-id approach could not reach).

- `calendars/live_events.py` (new): read live Busy events by real uuid, windowed to mirror the parser (`ends_at > now AND starts_at < window_end`)
- `sync/cron.py`: stateless `(starts_at, ends_at)` multiset reconcile - delete surplus by real uuid, create shortfall. Adds a look-ahead window bound and a `MAX_DELETES_PER_SYNC` safety valve; keeps the empty-feed guard.
- `routes/feeds.py`: disconnect deletes live blocks by real uuid (the same bug lived here); `/feeds/status` count reads live state
- `ui/pages.py`: admin config `event_count` reads live blocks (2 bulk queries, no N+1)
- `calendars/admin_lookup.py`: add look-up-only `find_admin_calendar_id`
- `ImportedEvent` marked deprecated/inert (kept to avoid a destructive migration); manifest grants `Event` read and bumps to `0.4.0`

## Supersedes

This replaces the earlier "adopt real event ids" approach on this PR, which repaired the stored id on tracked rows so future update/delete worked but could not clean up blocks that had already lost their tracking row. The stateless reconcile handles both.

## Assumption

The reconcile treats every future non-cancelled "Busy" event on a provider's Admin calendar as plugin-owned. Observed to hold: such blocks are only ever created on `": Admin"` calendars by this plugin.

## Tests

167 passing. Coverage for the reconcile (orphan cleanup, duplicate pruning, delete cap, look-ahead window bound, empty-feed guard), the live-events helper, the disconnect/status routes, and the admin count.

## Behavior note

Cleanup runs when a feed's contents change. A `304 Not Modified` tick is skipped, so a fully static feed's historical orphans clear on its next real change rather than immediately.
