### PR TITLE
Fix PayTheory card save — pass payorId during tokenization so cards l…

### DIFF
--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/card_form_api.py
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/card_form_api.py
@@ -36,10 +36,11 @@ class CardFormAPI(SimpleAPI):
         environment = self.secrets.get("paytheory_environment", DEFAULT_ENVIRONMENT)
         public_api_key = self.secrets["paytheory_public_key"]
         sdk_url = get_sdk_url(partner, environment)
+        payor_id = self.query_params.get("payor_id", "")
 
         html = render_to_string(
             "templates/card_form.html",
-            {"public_api_key": public_api_key, "sdk_url": sdk_url},
+            {"public_api_key": public_api_key, "sdk_url": sdk_url, "payor_id": payor_id},
         )
         return [
             HTMLResponse(

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/paytheory_payment_processor.py
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/handlers/paytheory_payment_processor.py
@@ -55,19 +55,21 @@ class PayTheoryPaymentProcessor(CardPaymentProcessor):
 
     def payment_form(self, patient: Patient | None = None) -> PaymentProcessorForm:
         """Return the payment form for the credit card processor."""
+        payor_id = self.get_or_create_payor_id(patient) if patient else None
         return PaymentProcessorForm(
-            content=self._card_fields_html(),
+            content=self._card_fields_html(payor_id=payor_id),
             intent=self.PaymentIntent.PAY,
         )
 
     def add_card_form(self, patient: Patient | None = None) -> PaymentProcessorForm:
         """Return the form for adding a card."""
+        payor_id = self.get_or_create_payor_id(patient) if patient else None
         return PaymentProcessorForm(
-            content=self._card_fields_html(),
+            content=self._card_fields_html(payor_id=payor_id),
             intent=self.PaymentIntent.ADD_CARD,
         )
 
-    def _card_fields_html(self) -> str:
+    def _card_fields_html(self, payor_id: str | None = None) -> str:
         """Embed the PayTheory card form in an iframe served from a real URL.
 
         A separate browsing context gives a fresh CustomElementRegistry each open,
@@ -79,6 +81,9 @@ class PayTheoryPaymentProcessor(CardPaymentProcessor):
         CustomPayment.tsx can find it via querySelector('#submit'). Clicks are
         forwarded to the iframe via postMessage.
         """
+        url = _CARD_FORM_URL
+        if payor_id:
+            url = f"{_CARD_FORM_URL}?payor_id={payor_id}"
         return (
             '<iframe id="pt-card-frame" title="Add a card" src="%s" '
             'style="width:100%%;min-height:300px;border:0;background:#fff;display:block;" '
@@ -93,7 +98,7 @@ class PayTheoryPaymentProcessor(CardPaymentProcessor):
             '  }'
             '});'
             '</script>'
-        ) % _CARD_FORM_URL
+        ) % url
 
     def get_or_create_payor_id(self, patient: Patient | None = None) -> str | None:
         """Retrieve or create a payor_id based on the patient_id."""

--- a/extensions/paytheory-payment-processor/paytheory_payment_processor/templates/card_form.html
+++ b/extensions/paytheory-payment-processor/paytheory_payment_processor/templates/card_form.html
@@ -88,7 +88,11 @@
 
       function doTokenize() {
         clearError();
-        paytheory.tokenizePaymentMethod({}).then(function(result) {
+        var tokenizeParams = {};
+        {% if payor_id %}
+        tokenizeParams.payorId = '{{ payor_id }}';
+        {% endif %}
+        paytheory.tokenizePaymentMethod(tokenizeParams).then(function(result) {
           if (result.type === 'ERROR') {
             showError(result.error);
             return;

--- a/extensions/paytheory-payment-processor/tests/handlers/test_paytheory_payment_processor.py
+++ b/extensions/paytheory-payment-processor/tests/handlers/test_paytheory_payment_processor.py
@@ -105,6 +105,15 @@ class TestCardFieldsHtml:
         assert 'postMessage' in html
         assert 'pt-submit' in html
 
+    def test_includes_payor_id_in_iframe_url(self, processor):
+        html = processor._card_fields_html(payor_id="payor-xyz")
+        assert 'src="/plugin-io/api/paytheory_payment_processor/card-form/?payor_id=payor-xyz"' in html
+
+    def test_no_payor_id_omits_query_param(self, processor):
+        html = processor._card_fields_html(payor_id=None)
+        assert 'src="/plugin-io/api/paytheory_payment_processor/card-form/"' in html
+        assert 'payor_id' not in html
+
 
 class TestPaymentForm:
     def test_returns_form_with_iframe(self, processor):
@@ -114,6 +123,14 @@ class TestPaymentForm:
         assert 'id="submit"' in result.content
         assert result.intent == "pay"
 
+    def test_includes_payor_id_for_patient(self, processor, mock_patient):
+        processor.api.get_payor_id.return_value = "payor-abc"
+
+        result = processor.payment_form(patient=mock_patient)
+
+        assert 'payor_id=payor-abc' in result.content
+        assert result.intent == "pay"
+
 
 class TestAddCardForm:
     def test_returns_form_with_iframe(self, processor):
@@ -121,6 +138,14 @@ class TestAddCardForm:
 
         assert '/plugin-io/api/paytheory_payment_processor/card-form/' in result.content
         assert 'id="submit"' in result.content
+        assert result.intent == "add_card"
+
+    def test_includes_payor_id_for_patient(self, processor, mock_patient):
+        processor.api.get_payor_id.return_value = "payor-abc"
+
+        result = processor.add_card_form(patient=mock_patient)
+
+        assert 'payor_id=payor-abc' in result.content
         assert result.intent == "add_card"
 
 


### PR DESCRIPTION
…ink to the patient

The iframe card form was calling tokenizePaymentMethod({}) with no payor association. Cards were tokenized but never linked to a payor, so get_payment_methods always returned 0 results. Now payment_form() and add_card_form() resolve the patient's payor_id and pass it through the iframe URL to the template, which passes it to tokenizePaymentMethod().