### PR TITLE
Fix gcal_sync namespace to msf__gcal_sync (v0.6.2)

### DIFF
--- a/extensions/gcal_sync/gcal_sync/CANVAS_MANIFEST.json
+++ b/extensions/gcal_sync/gcal_sync/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
     "sdk_version": "0.164.0",
-    "plugin_version": "0.6.1",
+    "plugin_version": "0.6.2",
     "name": "gcal_sync",
     "description": "Two-way Google Calendar sync for Canvas: pushes appointments and admin blocks (lunch/PTO) into providers' Workspace calendars in near-real-time, and imports provider-created Google events back into Canvas as admin holds. Canvas remains the system of record. Service-account + domain-wide delegation; no PHI in event fields.",
     "components": {
@@ -126,7 +126,7 @@
         "views": []
     },
     "custom_data": {
-        "namespace": "gcal_sync",
+        "namespace": "msf__gcal_sync",
         "access": "read_write"
     },
     "tags": {},


### PR DESCRIPTION
The namespace "gcal_sync" is invalid — Canvas requires the org__name double-underscore format. The previous revert (73d7c6d) was based on the incorrect assumption that existing deployments had data under the "gcal_sync" schema, but no instance ever successfully created it because it fails regex validation at install time. neuroglow-dev works because it runs v0.4.5 which already had "msf__gcal_sync".