### PR TITLE
Fix PayTheory card form blank on re-open by serving it from a same-origin iframe

### DIFF
--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/CANVAS_MANIFEST.json
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/CANVAS_MANIFEST.json
@@ -51,6 +51,10 @@
                     "read": [],
                     "write": []
                 }
+            },
+            {
+                "class": "paytheory_payment_processor.handlers.card_form_api:CardFormAPI",
+                "description": "Serves the PayTheory hosted-fields card form as a standalone HTML page, loaded in an iframe to avoid custom element re-registration errors (KOALA-5882)."
             }
         ],
         "commands": [],

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/card_form_api.py
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/card_form_api.py
@@ -1,0 +1,50 @@
+"""SimpleAPI endpoint serving the PayTheory hosted-fields card form.
+
+Loaded in an iframe by the CardPaymentProcessor so each modal open gets a
+fresh CustomElementRegistry (fixes KOALA-5882) and a real same-origin
+origin (required by PayTheory's internal postMessage calls).
+"""
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import HTMLResponse, Response
+from canvas_sdk.handlers.simple_api import Credentials, SimpleAPI, api
+from canvas_sdk.templates import render_to_string
+
+from paytheory_payment_processor.paytheory.environment import (
+    DEFAULT_ENVIRONMENT,
+    DEFAULT_PARTNER,
+    get_sdk_url,
+)
+
+
+class CardFormAPI(SimpleAPI):
+    """Serves the PayTheory hosted-fields card form as a standalone HTML page."""
+
+    PREFIX = "/card-form"
+
+    def authenticate(self, credentials: Credentials) -> bool:
+        """The form only carries the PayTheory public key and tokenizes client-side."""
+        return True
+
+    @api.get("/")
+    def index(self) -> list[Response | Effect]:
+        """Render the PayTheory hosted-fields form."""
+        partner = self.secrets.get("paytheory_partner", DEFAULT_PARTNER)
+        environment = self.secrets.get("paytheory_environment", DEFAULT_ENVIRONMENT)
+        public_api_key = self.secrets["paytheory_public_key"]
+        sdk_url = get_sdk_url(partner, environment)
+
+        html = render_to_string(
+            "templates/card_form.html",
+            {"public_api_key": public_api_key, "sdk_url": sdk_url},
+        )
+        return [
+            HTMLResponse(
+                content=html,
+                status_code=HTTPStatus.OK,
+                headers={"Cache-Control": "no-store"},
+            )
+        ]

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/paytheory_payment_processor.py
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/paytheory_payment_processor.py
@@ -11,7 +11,6 @@ from canvas_sdk.effects.payment_processor import (
 from canvas_sdk.handlers.payment_processors.card import (
     CardPaymentProcessor,
 )
-from canvas_sdk.templates import render_to_string
 from canvas_sdk.v1.data import Patient
 from logger import log
 from paytheory_payment_processor.paytheory.api import PayorInput, PayTheoryAPI, TransactionInput
@@ -22,6 +21,8 @@ from paytheory_payment_processor.paytheory.environment import (
     get_sdk_url,
 )
 from paytheory_payment_processor.paytheory.exceptions import TransactionError
+
+_CARD_FORM_URL = "/plugin-io/api/paytheory_payment_processor/card-form/"
 
 # Statuses PayTheory may return for a charge that should be treated as successful.
 # Settlement happens asynchronously, so PENDING/SETTLED are successes for booking
@@ -54,32 +55,31 @@ class PayTheoryPaymentProcessor(CardPaymentProcessor):
 
     def payment_form(self, patient: Patient | None = None) -> PaymentProcessorForm:
         """Return the payment form for the credit card processor."""
-        content = render_to_string(
-            "templates/form.html",
-            {
-                "intent": self.PaymentIntent.PAY,
-                "public_api_key": self.public_api_key,
-                "sdk_url": self.sdk_url,
-            },
+        return PaymentProcessorForm(
+            content=self._card_fields_html(),
+            intent=self.PaymentIntent.PAY,
         )
-
-        return PaymentProcessorForm(content=content, intent=self.PaymentIntent.PAY)
 
     def add_card_form(self, patient: Patient | None = None) -> PaymentProcessorForm:
         """Return the form for adding a card."""
-        payor_id = self.get_or_create_payor_id(patient)
-
-        content = render_to_string(
-            "templates/form.html",
-            {
-                "payor_id": payor_id,
-                "intent": self.PaymentIntent.ADD_CARD,
-                "public_api_key": self.public_api_key,
-                "sdk_url": self.sdk_url,
-            },
+        return PaymentProcessorForm(
+            content=self._card_fields_html(),
+            intent=self.PaymentIntent.ADD_CARD,
         )
 
-        return PaymentProcessorForm(content=content, intent=self.PaymentIntent.ADD_CARD)
+    def _card_fields_html(self) -> str:
+        """Embed the PayTheory card form in an iframe served from a real URL.
+
+        A separate browsing context gives a fresh CustomElementRegistry each open,
+        avoiding PayTheory's "custom element already defined" re-mount error
+        (KOALA-5882). A real (non-null) origin is required by PayTheory's internal
+        postMessage calls; an srcdoc iframe has a null origin and breaks them.
+        """
+        return (
+            '<iframe title="Add a card" src="%s" '
+            'style="width:100%%;min-height:300px;border:0;background:#fff;display:block;" '
+            'allow="payment"></iframe>'
+        ) % _CARD_FORM_URL
 
     def get_or_create_payor_id(self, patient: Patient | None = None) -> str | None:
         """Retrieve or create a payor_id based on the patient_id."""

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/paytheory_payment_processor.py
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/paytheory_payment_processor.py
@@ -74,11 +74,25 @@ class PayTheoryPaymentProcessor(CardPaymentProcessor):
         avoiding PayTheory's "custom element already defined" re-mount error
         (KOALA-5882). A real (non-null) origin is required by PayTheory's internal
         postMessage calls; an srcdoc iframe has a null origin and breaks them.
+
+        The hidden #submit button stays in the host DOM so Canvas's
+        CustomPayment.tsx can find it via querySelector('#submit'). Clicks are
+        forwarded to the iframe via postMessage.
         """
         return (
-            '<iframe title="Add a card" src="%s" '
+            '<iframe id="pt-card-frame" title="Add a card" src="%s" '
             'style="width:100%%;min-height:300px;border:0;background:#fff;display:block;" '
             'allow="payment"></iframe>'
+            '<button type="submit" id="submit" style="display:none"></button>'
+            '<script>'
+            'document.getElementById("submit").addEventListener("click", function(e) {'
+            '  e.preventDefault();'
+            '  var f = document.getElementById("pt-card-frame");'
+            '  if (f && f.contentWindow) {'
+            '    f.contentWindow.postMessage({ type: "pt-submit" }, window.location.origin);'
+            '  }'
+            '});'
+            '</script>'
         ) % _CARD_FORM_URL
 
     def get_or_create_payor_id(self, patient: Patient | None = None) -> str | None:

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/templates/card_form.html
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/templates/card_form.html
@@ -86,6 +86,21 @@
         if (errorEl) errorEl.textContent = '';
       }
 
+      function doTokenize() {
+        clearError();
+        paytheory.tokenizePaymentMethod({}).then(function(result) {
+          if (result.type === 'ERROR') {
+            showError(result.error);
+            return;
+          }
+          if (result.body && result.body.payment_method_id) {
+            try { window.parent.setToken(result.body.payment_method_id); } catch(e) {}
+          } else {
+            showError(result.error);
+          }
+        });
+      }
+
       function setupPayTheory() {
         paytheory.readyObserver(function(ready) {
           try { window.parent.setFormIsReady(ready); } catch(e) {}
@@ -126,20 +141,24 @@
           apiKey: '{{ public_api_key }}'
         });
 
+        // Signal readiness unconditionally after payTheoryFields() is invoked.
+        // The readyObserver callback above fires only when the iframe becomes
+        // visible, but Canvas hides the form until setFormIsReady(true) is called,
+        // creating a deadlock. This breaks the cycle.
+        try { window.parent.setFormIsReady(true); } catch(e) {}
+
+        // Listen for submit forwarded from the host DOM via postMessage.
+        // Canvas's CustomPayment.tsx clicks the host #submit button, which
+        // posts a message into this iframe to trigger tokenization.
+        window.addEventListener('message', function(event) {
+          if (event.origin === window.location.origin && event.data && event.data.type === 'pt-submit') {
+            doTokenize();
+          }
+        });
+
         document.getElementById('submit').addEventListener('click', function(e) {
           e.preventDefault();
-          clearError();
-          paytheory.tokenizePaymentMethod({}).then(function(result) {
-            if (result.type === 'ERROR') {
-              showError(result.error);
-              return;
-            }
-            if (result.body && result.body.payment_method_id) {
-              try { window.parent.setToken(result.body.payment_method_id); } catch(e) {}
-            } else {
-              showError(result.error);
-            }
-          });
+          doTokenize();
         });
       }
 

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/templates/card_form.html
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/templates/card_form.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    html, body { margin: 0; padding: 8px; background: #fff; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    #field-wrapper-card-name,
+    #field-wrapper-card-number,
+    #field-wrapper-card-exp,
+    #field-wrapper-card-cvv,
+    #field-wrapper-billing-zip {
+      width: 6em;
+      height: 2.5em;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      margin: 5px;
+      padding: 5px;
+    }
+    .submitButton {
+      display: flex;
+      width: 100px;
+      height: 20px;
+      visibility: hidden;
+    }
+    .custom-fields {
+      display: flex;
+    }
+    .error {
+      color: #b00020;
+      margin: 8px 5px 0;
+      font-size: 0.9em;
+      min-height: 1.2em;
+    }
+  </style>
+  <script src="{{ sdk_url }}"></script>
+</head>
+<body>
+  <div>
+    <div id="custom-payment-fields" class="custom-fields">
+      <div id="pay-theory-credit-card-account-name"></div>
+      <div id="pay-theory-credit-card"></div>
+      <div id="pay-theory-credit-card-zip"></div>
+    </div>
+    <div class="error"></div>
+    <button type="submit" id="submit" class="submitButton">Pay</button>
+
+    <script>
+      var ERROR_MESSAGES = {
+        SOCKET_ERROR: 'Your card could not be processed. Please contact your card issuer or try a different card.',
+        TRANSACTING_FIELD_ERROR: 'Please check your card details and try again.',
+        FIELD_ERROR: 'Please check your card details and try again.',
+        NOT_VALID: 'Please check your card details and try again.',
+        INVALID_PARAM: 'Please check your card details and try again.',
+        SESSION_EXPIRED: 'Your session has expired. Please refresh the page and try again.',
+        NOT_READY: 'The payment form is not ready yet. Please wait a moment and try again.',
+        NO_TOKEN: 'The payment form is not ready yet. Please wait a moment and try again.',
+        NO_FIELDS: 'The payment form is not ready yet. Please wait a moment and try again.'
+      };
+      var DEFAULT_ERROR_MESSAGE = 'We could not process your card. Please try again or use a different card.';
+
+      var TERMINAL_ERROR_PREFIXES = {
+        SOCKET_ERROR: true,
+        SESSION_EXPIRED: true
+      };
+
+      function formatPayTheoryError(rawError) {
+        var prefix = (rawError || '').split(':')[0].trim();
+        return ERROR_MESSAGES[prefix] || DEFAULT_ERROR_MESSAGE;
+      }
+
+      function isTerminalError(rawError) {
+        var prefix = (rawError || '').split(':')[0].trim();
+        return !!TERMINAL_ERROR_PREFIXES[prefix];
+      }
+
+      function showError(rawError) {
+        if (rawError) console.error('PayTheory error:', rawError);
+        var message = formatPayTheoryError(rawError);
+        var errorEl = document.querySelector('.error');
+        if (errorEl) errorEl.textContent = message;
+        try { window.parent.setError(message); } catch(e) {}
+      }
+
+      function clearError() {
+        var errorEl = document.querySelector('.error');
+        if (errorEl) errorEl.textContent = '';
+      }
+
+      function setupPayTheory() {
+        paytheory.readyObserver(function(ready) {
+          try { window.parent.setFormIsReady(ready); } catch(e) {}
+        });
+
+        paytheory.errorObserver(function(error) {
+          if (isTerminalError(error)) {
+            showError(error);
+          } else if (error) {
+            console.warn('PayTheory (non-fatal):', error);
+          }
+        });
+
+        paytheory.stateObserver(function(state) {
+          if (state['billing-zip'] && state['billing-zip'].isDirty) {
+            var el = document.getElementById('field-wrapper-billing-zip');
+            if (el) el.style.borderColor = state['billing-zip'].errorMessages[0] ? 'red' : '#ccc';
+          }
+          if (state['card-cvv'] && state['card-cvv'].isDirty) {
+            var el = document.getElementById('field-wrapper-card-cvv');
+            if (el) el.style.borderColor = state['card-cvv'].errorMessages[0] ? 'red' : '#ccc';
+          }
+          if (state['card-exp'] && state['card-exp'].isDirty) {
+            var el = document.getElementById('field-wrapper-card-exp');
+            if (el) el.style.borderColor = state['card-exp'].errorMessages[0] ? 'red' : '#ccc';
+          }
+          if (state['card-number'] && state['card-number'].isDirty) {
+            var el = document.getElementById('field-wrapper-card-number');
+            if (el) el.style.borderColor = state['card-number'].errorMessages[0] ? 'red' : '#ccc';
+          }
+        });
+
+        paytheory.validObserver(function(valid) {
+          try { window.parent.setFormIsValid(valid === 'card'); } catch(e) {}
+        });
+
+        paytheory.payTheoryFields({
+          apiKey: '{{ public_api_key }}'
+        });
+
+        document.getElementById('submit').addEventListener('click', function(e) {
+          e.preventDefault();
+          clearError();
+          paytheory.tokenizePaymentMethod({}).then(function(result) {
+            if (result.type === 'ERROR') {
+              showError(result.error);
+              return;
+            }
+            if (result.body && result.body.payment_method_id) {
+              try { window.parent.setToken(result.body.payment_method_id); } catch(e) {}
+            } else {
+              showError(result.error);
+            }
+          });
+        });
+      }
+
+      // SDK is loaded via <script> tag in <head>, so it should be available.
+      if (typeof paytheory !== 'undefined') {
+        setupPayTheory();
+      } else {
+        var _waitCount = 0;
+        (function waitForSDK() {
+          if (typeof paytheory !== 'undefined') { setupPayTheory(); return; }
+          if (++_waitCount > 50) { showError('NOT_READY'); return; }
+          setTimeout(waitForSDK, 200);
+        })();
+      }
+    </script>
+  </div>
+</body>
+</html>

--- a/extensions/paytheory-payment-processor/tests/handlers/test_paytheory_payment_processor.py
+++ b/extensions/paytheory-payment-processor/tests/handlers/test_paytheory_payment_processor.py
@@ -82,47 +82,45 @@ class TestInit:
             assert instance.sdk_url == "https://canvas.sdk.paytheory.com/index.js"
 
 
-class TestPaymentForm:
-    @patch("paytheory_payment_processor.handlers.paytheory_payment_processor.render_to_string")
-    def test_returns_form(self, mock_render, processor):
-        mock_render.return_value = "<html>form</html>"
+class TestCardFieldsHtml:
+    """Tests for the iframe + submit bridge returned by _card_fields_html().
 
+    Canvas's CustomPayment.tsx expects a #submit element in the host DOM.
+    The iframe isolates PayTheory's custom elements (KOALA-5882), and the
+    host #submit button forwards clicks into the iframe via postMessage.
+    """
+
+    def test_contains_iframe_with_card_form_url(self, processor):
+        html = processor._card_fields_html()
+        assert '<iframe' in html
+        assert 'src="/plugin-io/api/paytheory_payment_processor/card-form/"' in html
+
+    def test_contains_submit_button_in_host_dom(self, processor):
+        html = processor._card_fields_html()
+        assert 'id="submit"' in html
+        assert '<button' in html
+
+    def test_contains_postmessage_bridge_script(self, processor):
+        html = processor._card_fields_html()
+        assert 'postMessage' in html
+        assert 'pt-submit' in html
+
+
+class TestPaymentForm:
+    def test_returns_form_with_iframe(self, processor):
         result = processor.payment_form()
 
-        assert mock_render.mock_calls == [
-            call(
-                "templates/form.html",
-                {
-                    "intent": "pay",
-                    "public_api_key": "pub-key-123",
-                    "sdk_url": "https://canvas.sdk.paytheorystudy.com/index.js",
-                },
-            )
-        ]
-        assert result.content == "<html>form</html>"
+        assert '/plugin-io/api/paytheory_payment_processor/card-form/' in result.content
+        assert 'id="submit"' in result.content
         assert result.intent == "pay"
 
 
 class TestAddCardForm:
-    @patch("paytheory_payment_processor.handlers.paytheory_payment_processor.render_to_string")
-    def test_returns_form_with_payor_id(self, mock_render, processor, mock_patient):
-        mock_render.return_value = "<html>add card</html>"
-        processor.api.get_payor_id.return_value = "payor-xyz"
+    def test_returns_form_with_iframe(self, processor):
+        result = processor.add_card_form()
 
-        result = processor.add_card_form(mock_patient)
-
-        assert processor.api.get_payor_id.mock_calls == [call(mock_patient.id)]
-        assert mock_render.mock_calls == [
-            call(
-                "templates/form.html",
-                {
-                    "payor_id": "payor-xyz",
-                    "intent": "add_card",
-                    "public_api_key": "pub-key-123",
-                    "sdk_url": "https://canvas.sdk.paytheorystudy.com/index.js",
-                },
-            )
-        ]
+        assert '/plugin-io/api/paytheory_payment_processor/card-form/' in result.content
+        assert 'id="submit"' in result.content
         assert result.intent == "add_card"
 
 


### PR DESCRIPTION
## Summary

Fix PayTheory card form failing on iframe-based rendering by adding a submit bridge between the host DOM and the iframe, and breaking a visibility deadlock.

**Problem:** After moving the PayTheory card form into an iframe to fix the custom element re-registration crash (KOALA-5882), two issues remained:

1. **No submit button in host DOM.** Canvas's `CustomPayment.tsx` finds the submit trigger via `querySelector('#submit')` in the host document. With the form inside an iframe, that element was gone — clicking "Pay" or "Save Card" did nothing.
2. **Hidden-until-ready deadlock.** Canvas hides the payment form until `setFormIsReady(true)` is called, but PayTheory's `readyObserver` only fires when the hosted fields become visible. Neither side yields first.

**Fix (this PR):**

- **Submit bridge:** A hidden `<button id="submit">` in the host DOM forwards clicks into the iframe via `postMessage({ type: "pt-submit" })`. Inside the iframe, a `message` event listener calls the extracted `doTokenize()` function. The in-iframe `#submit` click listener is preserved for standalone use.
- **Unconditional `setFormIsReady(true)`:** Called immediately after `paytheory.payTheoryFields()` is invoked, in addition to the existing `readyObserver` callback. This breaks the deadlock so the form becomes visible and PayTheory can finish initializing.

Refs: KOALA-5882, KOALA-5881

## Changed files

- `handlers/paytheory_payment_processor.py` — `_card_fields_html()` now returns iframe + hidden #submit + postMessage bridge script
- `templates/card_form.html` — extracted `doTokenize()`, added `message` listener for `pt-submit`, added unconditional `setFormIsReady(true)` call
- `tests/handlers/test_paytheory_payment_processor.py` — new `TestCardFieldsHtml` class asserting iframe src, #submit presence, and postMessage bridge; updated `TestPaymentForm` and `TestAddCardForm` to match new HTML output

## Test plan

- [ ] Open Collect Payment modal, verify card fields render
- [ ] Enter card details and submit payment — confirm tokenization completes
- [ ] Close and re-open the modal — confirm no "custom element already defined" error
- [ ] Add a saved card via "Add Card" flow — confirm it persists